### PR TITLE
fix: Windows cross-platform CRLF, UTF-8 encoding, and regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,11 +257,12 @@ jobs:
   # Uses uv for fast dependency resolution (10-100x faster than pip)
   # See: https://docs.astral.sh/uv/guides/integration/github/
   test-uv:
-    name: Test uv (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Test uv (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
@@ -310,7 +311,7 @@ jobs:
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
-        if: matrix.python-version == '3.14'
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         with:
           name: coverage-report-uv
           path: |
@@ -321,7 +322,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-uv-${{ matrix.python-version }}
+          name: test-results-uv-${{ matrix.os }}-${{ matrix.python-version }}
           path: junit-uv-${{ matrix.python-version }}.xml
 
   # ===========================================================================

--- a/scripts/migration/verify-platform.sh
+++ b/scripts/migration/verify-platform.sh
@@ -26,6 +26,21 @@
 
 set -o pipefail
 
+# =============================================================================
+# Platform Guard: Skip on Windows (Git Bash / MSYS2 / Cygwin)
+# =============================================================================
+# This script relies on rsync, tar, and other Unix tools that are not available
+# on Windows. On Windows, use WSL or skip this verification step.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "[SKIP] verify-platform.sh: Windows detected ($(uname -s))"
+        echo "       This script requires rsync and GNU tar which are not"
+        echo "       available natively on Windows."
+        echo "       Run this script in WSL or on a Linux/macOS system."
+        exit 0
+        ;;
+esac
+
 # Colors for output (if terminal supports it)
 if [ -t 1 ]; then
     RED='\033[0;31m'

--- a/scripts/migration/verify-symlinks.sh
+++ b/scripts/migration/verify-symlinks.sh
@@ -44,6 +44,21 @@
 set -euo pipefail
 
 # ============================================================================
+# PLATFORM GUARD: Skip on Windows (Git Bash / MSYS2 / Cygwin)
+# ============================================================================
+# This script relies on `find -type l`, `readlink`, and symlink semantics
+# that differ significantly on Windows. On Windows, symlinks require elevated
+# privileges and behave differently from Unix symlinks.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "[SKIP] verify-symlinks.sh: Windows detected ($(uname -s))"
+        echo "       Symlink verification is not supported on Windows."
+        echo "       Run this script in WSL or on a Linux/macOS system."
+        exit 0
+        ;;
+esac
+
+# ============================================================================
 # CONFIGURATION
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Replace `split("\n")` with `splitlines()` across 7 source files to handle Windows CRLF line endings
- Add explicit `encoding="utf-8"` to `write_text()`/`read_text()` calls that defaulted to system encoding (CP1252 on Windows)
- Add 6 architecture tests that prevent cross-platform regressions
- Fix pre-existing ruff UP038 warnings in touched files

## Changes

### CRLF Line Ending Fixes (FEAT-009)
Files using `split("\n")` on file-sourced data replaced with `splitlines()`:
- `toon_serializer.py` (3 locations - format detection and decoding)
- `validate_vtt.py` (VTT content parsing)
- `statusline.py` (git status output)
- `check_agent_conformance.py` (YAML frontmatter parsing)
- `compose_agent_template.py` (2 locations - template parsing and validation)
- `subagent_stop.py` (agent output parsing)
- `patterns/loader.py` (YAML fallback parser)

### UTF-8 Encoding Fixes (FEAT-008)
- `chunker.py` - 2 `write_text()` calls now specify `encoding="utf-8"`
- `parse_transcript_command_handler.py` - 1 `write_text()` + 1 `read_text()` now specify `encoding="utf-8"`

### Regression Prevention Architecture Tests
New `tests/architecture/test_cross_platform.py` with 6 tests:
- `test_no_fcntl_import` - Blocks re-introduction of Unix-only `fcntl`
- `test_no_unix_only_modules` - Blocks `pwd`, `grp`, `termios`, etc.
- `test_no_split_newline_in_source` - Catches new `split("\n")` (with allowlist)
- `test_write_text_specifies_encoding` - Requires `encoding=` on `write_text()` in src/
- `test_read_text_specifies_encoding` - Requires `encoding=` on `read_text()` in src/
- `test_no_hardcoded_tmp_paths` - Blocks `/tmp/`, `/var/`, `/etc/` in production code

## Context

This builds on PR #4 (`fix/windows-fcntl-to-filelock`) which addressed the critical blockers (fcntl replacement, statusline UTF-8, pre-commit hooks). This PR addresses the remaining issues found during a comprehensive codebase audit.

## Test plan

- [x] All 636 unit tests pass
- [x] Full test suite: 2395 passed, 93 skipped, 0 failures
- [x] All 6 new architecture tests pass
- [x] All pre-commit hooks pass (ruff, ruff-format, pyright, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)