### PR TITLE
fix(hooks): BUG-013 uv sync wrong directory + FEAT-028 MCP integration

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv sync && uv run --directory ${CLAUDE_PLUGIN_ROOT} ${CLAUDE_PLUGIN_ROOT}/scripts/session_start_hook.py",
+            "command": "uv sync --directory ${CLAUDE_PLUGIN_ROOT} && uv run --directory ${CLAUDE_PLUGIN_ROOT} ${CLAUDE_PLUGIN_ROOT}/scripts/session_start_hook.py",
             "timeout": 10000
           }
         ]

--- a/projects/PROJ-001-oss-release/WORKTRACKER.md
+++ b/projects/PROJ-001-oss-release/WORKTRACKER.md
@@ -71,6 +71,7 @@
 | [BUG-010](./work/EPIC-001-oss-release/BUG-010-ci-lint-format-failure/BUG-010-ci-lint-format-failure.md) | CI Lint & Format Failure — Unformatted E2E Test File | done | high | EPIC-001 |
 | [BUG-011](./work/EPIC-001-oss-release/BUG-011-project-workflow-rule-conflict/BUG-011-project-workflow-rule-conflict.md) | project-workflow.md Duplicates and Conflicts with /worktracker Skill Rules | done | high | EPIC-001 |
 | [BUG-012](./work/EPIC-001-oss-release/BUG-012-ci-proj006-missing-dirs/BUG-012-ci-proj006-missing-dirs.md) | CI Failures — PROJ-006 Incomplete Project Directory Structure | done | high | EPIC-001 |
+| [BUG-013](./work/EPIC-001-oss-release/BUG-013-hook-uv-sync-wrong-directory/BUG-013-hook-uv-sync-wrong-directory.md) | SessionStart Hook `uv sync` Runs in Wrong Directory | in_progress | high | EPIC-001 |
 
 ---
 
@@ -266,6 +267,7 @@
 
 | 2026-02-20 | Claude | FEAT-028 created under EPIC-001: MCP Tool Integration (Context7 + Memory-Keeper). 5 enablers (EN-001–005), 11 effort pts, C3 criticality (AE-002). Created `.context/rules/mcp-tool-standards.md` governance rule. Context7 tools added to nse-explorer + nse-architecture (7 total). Memory-Keeper tools added to 7 agents (orch-planner, orch-tracker, orch-synthesizer, ps-architect, nse-requirements, ts-parser, ts-extractor). Updated 4 SKILL.md files, AGENTS.md (MCP Tool Access section), TOOL_REGISTRY.yaml (individual Memory-Keeper tool defs + agent permissions). All 5 enablers DONE. 3299 tests pass. |
 | 2026-02-20 | Claude | BUG-012 created under EPIC-001: CI Failures — PROJ-006 Incomplete Project Directory Structure. Same root cause as BUG-003 (EPIC-003). PROJ-006 bootstrapped with only `decisions/` but tests require >= 3 category dirs. Fix: add `research/`, `synthesis/`, `analysis/` with `.gitkeep`. 2 tasks (TASK-001, TASK-002). |
