### PR TITLE
ci: add Codecov integration with branch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,7 @@ jobs:
           pytest \
             -m "not subprocess and not llm" \
             --cov=src \
+            --cov-branch \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing \
@@ -299,6 +300,7 @@ jobs:
           pytest \
             -m "not subprocess and not llm" \
             --cov=src \
+            --cov-branch \
             --cov-report=xml \
             --cov-report=html \
             --cov-report=term-missing \
@@ -314,6 +316,15 @@ jobs:
             coverage.xml
             htmlcov/
             junit-pip-${{ matrix.python-version }}.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: pip
+          fail_ci_if_error: false
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -371,6 +382,7 @@ jobs:
           uv run pytest \
             -m "not llm and not subprocess" \
             --cov=src \
+            --cov-branch \
             --cov-report=xml \
             --cov-report=term-missing \
             --cov-fail-under=80 \
@@ -390,6 +402,7 @@ jobs:
           uv run pytest \
             -m "not llm and not subprocess" \
             --cov=src \
+            --cov-branch \
             --cov-report=xml \
             --cov-report=term-missing \
             --junitxml=junit-uv-${{ matrix.python-version }}.xml \
@@ -403,6 +416,15 @@ jobs:
           path: |
             coverage.xml
             junit-uv-${{ matrix.python-version }}.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: uv
+          fail_ci_if_error: false
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -183,7 +183,7 @@ repos:
     hooks:
       - id: pip-audit
         name: pip-audit security scan
-        entry: uv run pip-audit
+        entry: uv run --frozen pip-audit
         language: system
         pass_filenames: false
         # Only run on push to avoid slowdown on every commit

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "jerry"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

Integrate Codecov for automated coverage tracking and PR-level coverage diff comments. No production code changes — CI workflow only.

**Changes:**
- Add `codecov/codecov-action@v5` upload steps to `test-pip` and `test-uv` CI jobs
- Enable `--cov-branch` on all pytest invocations for branch-level coverage metrics
- Fix pip-audit pre-push hook failure caused by `uv run` triggering unintended `uv sync`
- Sync `uv.lock` to match current jerry package version (`0.10.1`)

## Changes

### Codecov Integration (`.github/workflows/ci.yml`)

**Branch coverage:** Added `--cov-branch` to all 4 pytest invocations — both jobs (`test-pip`, `test-uv`) x both paths (normal coverage threshold, skip-coverage). Branch coverage is stricter than line-only coverage and may report slightly lower percentages; the `--cov-fail-under=80` threshold is unchanged; with `--cov-branch` enabled, the reported percentage reflects combined line and branch coverage, which may be slightly lower than line-only.

**Upload steps:** Added `codecov/codecov-action@v5` after test runs in both jobs, gated to the primary matrix cell (`python-version == '3.14' && os == 'ubuntu-latest'`):
- `test-pip` uploads with `flags: pip`
- `test-uv` uploads with `flags: uv`
- `fail_ci_if_error: false` ensures a Codecov service outage won't break CI

**Coverage format:** The `--cov-report=xml` flag was already present on all pytest invocations — `coverage.xml` was already being generated. This PR adds only the upload step to send it to Codecov.

**No `codecov.yml` configuration:** Using Codecov defaults. Project-specific configuration (target thresholds, patch requirements) can be added in a follow-up if needed.

**No new dependencies:** `pytest` and `pytest-cov` are already project dependencies. `CODECOV_TOKEN` secret is pre-configured in the repo.

### Pre-push Hook Fix (`.pre-commit-config.yaml`)

The pip-audit pre-push hook was failing because `uv run pip-audit` triggered an implicit `uv sync`, which modified `uv.lock` when the lock file was out of sync with `pyproject.toml` (jerry `0.10.0` in lock vs `0.10.1` in pyproject). The hook correctly detected the file modification and failed.

**Fix:** Changed `entry: uv run pip-audit` to `entry: uv run --frozen pip-audit`. The `--frozen` flag prevents `uv` from running any resolution — if the lock file is genuinely out of sync, the hook fails with an explicit error rather than silently updating. This is the desired behavior for a pre-push hook.

### Lock File Sync (`uv.lock`)

Updated `uv.lock` to reflect the jerry package `0.10.1` version bump on main. This was the root cause of the pip-audit hook failure.

## Test plan

- [ ] CI pipeline passes — check Actions tab on this PR
- [ ] Codecov receives coverage data — verify Codecov PR comment appears or check Codecov dashboard
- [ ] Branch coverage metrics visible — check `--cov-branch` in pytest output
- [ ] pip-audit pre-push hook passes — confirmed locally, no "files were modified" error
- [ ] Coverage thresholds unchanged — `--cov-fail-under=80` still enforced

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
