### PR TITLE
fix(ci): release.yml CI fixes — ruff pin + test marker exclusions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,10 @@ jobs:
         run: pyright src/
 
       - name: Run tests
-        run: pytest -v --tb=short
+        run: |
+          # Exclude subprocess tests (require uv) and llm tests (require API keys)
+          # Matches ci.yml test-pip job marker exclusions
+          pytest -m "not subprocess and not llm" -v --tb=short
 
   # ===========================================================================
   # Build Plugin Archive


### PR DESCRIPTION
## Summary
- Pin ruff to `0.14.11` in release.yml to match ci.yml (prevents UP042 lint failures from unpinned newer ruff versions)
- Exclude `subprocess` and `llm` marked tests in release.yml CI job (subprocess tests require uv, llm tests require API keys — matches ci.yml test-pip job behavior)

## Context
These fixes unblock the v0.2.0 GitHub Release. The release pipeline was failing because:
1. Unpinned ruff picked up a newer version with UP042 rule enabled (7 lint failures)
2. Bare `pytest` ran all tests including subprocess-dependent tests that need uv

## Test plan
- [ ] Verify release pipeline CI Checks job passes after re-tagging v0.2.0
- [ ] Verify lint step passes with pinned ruff version
- [ ] Verify test step passes with subprocess/llm marker exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)