### PR TITLE
fix(docs): enable keyword triggering for transcript skill

### DIFF
--- a/.context/rules/mandatory-skill-usage.md
+++ b/.context/rules/mandatory-skill-usage.md
@@ -2,7 +2,7 @@
 
 > Proactive skill invocation rules. DO NOT wait for user to invoke.
 
-<!-- L2-REINJECT: rank=6, tokens=40, content="Proactive skill invocation REQUIRED (H-22). /problem-solving for research. /nasa-se for design. /orchestration for workflows. /adversary for standalone adversarial reviews, tournament scoring, formal strategy application." -->
+<!-- L2-REINJECT: rank=6, tokens=50, content="Proactive skill invocation REQUIRED (H-22). /problem-solving for research. /nasa-se for design. /orchestration for workflows. /transcript for transcript parsing and meeting notes. /adversary for standalone adversarial reviews, tournament scoring, formal strategy application." -->
 
 ## Document Sections
 
@@ -20,7 +20,7 @@
 
 | ID | Rule | Consequence |
 |----|------|-------------|
-| H-22 | MUST invoke `/problem-solving` for research/analysis. MUST invoke `/nasa-se` for requirements/design. MUST invoke `/orchestration` for multi-phase workflows. MUST invoke `/adversary` for standalone adversarial reviews outside creator-critic loops, tournament scoring, and formal strategy application (red team, devil's advocate, steelman, pre-mortem). | Work quality degradation. Rework required. |
+| H-22 | MUST invoke `/problem-solving` for research/analysis. MUST invoke `/nasa-se` for requirements/design. MUST invoke `/orchestration` for multi-phase workflows. MUST invoke `/transcript` for transcript parsing and meeting note extraction. MUST invoke `/adversary` for standalone adversarial reviews outside creator-critic loops, tournament scoring, and formal strategy application (red team, devil's advocate, steelman, pre-mortem). | Work quality degradation. Rework required. |
 
 ---
 
@@ -31,6 +31,7 @@
 | research, analyze, investigate, explore, root cause, why | `/problem-solving` |
 | requirements, specification, V&V, technical review, risk | `/nasa-se` |
 | orchestration, pipeline, workflow, multi-agent, phases, gates | `/orchestration` |
+| transcript, meeting notes, parse recording, meeting recording, VTT, SRT, captions | `/transcript` |
 | adversarial quality review, adversarial critique, rigorous critique, formal critique, adversarial, tournament, red team, devil's advocate, steelman, pre-mortem, quality gate, quality scoring | `/adversary` |
 
 ---

--- a/docs/playbooks/transcript.md
+++ b/docs/playbooks/transcript.md
@@ -2,7 +2,7 @@
 
 > **Skill:** transcript
 > **SKILL.md:** [transcript/SKILL.md](https://github.com/geekatron/jerry/blob/main/skills/transcript/SKILL.md)
-> **Trigger keywords:** CLI invocation — no automatic keyword triggers
+> **Trigger keywords:** transcript, meeting notes, parse recording, meeting recording, VTT, SRT, captions
 
 ## Document Sections
 
@@ -21,11 +21,13 @@
 
 ## When to Use
 
-> **Important:** The transcript skill is NOT triggered by keyword detection. It does NOT
-> activate automatically when you mention words like "transcript" or "meeting notes" in
-> conversation. You MUST explicitly invoke it using the `/transcript` command or by asking
-> Claude to run `uv run jerry transcript parse`. This design is intentional — the skill
-> requires a specific input file path that cannot be inferred from keyword context alone.
+> **Invocation:** The transcript skill can be triggered by keyword detection (e.g.,
+> "transcript", "meeting notes", "parse recording") or explicitly via the `/transcript`
+> command. When triggered by keywords, Claude will ask for the file path if not provided.
+> The skill uses a hybrid Python+LLM architecture: the Python CLI parser runs automatically
+> for VTT files (~1,250x cheaper than LLM parsing), while SRT and plain text files use
+> LLM-based parsing directly. The LLM instructions (ts-parser agent) handle format detection
+> and Python invocation automatically — no manual CLI knowledge is required from the user.
 
 ### Use this skill when:
 

--- a/projects/PROJ-001-oss-release/WORKTRACKER.md
+++ b/projects/PROJ-001-oss-release/WORKTRACKER.md
@@ -66,6 +66,7 @@
 | [BUG-005](./work/EPIC-001-oss-release/BUG-005-version-bump-pipeline-failure/BUG-005-version-bump-pipeline-failure.md) | Version Bump Pipeline Fails on Merge to Main | completed | high | EPIC-001 |
 | [BUG-006](./work/EPIC-001-oss-release/BUG-006-version-bump-toml-tag-drift/BUG-006-version-bump-toml-tag-drift.md) | Version Bump Fails — TOML Quoting Bug + Version-Tag Drift | completed | high | EPIC-001 |
 | [BUG-007](./work/EPIC-001-oss-release/BUG-007-pages-build-jekyll-liquid-error/BUG-007-pages-build-jekyll-liquid-error.md) | GitHub Pages Build Fails — Jekyll Liquid Syntax Error | completed | high | EPIC-001 |
+| [BUG-008](./work/EPIC-001-oss-release/BUG-008-transcript-keyword-trigger-docs/BUG-008-transcript-keyword-trigger-docs.md) | Transcript Skill Incorrectly Documented as Non-Keyword-Triggerable | pending | medium | EPIC-001 |
 
 ---
 
@@ -242,6 +243,8 @@
 | 2026-02-19 | Claude | **Worktracker audit.** wt-verifier: FEAT-025 PASS (all 4 enablers clean). wt-auditor: 9 findings (3 errors, 4 warnings, 2 info). All findings remediated: EPIC-001 header updated to `done`, FEAT-023/EN-945 closed out with delivery evidence, FEAT-024 inline enabler table fixed, bug counts reconciled (19/19). **EPIC-001 CLOSED — clean.** |
 | 2026-02-18 | Claude | **Project directory cleanup.** Deleted orphan directories: `PROJ-001-plugin-cleanup` (empty scaffold, duplicate ID conflict), `PROJ-009-oss-release` (empty scaffold, false start). Neither was git-tracked or listed in `projects/README.md`. Staged `research/single-vs-multi-agent-analysis.md`. |
 | 2026-02-19 | Claude | **FEAT-026 COMPLETE.** Post-Public Documentation Refresh. 3 enablers (EN-955–957), 10 effort pts. C2 quality gate: S-003 + S-007 + S-002 + S-014 (0.8925 REVISE → 0.9195 PASS). INSTALLATION.md rewritten, docs/index.md enriched. **EPIC-001 CLOSED: 11/11 features, 44/44 enablers, 19/19 bugs. 100%.** |
+
+| 2026-02-19 | Claude | BUG-008 created under EPIC-001: Transcript Skill Incorrectly Documented as Non-Keyword-Triggerable. Playbook and mandatory-skill-usage.md incorrectly exclude transcript from keyword triggers, citing Python script dependency. Python is VTT-only; LLM fallback handles non-VTT automatically. EPIC-001 reopened. |
 
 ---
 

--- a/projects/PROJ-001-oss-release/work/EPIC-001-oss-release/BUG-008-transcript-keyword-trigger-docs/BUG-008-transcript-keyword-trigger-docs.md
+++ b/projects/PROJ-001-oss-release/work/EPIC-001-oss-release/BUG-008-transcript-keyword-trigger-docs/BUG-008-transcript-keyword-trigger-docs.md
@@ -1,0 +1,127 @@
+# BUG-008: Transcript Skill Incorrectly Documented as Non-Keyword-Triggerable
+
+> **Type:** bug
+> **Status:** pending
+> **Priority:** medium
+> **Impact:** medium
+> **Severity:** minor
+> **Created:** 2026-02-19
+> **Due:** --
+> **Completed:** --
+> **Parent:** EPIC-001
+> **Owner:** --
+> **Found In:** 0.2.3
+> **Fix Version:** --
+
+---
+
+## Document Sections
+
+| Section | Purpose |
+|---------|---------|
+| [Summary](#summary) | Brief description and key details |
+| [Reproduction Steps](#reproduction-steps) | Steps to reproduce the issue |
+| [Environment](#environment) | Environment where bug occurs |
+| [Root Cause Analysis](#root-cause-analysis) | Investigation and root cause details |
+| [Acceptance Criteria](#acceptance-criteria) | Conditions for bug to be fixed |
+| [Related Items](#related-items) | Hierarchy and related work items |
+| [History](#history) | Status changes and key events |
+
+---
+
+## Summary
+
+The transcript playbook (`docs/playbooks/transcript.md` lines 24-28) and the `mandatory-skill-usage.md` trigger map incorrectly document the transcript skill as non-keyword-triggerable. The stated rationale cites the Python script dependency as the reason, but the Python parser is only required for VTT files. The LLM instructions (ts-parser agent) automatically run the Python script for VTT and fall back to LLM-based parsing for non-VTT formats (SRT, plain text). The skill should be keyword-triggerable like all other skills.
+
+**Key Details:**
+- **Symptom:** Transcript skill excluded from keyword trigger map; playbook explicitly states "NOT triggered by keyword detection" with incorrect Python-dependency rationale
+- **Frequency:** Every session where transcript-related keywords are used
+- **Workaround:** User must explicitly invoke `/transcript` command
+
+---
+
+## Reproduction Steps
+
+### Prerequisites
+
+- Jerry Framework v0.2.3
+- Any active project with `JERRY_PROJECT` set
+
+### Steps to Reproduce
+
+1. Read `docs/playbooks/transcript.md` lines 24-28 — note the claim: "The transcript skill is NOT triggered by keyword detection...This design is intentional — the skill requires a specific input file path that cannot be inferred from keyword context alone."
+2. Read `.context/rules/mandatory-skill-usage.md` trigger map — note that every skill has keyword triggers except transcript.
+3. Read `skills/transcript/agents/ts-parser.md` — note that Step 2A (Python CLI) is VTT-only, and Step 2B (LLM fallback) handles SRT, plain text, and Python parser failures automatically.
+
+### Expected Result
+
+The transcript skill should have keyword triggers in `mandatory-skill-usage.md` (e.g., "transcript", "meeting notes", "parse recording") consistent with the hybrid architecture where the Python script is only a VTT optimization, not a hard dependency.
+
+### Actual Result
+
+The transcript skill is documented as requiring explicit `/transcript` invocation only, with incorrect rationale that the Python script prevents keyword triggering.
+
+---
+
+## Environment
+
+| Attribute | Value |
+|-----------|-------|
+| **Operating System** | macOS Darwin 24.6.0 |
+| **Application Version** | Jerry Framework 0.2.3 |
+| **Configuration** | Default |
+
+---
+
+## Root Cause Analysis
+
+### Root Cause
+
+During FEAT-018 (User Documentation -- Runbooks & Playbooks), the playbook author conflated the VTT-specific Python parser requirement with a general skill invocation constraint. The ts-parser agent's hybrid architecture (Python for VTT, LLM fallback for everything else) was misinterpreted as "Python required for all formats, therefore keyword triggering is impossible."
+
+### Contributing Factors
+
+- The hybrid Python+LLM architecture is complex and easy to misunderstand
+- The playbook was authored in a single orchestration pass without verifying the ts-parser agent's actual fallback behavior
+- No cross-reference check against ts-parser.md Step 2B (LLM fallback path)
+
+---
+
+## Acceptance Criteria
+
+### Fix Verification
+
+- [ ] AC-1: `docs/playbooks/transcript.md` "When to Use" section updated to remove the incorrect "NOT triggered by keyword detection" claim and Python-dependency rationale
+- [ ] AC-2: `.context/rules/mandatory-skill-usage.md` trigger map includes transcript skill with appropriate keywords (e.g., "transcript", "meeting notes", "parse recording", "meeting recording")
+- [ ] AC-3: Updated documentation accurately describes the hybrid architecture: Python for VTT (automatic, handled by LLM instructions), LLM fallback for non-VTT
+- [ ] AC-4: No regression in other playbook sections or skill documentation
+
+### Quality Checklist
+
+- [ ] Existing documentation structure preserved
+- [ ] No new issues introduced
+- [ ] Documentation reviewed via /adversary
+
+---
+
+## Related Items
+
+### Hierarchy
+
+- **Parent:** [EPIC-001: OSS Release Preparation](../../EPIC-001-oss-release/EPIC-001-oss-release.md)
+
+### Related Items
+
+- **Causing Change:** FEAT-018 (User Documentation -- Runbooks & Playbooks)
+- **Affected Files:** `docs/playbooks/transcript.md`, `.context/rules/mandatory-skill-usage.md`
+- **Reference:** `skills/transcript/agents/ts-parser.md` (correct architecture)
+
+---
+
+## History
+
+| Date | Author | Status | Notes |
+|------|--------|--------|-------|
+| 2026-02-19 | Claude | pending | Initial report — user identified incorrect Python-dependency rationale in transcript skill docs |
+
+---

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "jerry"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary
- **BUG-008:** Transcript playbook and mandatory-skill-usage.md incorrectly documented the transcript skill as non-keyword-triggerable, citing Python script dependency
- Python CLI parser is VTT-only; LLM instructions (ts-parser agent) handle format detection and fallback automatically for SRT/plain text
- Added transcript to keyword trigger map, updated H-22 rule, updated L2-REINJECT tag, and rewrote playbook "When to Use" section

## Changes
- `docs/playbooks/transcript.md` — Replaced incorrect "NOT triggered by keyword detection" claim with accurate hybrid architecture description
- `.context/rules/mandatory-skill-usage.md` — Added `/transcript` to trigger map, H-22 rule, and L2-REINJECT tag
- `projects/PROJ-001-oss-release/WORKTRACKER.md` — Registered BUG-008
- New: `BUG-008-transcript-keyword-trigger-docs.md` entity file with root cause analysis and ACs

## Quality
- S-010 Self-Refine: 2 minor findings caught and fixed (keyword mismatch, missing L2-REINJECT update)
- S-014 LLM-as-Judge: **0.933 PASS** (threshold 0.92)

## Test plan
- [ ] Verify `docs/playbooks/transcript.md` "When to Use" section accurately describes keyword triggering + hybrid architecture
- [ ] Verify `.context/rules/mandatory-skill-usage.md` trigger map includes transcript keywords
- [ ] Verify H-22 rule text mentions `/transcript`
- [ ] Verify L2-REINJECT tag includes `/transcript`
- [ ] Verify keyword consistency across playbook header and trigger map

🤖 Generated with [Claude Code](https://claude.com/claude-code)