+| 2026-02-20 | Claude | BUG-013 created under EPIC-001: SessionStart Hook `uv sync` Runs in Wrong Directory. `uv sync` on line 10 of `hooks/hooks.json` missing `--directory ${CLAUDE_PLUGIN_ROOT}` — runs in CWD instead of plugin root. Shell `&&` short-circuits, preventing `session_start_hook.py` from executing. Fix: add `--directory ${CLAUDE_PLUGIN_ROOT}` to `uv sync`. GitHub Issue [#46](https://github.com/geekatron/jerry/issues/46). |
 
 ---
 

--- a/projects/PROJ-001-oss-release/work/EPIC-001-oss-release/BUG-013-hook-uv-sync-wrong-directory/BUG-013-hook-uv-sync-wrong-directory.md
+++ b/projects/PROJ-001-oss-release/work/EPIC-001-oss-release/BUG-013-hook-uv-sync-wrong-directory/BUG-013-hook-uv-sync-wrong-directory.md
@@ -1,0 +1,160 @@
+# BUG-013: SessionStart Hook `uv sync` Runs in Wrong Directory
+
+> **Type:** bug
+> **Status:** in_progress
+> **Priority:** high
+> **Impact:** high
+> **Severity:** major
+> **Created:** 2026-02-20
+> **Parent:** EPIC-001-oss-release
+> **Owner:** Claude
+> **Found In:** 0.7.0
+
+---
+
+## Document Sections
+
+| Section | Purpose |
+|---------|---------|
+| [Summary](#summary) | Brief description and key details |
+| [Reproduction Steps](#reproduction-steps) | Steps to reproduce the issue |
+| [Environment](#environment) | Environment where bug occurs |
+| [Root Cause Analysis](#root-cause-analysis) | Investigation and root cause details |
+| [Fix Description](#fix-description) | Solution approach and changes made |
+| [Acceptance Criteria](#acceptance-criteria) | Conditions for bug to be fixed |
+| [Related Items](#related-items) | Hierarchy and related work items |
+| [History](#history) | Status changes and key events |
+
+---
+
+## Summary
+
+The SessionStart hook's `uv sync` command on line 10 of `hooks/hooks.json` runs without `--directory ${CLAUDE_PLUGIN_ROOT}`, causing it to search for `pyproject.toml` in the current working directory instead of the Jerry plugin directory. When the CWD is a different repository (e.g., a consumer repo without its own `pyproject.toml`), `uv sync` fails and the `&&` short-circuit prevents the actual hook script from executing.
+
+**Key Details:**
+- **Symptom:** `uv sync` fails with `error: No pyproject.toml found in current directory or any parent directory` when CWD is not the Jerry repo. The SessionStart hook script never executes.
+- **Frequency:** Always, when Jerry plugin is used from a repository that lacks its own `pyproject.toml` or has an incompatible one.
+- **Workaround:** The second matched hook (if present) may succeed independently, masking the failure. Sessions sometimes appear to start normally due to duplicate hook matching.
+
+---
+
+## Reproduction Steps
+
+### Prerequisites
+
+- Jerry plugin installed in Claude Code
+- A separate repository (consumer repo) that does not contain a `pyproject.toml` at its root or any parent directory
+
+### Steps to Reproduce
+
+1. Open Claude Code in a consumer repository (e.g., `G.N.A.R/Forge`)
+2. Start a new session (triggers SessionStart hook)
+3. Observe hook execution output
+
+### Expected Result
+
+`uv sync` resolves `pyproject.toml` from the Jerry plugin directory (`${CLAUDE_PLUGIN_ROOT}`), installs/syncs dependencies, then runs `session_start_hook.py` successfully.
+
+### Actual Result
+
+`uv sync` searches CWD upward for `pyproject.toml`, fails with exit code 1, and the `&&` operator short-circuits — `session_start_hook.py` never executes. The session starts without Jerry framework initialization.
+
+---
+
+## Environment
+
+| Attribute | Value |
+|-----------|-------|
+| **Operating System** | macOS (Darwin 24.6.0) |
+| **Runtime** | Claude Code CLI |
+| **Application Version** | Jerry 0.7.0 |
+| **Configuration** | Jerry plugin installed via Claude Code marketplace/plugins |
+
+---
+
+## Root Cause Analysis
+
+### Investigation Summary
+
+Comparison of line 10 with all other hook commands in `hooks/hooks.json` reveals the inconsistency immediately. Lines 21, 33, and 44 all use `uv run --directory ${CLAUDE_PLUGIN_ROOT}`, correctly scoping uv to the plugin's `pyproject.toml`. Line 10 chains two commands:
+
+```
+uv sync && uv run --directory ${CLAUDE_PLUGIN_ROOT} ...
+```
+
+The second command correctly uses `--directory`, but the first (`uv sync`) does not.
+
+### Root Cause
+
+**Missing `--directory ${CLAUDE_PLUGIN_ROOT}` flag on the `uv sync` command.** The `uv sync` call defaults to searching CWD upward for `pyproject.toml`, which fails when the CWD is not the Jerry plugin directory.
+
+### Contributing Factors
+
+- Shell `&&` semantics: `A && B` only runs B if A exits 0. The `uv sync` failure (exit 1) prevents `session_start_hook.py` from ever executing.
+- The bug is partially masked because Claude Code may match multiple hooks for the same event. If a second SessionStart hook exists and succeeds, the session appears to work despite this hook failing.
+- No other hook command in the file has a bare `uv sync` — this is the only two-command chain, making it a unique case that was likely overlooked during development.
+
+---
+
+## Fix Description
+
+### Solution Approach
+
+Add `--directory ${CLAUDE_PLUGIN_ROOT}` to the `uv sync` command so it resolves `pyproject.toml` from the plugin root, consistent with all other `uv` invocations in the file.
+
+### Changes Made
+
+- Added `--directory ${CLAUDE_PLUGIN_ROOT}` to the `uv sync` call in the SessionStart hook command
+
+### Code References
+
+| File | Change Description |
+|------|-------------------|
+| `hooks/hooks.json:10` | `uv sync` → `uv sync --directory ${CLAUDE_PLUGIN_ROOT}` |
+
+**Before:**
+```json
+"command": "uv sync && uv run --directory ${CLAUDE_PLUGIN_ROOT} ${CLAUDE_PLUGIN_ROOT}/scripts/session_start_hook.py"
+```
+
+**After:**
+```json
+"command": "uv sync --directory ${CLAUDE_PLUGIN_ROOT} && uv run --directory ${CLAUDE_PLUGIN_ROOT} ${CLAUDE_PLUGIN_ROOT}/scripts/session_start_hook.py"
+```
+
+---
+
+## Acceptance Criteria
+
+### Fix Verification
+
+- [x] `uv sync --directory ${CLAUDE_PLUGIN_ROOT}` added to SessionStart hook command
+- [x] All `uv` invocations in `hooks/hooks.json` now consistently use `--directory ${CLAUDE_PLUGIN_ROOT}`
+- [ ] SessionStart hook executes successfully when CWD is a consumer repo without `pyproject.toml`
+- [ ] No regression: SessionStart hook still works when CWD is the Jerry repo itself
+
+### Quality Checklist
+
+- [ ] Existing tests still passing
+- [ ] No new issues introduced
+
+---
+
+## Related Items
+
+### Hierarchy
+
+- **Parent:** [EPIC-001-oss-release](../EPIC-001-oss-release.md)
+
+### Related Items
+
+- **GitHub Issue:** [geekatron/jerry#46](https://github.com/geekatron/jerry/issues/46)
+
+---
+
+## History
+
+| Date | Author | Status | Notes |
+|------|--------|--------|-------|
+| 2026-02-20 | Claude | pending | Initial report. `uv sync` missing `--directory` flag on SessionStart hook. |
+| 2026-02-20 | Claude | in_progress | Root cause confirmed. Fix applied to `hooks/hooks.json`. |

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "jerry"
-version = "0.3.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

- **BUG-013:** Fixed SessionStart hook `uv sync` running in wrong directory — missing `--directory ${CLAUDE_PLUGIN_ROOT}` flag caused `uv sync` to search CWD for `pyproject.toml`, fail in consumer repos, and `&&` short-circuit prevented `session_start_hook.py` from ever executing
- **BUG-012:** Added missing category dirs to PROJ-006 (CI fix)
- **FEAT-028:** MCP tool governance rule + Context7/Memory-Keeper integration across 14 agents
- **Version bumps:** 0.5.0 → 0.6.0 → 0.7.0

## Test plan

- [x] `uv sync --directory` flag added — consistent with all other `uv` calls in `hooks/hooks.json`
- [ ] Verify SessionStart hook executes successfully in consumer repos without `pyproject.toml`
- [ ] Verify no regression when CWD is the Jerry repo itself
- [ ] CI passes

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
