### PR TITLE
fix: reconcile EN-002 governance changes lost in PR #52 merge

### DIFF
--- a/.context/guides/architecture-layers.md
+++ b/.context/guides/architecture-layers.md
@@ -272,7 +272,7 @@ class SqlAlchemyAdapter(IRepository):
 
 **Solution**: Application depends on **ports** (interfaces), infrastructure **implements** ports.
 
-### Why Only Bootstrap Instantiates Infrastructure (H-09)
+### Why Only Bootstrap Instantiates Infrastructure (H-07)
 
 **Reason**: Centralized wiring. All dependency injection happens in **one place** (`src/bootstrap.py`).
 
@@ -619,7 +619,7 @@ def test_domain_has_no_infrastructure_imports():
 
 - Reviewers check for layer violations
 - Look for imports that violate dependency rules
-- Verify H-09 (only bootstrap instantiates infrastructure)
+- Verify H-07 (only bootstrap instantiates infrastructure)
 
 ---
 
@@ -631,7 +631,7 @@ def test_domain_has_no_infrastructure_imports():
 
 ```
 src/
-  bootstrap.py                                           # Composition root (H-09)
+  bootstrap.py                                           # Composition root (H-07)
   shared_kernel/                                         # Cross-cutting: VertexId, DomainEvent, exceptions
   application/
     dispatchers/query_dispatcher.py                      # QueryDispatcher (routes queries)
@@ -659,7 +659,7 @@ src/
     infrastructure/adapters/filesystem_project_adapter.py # Adapter
 ```
 
-### Composition Root (H-09) -- Real Implementation
+### Composition Root (H-07) -- Real Implementation
 
 **`src/bootstrap.py`** is the sole composition root. It:
 - Imports ALL infrastructure adapters (lines 47-106)
@@ -684,7 +684,7 @@ All dependencies are created HERE and injected.
 
 | Test File | What It Verifies |
 |-----------|-----------------|
-| `tests/architecture/test_composition_root.py` | Bootstrap imports infrastructure; dispatchers/ports do not (H-09) |
+| `tests/architecture/test_composition_root.py` | Bootstrap imports infrastructure; dispatchers/ports do not (H-07) |
 | `tests/architecture/test_config_boundaries.py` | Domain has no infra/app imports; adapters implement ports |
 | `tests/session_management/architecture/test_architecture.py` | Per-context: domain layer stdlib-only, dependency direction inward |
 

--- a/.context/guides/coding-practices.md
+++ b/.context/guides/coding-practices.md
@@ -232,7 +232,7 @@ class IRepository(Protocol[TAggregate, TId]):
 
 ## Docstring Best Practices
 
-### Why Docstrings Are Required (H-12)
+### Why Docstrings Are Required (H-11)
 
 **Rule**: All public functions, classes, and modules MUST have docstrings.
 
@@ -801,7 +801,7 @@ from re import Pattern
 from typing import ClassVar
 ```
 
-### Docstrings (H-12) -- Real Examples
+### Docstrings (H-11) -- Real Examples
 
 **`src/session_management/domain/aggregates/session.py`** -- Google-style class and method docstrings:
 ```python
@@ -886,7 +886,7 @@ class IQueryDispatcher(Protocol):
 
 ### Related Documents
 
-- [Coding Standards](../rules/coding-standards.md) - Enforcement rules (H-11, H-12)
+- [Coding Standards](../rules/coding-standards.md) - Enforcement rules (H-11)
 - [Architecture Layers Guide](architecture-layers.md) - Layer import rules
 - [Error Handling Guide](error-handling.md) - Exception hierarchy details
 

--- a/.context/guides/skill-development.md
+++ b/.context/guides/skill-development.md
@@ -768,7 +768,7 @@ Claude will quote the description back to you, showing exactly how it interprets
 
 > **Jerry Framework Note:** The following sections describe Anthropic's general skill distribution model (Claude.ai upload, API, GitHub hosting). Jerry skills are deployed via the repository filesystem — see [Context Distribution Architecture](#context-distribution-architecture) in Jerry Framework Conventions below. The general distribution guidance is included for completeness and for skills intended for community sharing outside Jerry.
 >
-> **H-27 Reminder:** The skill folder (`skills/your-skill-name/`) MUST NOT contain `README.md`. For GitHub hosting, the README belongs at the *hosting repository root*, not inside the skill folder. All skill documentation goes in `SKILL.md` or `references/`.
+> **H-25 Reminder:** The skill folder (`skills/your-skill-name/`) MUST NOT contain `README.md`. For GitHub hosting, the README belongs at the *hosting repository root*, not inside the skill folder. All skill documentation goes in `SKILL.md` or `references/`.
 
 ### Individual Installation
 
@@ -888,7 +888,7 @@ Jerry SKILL.md files follow a consistent structure:
 | [References](#references) | Source documents |
 
 > **Required by H-23/NAV-001.** SKILL.md is Claude-consumed markdown (always >30
-> lines). Navigation table with anchor links (H-24) enables Claude to understand
+> lines). Navigation table with anchor links (H-23) enables Claude to understand
 > document structure and navigate to relevant sections efficiently.
 
 ## Document Audience (Triple-Lens)

--- a/.context/guides/testing-practices.md
+++ b/.context/guides/testing-practices.md
@@ -207,7 +207,7 @@ def test_domain_has_no_infrastructure_imports():
 ```
 
 **Why 5%?**
-- Few architectural rules (H-07, H-08, H-09, H-10)
+- Few architectural rules (H-07, H-10)
 - Architectural violations are rare once established
 
 ---
@@ -1020,7 +1020,7 @@ def test_domain_has_no_infrastructure_imports():
 
 ---
 
-#### H-08: Application has no interface imports
+#### H-07: Application has no interface imports
 
 ```python
 def test_application_has_no_interface_imports():
@@ -1034,7 +1034,7 @@ def test_application_has_no_interface_imports():
 
 ---
 
-#### H-09: Only bootstrap instantiates infrastructure
+#### H-07: Only bootstrap instantiates infrastructure
 
 ```python
 def test_only_bootstrap_imports_infrastructure_adapters():
@@ -1049,7 +1049,7 @@ def test_only_bootstrap_imports_infrastructure_adapters():
         for file in layer_path.rglob("*.py"):
             imports = extract_imports_from_file(file)
             adapters = [i for i in imports if "infrastructure/adapters" in i]
-            assert not adapters, f"{file.name} violates H-09: {adapters}"
+            assert not adapters, f"{file.name} violates H-07: {adapters}"
 ```
 
 ---
@@ -1145,13 +1145,13 @@ Based on the actual `tests/` directory structure:
 
 | Metric | Target | CI Configuration | Status |
 |--------|--------|-----------------|--------|
-| Line Coverage | >= 90% (H-21) | `--cov-fail-under=80` in CI | Gap: CI threshold is 80%, rule says 90% |
+| Line Coverage | >= 90% (H-20) | `--cov-fail-under=80` in CI | Gap: CI threshold is 80%, rule says 90% |
 | Branch Coverage | >= 85% | Not explicitly configured in CI | Gap: Not enforced |
 | Function Coverage | >= 95% | Not explicitly configured in CI | Gap: Not enforced |
 
 ### Key Gaps
 
-1. **Coverage threshold gap**: CI enforces 80% (`ci.yml` line 249), but H-21 requires 90%. The CI threshold should be raised to match the rule.
+1. **Coverage threshold gap**: CI enforces 80% (`ci.yml` line 249), but H-20 requires 90%. The CI threshold should be raised to match the rule.
 2. **Branch coverage not enforced**: `pyproject.toml` does not include `branch = true` in coverage configuration. Consider adding `[tool.coverage.run] branch = true`.
 3. **Test markers**: `pyproject.toml` defines markers for `happy-path`, `negative`, `edge-case`, `boundary` (lines 106-111), but not all tests use these markers consistently.
 4. **Coverage exclusions**: No `[tool.coverage.report] exclude_lines` configuration found in `pyproject.toml`. Should add exclusions for `TYPE_CHECKING`, `@abstractmethod`, etc.
@@ -1173,7 +1173,7 @@ Based on the actual `tests/` directory structure:
 ```
 tests/
   architecture/
-    test_composition_root.py                # H-07, H-08, H-09 boundary checks
+    test_composition_root.py                # H-07 boundary checks
     test_config_boundaries.py               # Domain/application boundary enforcement
     test_check_architecture_boundaries.py   # Cross-module boundary checks
     test_session_hook_architecture.py        # Hook architecture compliance
@@ -1275,7 +1275,7 @@ test = [
 
 ### Related Documents
 
-- [Testing Standards](../rules/testing-standards.md) - Enforcement rules (H-20, H-21)
+- [Testing Standards](../rules/testing-standards.md) - Enforcement rules (H-20)
 - [Architecture Layers Guide](architecture-layers.md) - Layer responsibilities
 - [Coding Practices Guide](coding-practices.md) - Mocking, fixtures
 

--- a/.context/patterns/README.md
+++ b/.context/patterns/README.md
@@ -27,7 +27,7 @@
 
 | File | Demonstrates | Key Rules |
 |------|-------------|-----------|
-| `value_object_pattern.py` | Frozen dataclasses, validation in `__post_init__`, factory methods | H-11 (type hints), H-12 (docstrings) |
+| `value_object_pattern.py` | Frozen dataclasses, validation in `__post_init__`, factory methods | H-11 (type hints, docstrings) |
 | `domain_event_pattern.py` | Past-tense naming, EVENT_TYPE, payload serialization, from_dict() factory | Immutability, `_payload()` pattern |
 | `aggregate_pattern.py` | `_apply()`, `collect_events()`, factory methods, invariant enforcement | H-07 (no external imports) |
 
@@ -41,7 +41,7 @@
 
 | File | Demonstrates | Key Rules |
 |------|-------------|-----------|
-| `repository_pattern.py` | IRepository protocol, InMemoryRepository, FileRepository adapter, optimistic locking | H-09 (composition root only) |
+| `repository_pattern.py` | IRepository protocol, InMemoryRepository, FileRepository adapter, optimistic locking | H-07 (composition root only) |
 
 ### Shared Kernel Patterns
 
@@ -88,7 +88,7 @@
 
 ✅ **Valid Python** - Must pass `ruff check` and `mypy`
 ✅ **Type Hints** - All public functions (H-11)
-✅ **Docstrings** - All public classes and functions (H-12)
+✅ **Docstrings** - All public classes and functions (H-11)
 ✅ **Examples** - Docstring examples showing usage
 ✅ **Self-Contained** - Can be read independently
 ✅ **Commented** - Explain WHY, not just WHAT

--- a/.context/rules/mandatory-skill-usage.md
+++ b/.context/rules/mandatory-skill-usage.md
@@ -26,18 +26,20 @@
 
 ## Trigger Map
 
-| Detected Keywords | Skill |
-|-------------------|-------|
-| research, analyze, investigate, explore, root cause, why | `/problem-solving` |
-| requirements, specification, V&V, technical review, risk | `/nasa-se` |
-| orchestration, pipeline, workflow, multi-agent, phases, gates | `/orchestration` |
-| transcript, meeting notes, parse recording, meeting recording, VTT, SRT, captions | `/transcript` |
-| adversarial quality review, adversarial critique, rigorous critique, formal critique, adversarial, tournament, red team, devil's advocate, steelman, pre-mortem, quality gate, quality scoring | `/adversary` |
-| saucer boy, mcconkey, talk like mcconkey, pep talk, roast this code, saucer boy mode | `/saucer-boy` |
-| voice check, voice review, persona compliance, voice rewrite, voice fidelity, voice score, framework voice, persona review | `/saucer-boy-framework-voice` |
-| frontmatter, entity metadata, status extraction, validate entity, parse markdown, blockquote frontmatter, nav table validation, schema validation | `/ast` |
-| secure development, secure design, threat model, security architecture, STRIDE, DREAD, SDLC, DevSecOps, SAST, DAST, code review for security, OWASP, ASVS, CWE, SSDF, SLSA, incident response, supply chain security, security requirements, CIS benchmark | `/eng-team` |
-| penetration test, pentest, red team, offensive security, reconnaissance, exploit, privilege escalation, lateral movement, persistence, exfiltration, C2, command and control, social engineering, phishing, attack surface, kill chain, PTES, OSSTMM, ATT&CK, rules of engagement, vulnerability assessment | `/red-team` |
+> Phase 1 enhanced format (5-column) per `agent-routing-standards.md`. Backward-compatible: consumers parsing only columns 1+5 continue to function.
+
+| Detected Keywords | Negative Keywords | Priority | Compound Triggers | Skill |
+|---|---|---|---|---|
+| research, analyze, investigate, explore, root cause, why, debug, troubleshoot, diagnose, figure out, what went wrong, compare, evaluate | requirements, specification, V&V, adversarial, tournament, transcript, VTT, SRT, voice, persona | 6 | -- | `/problem-solving` |
+| requirements, specification, V&V, technical review, risk, design, architecture, interface, trade study, compliance | root cause, debug, adversarial, tournament, research (standalone), transcript | 5 | "technical review" (both words required) | `/nasa-se` |
+| orchestration, pipeline, workflow, multi-agent, phases, gates, plan, coordinate, break into steps, sequence | adversarial, transcript, root cause, debug | 1 | -- | `/orchestration` |
+| transcript, meeting notes, parse recording, meeting recording, VTT, SRT, captions, audio, summarize this meeting | adversarial, requirements, design | 2 | "parse recording" OR "meeting recording" (phrase match) | `/transcript` |
+| adversarial quality review, adversarial critique, rigorous critique, formal critique, adversarial, tournament, red team, devil's advocate, steelman, pre-mortem, quality gate, quality scoring | requirements, specification, design, research, investigate, penetration, exploit, engagement | 7 | "adversarial review" OR "quality gate" OR "quality scoring" (phrase match) | `/adversary` |
+| saucer boy, mcconkey, talk like mcconkey, pep talk, roast this code, saucer boy mode | -- | 3 | -- | `/saucer-boy` |
+| voice check, voice review, persona compliance, voice rewrite, voice fidelity, voice score, framework voice, persona review | -- | 4 | ("voice" OR "persona") AND ("review" OR "check" OR "score") | `/saucer-boy-framework-voice` |
+| frontmatter, entity metadata, status extraction, validate entity, parse markdown, blockquote frontmatter, nav table validation, schema validation | -- | 8 | -- | `/ast` |
+| secure development, secure design, threat model, security architecture, STRIDE, DREAD, SDLC, DevSecOps, SAST, DAST, code review for security, OWASP, ASVS, CWE, SSDF, SLSA, incident response, supply chain security, security requirements, CIS benchmark | adversarial, tournament, quality gate | 9 | -- | `/eng-team` |
+| penetration test, pentest, red team, offensive security, reconnaissance, exploit, privilege escalation, lateral movement, persistence, exfiltration, C2, command and control, social engineering, phishing, attack surface, kill chain, PTES, OSSTMM, ATT&CK, rules of engagement, vulnerability assessment | adversarial quality review, quality gate, quality scoring | 10 | -- | `/red-team` |
 
 > **Disambiguation: "red team" keyword overlap.** The `/adversary` skill uses "red team" for adversarial quality review (S-001 Red Team Analysis strategy). The `/red-team` skill uses "red team" for offensive security testing. Context determines routing: quality/review context -> `/adversary`; engagement/target/penetration context -> `/red-team`; ambiguous -> clarify per H-31.
 

--- a/.context/rules/project-workflow.md
+++ b/.context/rules/project-workflow.md
@@ -10,6 +10,7 @@
 | [HARD Rule Reference](#hard-rule-reference) | H-04 active project requirement |
 | [GitHub Issue Parity](#github-issue-parity) | H-31 dual-tracking requirement |
 | [Workflow Phases](#workflow-phases) | Before, during, after work |
+| [Workflow Methodology (MEDIUM)](#workflow-methodology-medium) | Plan mode and structured workflow for C2+ work |
 | [Project Orientation](#project-orientation) | Minimal structural context for session start |
 | [Project Resolution](#project-resolution) | How to handle missing project context |
 
@@ -45,6 +46,27 @@
 | **After** | Update completion status. Capture learnings in `docs/experience/`. Commit with semantic messages. |
 
 > **Integrity enforcement (HARD):** All worktracker operations MUST follow WTI-001 through WTI-007. See `skills/worktracker/rules/worktracker-behavior-rules.md` for full definitions.
+
+---
+
+## Workflow Methodology (MEDIUM)
+
+> Override requires documented justification.
+
+| ID | Standard | Guidance | Source |
+|----|----------|----------|--------|
+| PM-M-001 | For C2+ work, SHOULD follow the explore-plan-approve-implement-verify sequence. Plan mode SHOULD be used when: (a) 3+ files will be affected, (b) multiple valid implementation approaches exist, or (c) no explicit user plan has been provided. Plan mode is NOT needed for: single-file changes, obvious bug fixes, or when the user provides detailed implementation instructions. | This formalizes the structured workflow pattern recommended by Anthropic's Claude Code best practices. For multi-agent workflows, `/orchestration` provides the equivalent coordination; PM-M-001 covers the single-agent case where the main context manages the work directly. Plan mode enables the user to review and approve the approach before implementation begins, reducing wrong-direction work (H-31 alignment). | Anthropic Claude Code best practices, H-31 (ambiguity resolution) |
+
+### PM-M-001 Decision Guide
+
+| Condition | Use Plan Mode? | Rationale |
+|-----------|---------------|-----------|
+| C1 task, single file, clear instructions | No | Overhead exceeds benefit |
+| C2 task, 3+ files, clear approach | Recommended | Confirms scope alignment |
+| C2 task, multiple valid approaches | Yes | User selects preferred approach |
+| C3+ task, any scope | Yes | High-impact work warrants explicit approval |
+| User provided detailed step-by-step | No | User's plan serves as the approved plan |
+| `/orchestration` is being invoked | No | Orchestration provides its own planning phase |
 
 ---
 

--- a/.context/rules/quality-enforcement.md
+++ b/.context/rules/quality-enforcement.md
@@ -1,6 +1,6 @@
 # Quality Enforcement -- Single Source of Truth
 
-<!-- VERSION: 1.3.0 | DATE: 2026-02-15 | SOURCE: EPIC-002 Final Synthesis, ADR-EPIC002-001, ADR-EPIC002-002 -->
+<!-- VERSION: 1.6.0 | DATE: 2026-02-21 | SOURCE: EPIC-002/EN-002/EN-001 — added H-34 (agent-dev), H-36 (agent-routing), consolidated H-20/H-21 -->
 
 > Canonical constants for the quality framework. All hooks, rules, and skills MUST reference this file.
 
@@ -8,10 +8,14 @@
 
 | Section | Purpose |
 |---------|---------|
-| [HARD Rule Index](#hard-rule-index) | H-01 through H-33 |
+| [HARD Rule Index](#hard-rule-index) | H-01 through H-36 (post-EN-001/EN-002 consolidation) |
+| [Retired Rule IDs](#retired-rule-ids) | Tombstoned IDs from EN-002 consolidation |
 | [Quality Gate](#quality-gate) | Threshold, dimensions, weights, consequences |
 | [Criticality Levels](#criticality-levels) | C1-C4 decision classification with strategy sets |
 | [Tier Vocabulary](#tier-vocabulary) | HARD/MEDIUM/SOFT enforcement language |
+| [Two-Tier Enforcement Model](#two-tier-enforcement-model) | Tier A (L2-protected) vs Tier B (compensating controls) |
+| [HARD Rule Ceiling Derivation](#hard-rule-ceiling-derivation) | Principled upper boundary (25 rules) |
+| [HARD Rule Ceiling Exception Mechanism](#hard-rule-ceiling-exception-mechanism) | Controlled temporary expansion |
 | [Auto-Escalation Rules](#auto-escalation-rules) | AE-001 through AE-006e (graduated context fill sub-rules) |
 | [Enforcement Architecture](#enforcement-architecture) | L1-L5 layer definitions |
 | [Strategy Catalog](#strategy-catalog) | S-001 through S-015 (selected and excluded) |
@@ -24,25 +28,23 @@
 
 > These are the authoritative HARD rules. Each rule CANNOT be overridden. See source files for consequences.
 
-<!-- L2-REINJECT: rank=1, tokens=50, content="Constitutional: No recursive subagents (P-003). User decides, never override (P-020). No deception (P-022). These are HARD constraints that CANNOT be overridden." -->
+<!-- L2-REINJECT: rank=1, content="Constitutional: No recursive subagents (P-003). User decides, never override (P-020). No deception (P-022). These are HARD constraints that CANNOT be overridden." -->
 
-<!-- L2-REINJECT: rank=2, tokens=90, content="Quality gate >= 0.92 weighted composite for C2+ deliverables (H-13). Creator-critic-revision cycle REQUIRED, minimum 3 iterations (H-14). Below threshold = REJECTED." -->
+<!-- L2-REINJECT: rank=2, content="Quality gate >= 0.92 weighted composite for C2+ deliverables (H-13). Creator-critic-revision cycle REQUIRED, minimum 3 iterations (H-14). Below threshold = REJECTED." -->
 
-<!-- L2-REINJECT: rank=2, tokens=50, content="Ambiguity resolution (H-31): When requirements have multiple valid interpretations, unclear scope, or imply destructive action -- MUST ask clarifying questions before proceeding. Do NOT assume. Do NOT ask when requirements are clear or answers are in the codebase." -->
+<!-- L2-REINJECT: rank=2, content="Ambiguity resolution (H-31): When requirements have multiple valid interpretations, unclear scope, or imply destructive action -- MUST ask clarifying questions before proceeding. Do NOT assume. Do NOT ask when requirements are clear or answers are in the codebase." -->
 
-<!-- L2-REINJECT: rank=3, tokens=25, content="UV only for Python (H-05/H-06). NEVER use python/pip directly." -->
+<!-- L2-REINJECT: rank=3, content="UV only for Python (H-05). NEVER use python/pip directly. Use uv run for execution, uv add for deps." -->
 
-<!-- L2-REINJECT: rank=4, tokens=30, content="LLM-as-Judge scoring (S-014): Apply strict rubric. Leniency bias must be actively counteracted." -->
+<!-- L2-REINJECT: rank=4, content="LLM-as-Judge scoring (S-014): Apply strict rubric. Leniency bias must be actively counteracted." -->
 
-<!-- L2-REINJECT: rank=5, tokens=30, content="Self-review REQUIRED before presenting any deliverable (H-15, S-010)." -->
+<!-- L2-REINJECT: rank=5, content="Self-review REQUIRED before presenting any deliverable (H-15, S-010)." -->
 
-<!-- L2-REINJECT: rank=8, tokens=40, content="Governance escalation REQUIRED per AE rules (H-19). Touches .context/rules/ = auto-C3. Touches constitution = auto-C4." -->
+<!-- L2-REINJECT: rank=8, content="Governance escalation REQUIRED per AE rules (H-19). Touches .context/rules/ = auto-C3. Touches constitution = auto-C4." -->
 
 <!-- L2-REINJECT: rank=9, tokens=40, content="AE-006 graduated escalation: NOMINAL=no-op, WARNING=log+consider-checkpoint, CRITICAL=auto-checkpoint+reduce-verbosity, EMERGENCY=mandatory-checkpoint+warn-user, COMPACTION=human-escalation-C3+." -->
 
-<!-- L2-REINJECT: rank=9, tokens=25, content="Resumption update: MUST update ORCHESTRATION.yaml resumption section at every state transition (phase/QG/agent/compaction)." -->
-
-<!-- L2-REINJECT: rank=10, tokens=30, content="AST-based parsing REQUIRED for worktracker entity operations (H-33). Use /ast skill query_frontmatter() and validate_file(). NEVER use regex for frontmatter extraction." -->
+<!-- L2-REINJECT: rank=10, tokens=30, content="AST-based parsing REQUIRED for worktracker entity operations (H-33). Use jerry ast frontmatter and jerry ast validate CLI commands. NEVER use regex for frontmatter extraction." -->
 
 | ID | Rule | Source |
 |----|------|--------|
@@ -50,14 +52,10 @@
 | H-02 | User authority -- never override | P-020 |
 | H-03 | No deception about actions/capabilities | P-022 |
 | H-04 | Active project REQUIRED | CLAUDE.md |
-| H-05 | UV only for Python execution | python-environment |
-| H-06 | UV only for dependencies | python-environment |
-| H-07 | Domain layer: no external imports | architecture-standards |
-| H-08 | Application layer: no infra/interface imports | architecture-standards |
-| H-09 | Composition root exclusivity | architecture-standards |
+| H-05 | UV-only Python environment (execution via `uv run`, dependencies via `uv add`) | python-environment |
+| H-07 | Architecture layer isolation (domain imports, application imports, composition root) | architecture-standards |
 | H-10 | One class per file | architecture-standards |
-| H-11 | Type hints REQUIRED on public functions | coding-standards |
-| H-12 | Docstrings REQUIRED on public functions | coding-standards |
+| H-11 | Public function signatures (type hints + docstrings REQUIRED) | coding-standards |
 | H-13 | Quality threshold >= 0.92 for C2+ | quality-enforcement |
 | H-14 | Creator-critic-revision cycle (3 min) | quality-enforcement |
 | H-15 | Self-review before presenting (S-010) | quality-enforcement |
@@ -65,26 +63,43 @@
 | H-17 | Quality scoring REQUIRED for deliverables | quality-enforcement |
 | H-18 | Constitutional compliance check (S-007) | quality-enforcement |
 | H-19 | Governance escalation per AE rules | quality-enforcement |
-| H-20 | Test before implement (BDD Red phase) | testing-standards |
-| H-21 | 90% line coverage REQUIRED | testing-standards |
+| H-20 | Testing standards (BDD test-first Red phase, 90% line coverage REQUIRED) | testing-standards |
 | H-22 | Proactive skill invocation | mandatory-skill-usage |
-| H-23 | Navigation table REQUIRED (NAV-001) | markdown-navigation |
-| H-24 | Anchor links REQUIRED (NAV-006) | markdown-navigation |
-| H-25 | Skill file MUST be exactly `SKILL.md` (case-sensitive) | skill-standards |
-| H-26 | Skill folder MUST use kebab-case, match `name` field | skill-standards |
-| H-27 | No `README.md` inside skill folder | skill-standards |
-| H-28 | Description: WHAT + WHEN + triggers, <1024 chars, no XML | skill-standards |
-| H-29 | Full repo-relative paths in SKILL.md | skill-standards |
-| H-30 | Register in CLAUDE.md + AGENTS.md (+ mandatory-skill-usage.md if proactive) | skill-standards |
+| H-23 | Markdown navigation (navigation table NAV-001, anchor links NAV-006) | markdown-navigation |
+| H-25 | Skill naming and structure (SKILL.md case, kebab-case folder, no README.md) | skill-standards |
+| H-26 | Skill description, paths, and registration (WHAT+WHEN+triggers, repo-relative paths, CLAUDE.md+AGENTS.md) | skill-standards |
 | H-31 | Clarify before acting when ambiguous (ask, don't assume) | quality-enforcement |
 | H-32 | GitHub Issue parity for jerry repo work items | project-workflow |
 | H-33 | AST-based parsing REQUIRED for worktracker entity ops | ast-enforcement |
+| H-34 | Agent definition standards (YAML schema validation, constitutional compliance triplet) | agent-development-standards |
+| H-36 | Agent routing standards (circuit breaker max 3 hops, keyword-first routing) | agent-routing-standards |
+
+---
+
+## Retired Rule IDs
+
+> Rule IDs below were retired during EN-002 consolidation (2026-02-21). These IDs MUST NOT be reassigned to prevent confusion with historical references.
+
+| Retired ID | Consolidated Into | Original Rule | Date |
+|------------|-------------------|---------------|------|
+| H-08 | H-07 (sub-item b) | Application layer: no infra/interface imports | 2026-02-21 |
+| H-09 | H-07 (sub-item c) | Composition root exclusivity | 2026-02-21 |
+| H-27 | H-25 | No README.md inside skill folder | 2026-02-21 |
+| H-28 | H-26 | Skill description: WHAT+WHEN+triggers, <1024 chars, no XML | 2026-02-21 |
+| H-29 | H-26 | Full repo-relative paths in SKILL.md | 2026-02-21 |
+| H-30 | H-26 | Register in CLAUDE.md + AGENTS.md | 2026-02-21 |
+| H-06 | H-05 (sub-item b) | UV only for dependencies | 2026-02-21 |
+| H-12 | H-11 (sub-item b) | Docstrings REQUIRED on public functions | 2026-02-21 |
+| H-24 | H-23 (sub-item b) | Anchor links REQUIRED (NAV-006) | 2026-02-21 |
+| H-21 | H-20 (sub-item b) | 90% line coverage REQUIRED | 2026-02-21 |
+| H-35 | H-34 (sub-item b) | Constitutional compliance in agent definitions | 2026-02-21 |
+| H-37 | H-36 (sub-item b) | Keyword-first routing below 20 skills | 2026-02-21 |
 
 ---
 
 ## Quality Gate
 
-<!-- L2-REINJECT: rank=6, tokens=100, content="Criticality levels: C1 Routine (reversible 1 session, HARD only). C2 Standard (reversible 1 day, HARD+MEDIUM). C3 Significant (>1 day, all tiers). C4 Critical (irreversible, all tiers + tournament). AE-002: .context/rules/ = auto-C3. AE-001/AE-004: constitution/baselined ADR = auto-C4." -->
+<!-- L2-REINJECT: rank=6, content="Criticality levels: C1 Routine (reversible 1 session, HARD only). C2 Standard (reversible 1 day, HARD+MEDIUM). C3 Significant (>1 day, all tiers). C4 Critical (irreversible, all tiers + tournament). AE-002: .context/rules/ = auto-C3. AE-001/AE-004: constitution/baselined ADR = auto-C4." -->
 
 **Threshold:** >= 0.92 weighted composite score (C2+ deliverables)
 
@@ -145,9 +160,80 @@ Below-threshold deliverables are subdivided into operational bands for workflow 
 
 | Tier | Keywords | Override | Max Count |
 |------|----------|----------|-----------|
-| **HARD** | MUST, SHALL, NEVER, FORBIDDEN, REQUIRED, CRITICAL | Cannot override | <= 35 |
+| **HARD** | MUST, SHALL, NEVER, FORBIDDEN, REQUIRED, CRITICAL | Cannot override | <= 25 |
 | **MEDIUM** | SHOULD, RECOMMENDED, PREFERRED, EXPECTED | Documented justification | Unlimited |
 | **SOFT** | MAY, CONSIDER, OPTIONAL, SUGGESTED | No justification needed | Unlimited |
+
+### Two-Tier Enforcement Model
+
+Rules are classified by their enforcement reliability:
+
+**Tier A** — L2 engine-protected (per-prompt re-injection + compensating L3/L5 controls):
+
+| Rules | L2 Source | Count |
+|-------|-----------|-------|
+| H-01, H-02, H-03 | quality-enforcement.md rank 1 | 3 |
+| H-05 | python-environment.md rank 3 | 1 |
+| H-07, H-10 | architecture-standards.md rank 4 | 2 |
+| H-11 | coding-standards.md rank 7 | 1 |
+| H-13, H-14, H-31 | quality-enforcement.md rank 2 | 3 |
+| H-15 | quality-enforcement.md rank 5 | 1 |
+| H-19 | quality-enforcement.md rank 8 | 1 |
+| H-20 | testing-standards.md rank 5 | 1 |
+| H-22 | mandatory-skill-usage.md rank 6 | 1 |
+| H-23 | markdown-navigation.md rank 7 | 1 |
+| H-25, H-26 | skill-standards.md rank 7 | 2 |
+| H-33 | quality-enforcement.md rank 10 | 1 |
+| H-34 | agent-development-standards.md rank 5 | 1 |
+| H-36 | agent-routing-standards.md rank 6 | 1 |
+| **Tier A Total** | | **20** |
+
+**Tier B** — Structural L2 (L1 awareness only, compensating controls prevent bypass):
+
+| Rule | Compensating Controls | Count |
+|------|----------------------|-------|
+| H-04 (active project) | SessionStart hook enforcement (L3), CLI validation | 1 |
+| H-16 (steelman before critique) | /adversary skill enforcement, L1 rule awareness | 1 |
+| H-17 (quality scoring) | /adversary + /problem-solving skill enforcement | 1 |
+| H-18 (constitutional compliance) | S-007 strategy enforcement in /adversary skill | 1 |
+| H-32 (GitHub Issue parity) | /worktracker skill enforcement, CI workflow | 1 |
+| **Tier B Total** | | **5** |
+
+**Total:** 25 HARD rules (20 Tier A + 5 Tier B)
+
+> **Note:** Tier B rules are candidates for L2 marker addition pending effectiveness measurement (DEC-005). Current compensating controls provide adequate enforcement through deterministic mechanisms (hooks, skills, CI gates).
+
+### HARD Rule Ceiling Derivation
+
+The ceiling of 25 HARD rules is derived from three independent constraint families (EN-002, C4 derivation scored 0.95 PASS, 2 iterations):
+
+1. **Cognitive Load** — LLM instruction-following reliability degrades when rule sets exceed ~20-25 items, consistent with chunking limits observed in structured prompt compliance benchmarks. At 25 rules, the framework operates at the practical upper bound; beyond this, enforcement reliability drops measurably.
+2. **Enforcement Coverage** — L2 per-prompt re-injection operates within an 850-token budget. Current 25 rules consume 559/850 tokens (65.8%) via 16 L2-REINJECT markers. Each additional rule requires ~30-50 tokens of reinforcement capacity, leaving room for ~6 additional markers before budget exhaustion.
+3. **Governance Burden** — Each HARD rule requires: (a) constitutional justification, (b) at least one enforcement mechanism (L2 marker, L3 AST gate, L5 CI check, or skill enforcement), and (c) ongoing maintenance. At 25 rules, governance overhead is manageable; beyond 28, the review burden for ceiling exceptions approaches the cost of the rules themselves.
+
+**Convergence:** All three families independently converge on 25 as the practical upper bound. The absolute maximum (28) is enforced by an independent constant in the L5 gate script, preventing self-referential ceiling manipulation.
+
+**Current count:** 25 HARD rules (post-EN-001/EN-002 consolidation). Zero headroom. H-34 (agent definition standards) and H-36 (agent routing standards) added via EN-001 with H-20/H-21 consolidation to stay at ceiling.
+
+### HARD Rule Ceiling Exception Mechanism
+
+Temporary ceiling expansion is permitted under controlled conditions:
+
+| Condition | Requirement |
+|-----------|-------------|
+| Justification | C4-reviewed ADR documenting why the ceiling must be exceeded |
+| Scope | Maximum N=3 additional slots (ceiling+3 = 28 absolute max) |
+| Concurrency | Maximum 1 active exception at any time (M-09: no stacking) |
+| Duration | 3 months maximum; consolidation plan required |
+| Enforcement | L5 CI gate must be updated to reflect temporary ceiling |
+| Reversion | Consolidation or demotion must restore count to <= 25 within 3 months |
+| Tracking | Exception MUST be tracked as a worktracker entity with reversion deadline |
+
+**Process:** File an ADR per AE-003/AE-004. If approved after C4 review, update the L5 CI gate ceiling parameter in quality-enforcement.md (the `_ABSOLUTE_MAX_CEILING` constant in `check_hard_rule_ceiling.py` enforces the absolute maximum independently). Track the temporary expansion in the worktracker with a reversion deadline. The L5 CI gate will automatically enforce the updated ceiling on every commit and in GitHub Actions CI.
+
+**Reversion enforcement (C-03):** The L5 CI gate provides automated enforcement — when the exception expires, the ceiling value is reverted to 25 and any excess rules will cause CI failure. The worktracker reversion deadline provides human-visible tracking.
+
+**EN-001 phasing note (C-02):** H-32 and H-33 were added by PROJ-005 via merge. EN-001 added H-34 (agent definition standards, compound: schema validation + constitutional compliance) and H-36 (agent routing standards, compound: circuit breaker + keyword-first routing) with H-20/H-21 testing consolidation. Current count: 25/25. H-35, H-37, H-21 retired into compound parents.
 
 ---
 
@@ -173,14 +259,14 @@ Below-threshold deliverables are subdivided into operational bands for workflow 
 | Layer | Timing | Function | Context Rot | Tokens |
 |-------|--------|----------|-------------|--------|
 | L1 | Session start | Behavioral foundation via rules | Vulnerable | ~12,500 |
-| L2 | Every prompt | Re-inject critical rules | Immune | ~600/prompt |
+| L2 | Every prompt | Re-inject critical rules | Immune | ~850/prompt |
 | L3 | Before tool calls | Deterministic gating (AST) | Immune | 0 |
 | L4 | After tool calls | Output inspection, self-correction | Mixed | 0-1,350 |
 | L5 | Commit/CI | Post-hoc verification | Immune | 0 |
 
 **Context Rot:** Vulnerable = degrades with context fill. Immune = unaffected. Mixed = deterministic gating immune, self-correction vulnerable.
 
-**Total enforcement budget:** ~15,100 tokens (7.6% of 200K context)
+**Total enforcement budget:** ~15,350 tokens (7.7% of 200K context)
 
 ---
 

--- a/.context/rules/skill-standards.md
+++ b/.context/rules/skill-standards.md
@@ -9,13 +9,13 @@ paths:
 > Rules for building, structuring, and registering Jerry framework skills.
 > Based on Anthropic's "Complete Guide to Building Skills for Claude" (January 2026) and Jerry's established conventions across 8 production skills.
 
-<!-- L2-REINJECT: rank=7, tokens=70, content="Skills: SKILL.md exact case (H-25). Folder kebab-case (H-26). No README.md in skill folder (H-27). Description MUST include WHAT + WHEN + triggers (H-28). Full repo-relative paths for all file references (H-29). Register in CLAUDE.md + AGENTS.md (H-30). Document Sections navigation table REQUIRED (H-23). .context/ is Claude-agnostic; .claude/rules/ symlinks to .context/rules/ for auto-loading." -->
+<!-- L2-REINJECT: rank=7, content="Skills: SKILL.md exact case, kebab-case folder, no README.md (H-25). Description WHAT+WHEN+triggers, repo-relative paths, register in CLAUDE.md+AGENTS.md (H-26). Navigation table REQUIRED (H-23)." -->
 
 ## Document Sections
 
 | Section | Purpose |
 |---------|---------|
-| [HARD Rules](#hard-rules) | Skill constraints H-25 through H-30 |
+| [HARD Rules](#hard-rules) | Skill constraints H-25, H-26 (compound) |
 | [Standards (MEDIUM)](#standards-medium) | Structural conventions, frontmatter, progressive disclosure |
 | [Guidance (SOFT)](#guidance-soft) | Optional practices and recommendations |
 
@@ -27,12 +27,8 @@ paths:
 
 | ID | Rule | Consequence |
 |----|------|-------------|
-| H-25 | Skill file MUST be exactly `SKILL.md` (case-sensitive). No variations (`SKILL.MD`, `skill.md`, `Skill.md`). Case sensitivity is required for Linux filesystems (Claude.ai, CI/CD) even if macOS (case-insensitive) accepts variations. | Skill silently absent from session. Claude's skill loader performs exact case match — no error raised, skill simply does not load. |
-| H-26 | Skill folder MUST use kebab-case. No spaces, underscores, or capitals. Folder name MUST match the `name` field in frontmatter. | Skill not loadable. |
-| H-27 | No `README.md` inside the skill folder. All documentation goes in `SKILL.md` or `references/`. | Some hosting and automation tooling (including Claude's skill loader) may use README.md preferentially, bypassing SKILL.md as the entry point. |
-| H-28 | Frontmatter `description` field MUST include WHAT it does AND WHEN to use it (trigger conditions). MUST include specific phrases users would say. Under 1024 characters. No XML tags (`< >`). | Skill does not trigger. Security risk (XML injection into system prompt). |
-| H-29 | All file references in SKILL.md MUST use full repo-relative paths (`skills/saucer-boy-framework-voice/references/voice-guide.md`), not relative paths (`references/voice-guide.md`). Claude's working directory at load time is session-state-dependent, not skill-location-dependent. | Relative paths resolve against CWD (unpredictable), not the skill folder. Full repo-relative paths are the only style that resolves correctly regardless of session state. |
-| H-30 | New skills MUST be registered in: (1) `CLAUDE.md` Quick Reference Skills table; (2) `AGENTS.md` for all agents defined; (3) `.context/rules/mandatory-skill-usage.md` trigger map IF the skill requires proactive invocation per H-22 (note: modifying this file triggers AE-002, auto-C3 minimum). | Skill undiscoverable, agents unregistered. Missing mandatory-skill-usage.md entry causes proactive invocation to silently fail. |
+| H-25 | **Skill naming and structure:** (a) Skill file MUST be exactly `SKILL.md` (case-sensitive, no variations); (b) Skill folder MUST use kebab-case (no spaces, underscores, or capitals) and match the `name` field in frontmatter; (c) No `README.md` inside the skill folder (all documentation in `SKILL.md` or `references/`). | Skill silently absent from session, not loadable, or loader bypasses SKILL.md. |
+| H-26 | **Skill description, paths, and registration:** (a) Frontmatter `description` MUST include WHAT + WHEN + trigger phrases, under 1024 chars, no XML tags (`< >`); (b) All file references in SKILL.md MUST use full repo-relative paths; (c) New skills MUST be registered in CLAUDE.md, AGENTS.md, and mandatory-skill-usage.md (if proactive per H-22). | Skill does not trigger, paths resolve incorrectly, or skill is undiscoverable. |
 
 ### Security Restrictions
 
@@ -168,7 +164,7 @@ For critical validations, consider bundling a script in `scripts/` that performs
 
 ### Existing Skills
 
-Rules H-25 through H-30 apply to all new skills immediately. Existing production skills (9 as of 2026-02-19) SHOULD be audited for compliance. Non-compliant existing skills MUST have a compliance issue filed in the worktracker.
+Rules H-25 and H-26 apply to all new skills immediately. Existing production skills (9 as of 2026-02-19) SHOULD be audited for compliance. Non-compliant existing skills MUST have a compliance issue filed in the worktracker.
 
 ---
 
@@ -186,9 +182,9 @@ Rules H-25 through H-30 apply to all new skills immediately. Existing production
 
 ---
 
-<!-- VERSION: 1.1.0 | DATE: 2026-02-19 | SOURCE: Anthropic Skill Guide (Jan 2026), Jerry Framework v0.2.3, C3 adversarial review -->
+<!-- VERSION: 1.2.0 | DATE: 2026-02-21 | SOURCE: Anthropic Skill Guide (Jan 2026), Jerry Framework v0.2.3, EN-002 consolidation -->
 
-*Standards Version: 1.1.0*
-*SSOT: `.context/rules/quality-enforcement.md` (H-25 through H-30 registered)*
+*Standards Version: 1.2.0*
+*SSOT: `.context/rules/quality-enforcement.md` (H-25, H-26 registered — consolidated from H-25..H-30 per EN-002)*
 *Source: Anthropic Skill Guide (Jan 2026) + Jerry Framework v0.2.3*
 *Created: 2026-02-19*

--- a/.context/templates/adversarial/s-007-constitutional-ai.md
+++ b/.context/templates/adversarial/s-007-constitutional-ai.md
@@ -98,7 +98,7 @@ Systematic constitutional compliance report: enumerates applicable principles, c
 
 ### Context Requirements
 
-Load: `JERRY_CONSTITUTION.md` (P-001–P-043), `.context/rules/*.md` (H-01–H-24), `quality-enforcement.md` (SSOT).
+Load: `JERRY_CONSTITUTION.md` (P-001–P-043), `.context/rules/*.md` (H-01–H-33), `quality-enforcement.md` (SSOT).
 
 **Tier Mapping:** HARD (MUST, SHALL, NEVER, FORBIDDEN, REQUIRED, CRITICAL→Critical), MEDIUM (SHOULD, RECOMMENDED, PREFERRED, EXPECTED→Major), SOFT (MAY, CONSIDER, OPTIONAL, SUGGESTED→Minor).
 
@@ -124,8 +124,8 @@ Load: `JERRY_CONSTITUTION.md` (P-001–P-043), `.context/rules/*.md` (H-01–H-2
    - Document deliverables: `markdown-navigation-standards.md`, `quality-enforcement.md`
    - Template/rule deliverables: ALL rules (AE-002 triggers auto-C3)
    - Architecture/design: `architecture-standards.md`, `file-organization.md`
-4. Read `quality-enforcement.md` for HARD rule index (H-01 through H-24), tier vocabulary, auto-escalation rules
-   - **H-Rule Quick Reference:** 24 HARD rules exist (H-01 through H-24). See quality-enforcement.md lines 38-63 for the complete H-rule index with rule text and source files. Review this index before Step 2 to ensure no HARD rules are missed during principle enumeration.
+4. Read `quality-enforcement.md` for HARD rule index (H-01 through H-33), tier vocabulary, auto-escalation rules
+   - **H-Rule Quick Reference:** 33 HARD rules exist (H-01 through H-33). See quality-enforcement.md HARD Rule Index for the complete H-rule index with rule text and source files. Review this index before Step 2 to ensure no HARD rules are missed during principle enumeration.
 5. Create index of all loaded principles with tier classification
 
 **Decision Point:** AE-001 (constitution→C4), AE-002 (rules/templates→C3)
@@ -385,10 +385,10 @@ from domain.project import Project
 
 class CreateProjectCommandHandler(ICommandHandler):
     def handle(self, command):  # CC-002 violation (no type hints per H-11)
-        adapter = FilesystemProjectAdapter()  # CC-003 violation (violates H-09 composition root)
+        adapter = FilesystemProjectAdapter()  # CC-003 violation (violates H-07 composition root)
         project = Project.create(command.project_id, command.name)
         adapter.save(project)
-        # CC-004 violation (no docstring per H-12)
+        # CC-004 violation (no docstring per H-11)
 ```
 
 **Strategy Execution:**
@@ -396,20 +396,20 @@ class CreateProjectCommandHandler(ICommandHandler):
 **Step 1:** Loaded `JERRY_CONSTITUTION.md`, `architecture-standards.md`, `coding-standards.md`, `quality-enforcement.md`.
 
 **Step 2:** Identified applicable principles:
-- H-08: Application layer MUST NOT import from infrastructure (HARD)
-- H-09: Only bootstrap.py SHALL instantiate infrastructure adapters (HARD)
+- H-07: Application layer MUST NOT import from infrastructure (HARD)
+- H-07: Only bootstrap.py SHALL instantiate infrastructure adapters (HARD)
 - H-11: Type hints REQUIRED on public functions (HARD)
-- H-12: Docstrings REQUIRED on public classes (HARD)
+- H-11: Docstrings REQUIRED on public classes (HARD)
 - M-05: Handler naming convention `{Command}Handler` (MEDIUM)
 
 **Step 3:** Principle evaluation findings:
 
 | ID | Principle | Tier | Severity | Evidence | Affected Dimension |
 |----|-----------|------|----------|----------|--------------------|
-| CC-001-20260215T1430 | H-08: Application layer imports | HARD | Critical | Line 3: imports `infrastructure.adapters` | Methodological Rigor |
+| CC-001-20260215T1430 | H-07: Application layer imports | HARD | Critical | Line 3: imports `infrastructure.adapters` | Methodological Rigor |
 | CC-002-20260215T1430 | H-11: Type hints required | HARD | Critical | Line 6: `handle(self, command)` lacks type annotations | Methodological Rigor |
-| CC-003-20260215T1430 | H-09: Composition root exclusivity | HARD | Critical | Line 8: instantiates `FilesystemProjectAdapter` outside bootstrap | Methodological Rigor |
-| CC-004-20260215T1430 | H-12: Docstrings required | HARD | Critical | Class lacks docstring | Completeness |
+| CC-003-20260215T1430 | H-07: Composition root exclusivity | HARD | Critical | Line 8: instantiates `FilesystemProjectAdapter` outside bootstrap | Methodological Rigor |
+| CC-004-20260215T1430 | H-11: Docstrings required | HARD | Critical | Class lacks docstring | Completeness |
 | CC-005-20260215T1430 | M-05: Handler naming | MEDIUM | Major | COMPLIANT (`CreateProjectCommandHandler`) | N/A |
 
 **Step 4:** Remediation guidance (Critical findings only):
@@ -436,7 +436,7 @@ class CreateProjectCommandHandler(ICommandHandler):
         self._repository.save(project)
 ```
 
-**Result:** 4 Critical violations resolved. Score: 0.60→1.00 (REJECTED→PASS). Now complies with H-08, H-11, H-09, H-12.
+**Result:** 4 Critical violations resolved. Score: 0.60→1.00 (REJECTED→PASS). Now complies with H-07, H-11.
 
 ---
 
@@ -474,7 +474,7 @@ Check in Step 1: AE-001 (constitution→C4), AE-002 (rules/templates→C3), AE-0
 
 ### Cross-References
 
-**Sources:** `quality-enforcement.md` (SSOT H-01–H-24), `JERRY_CONSTITUTION.md` (P-001–P-043), `architecture-standards.md` (H-07–H-10), `coding-standards.md` (H-11, H-12), `testing-standards.md` (H-20, H-21), `markdown-navigation-standards.md` (H-23, H-24)
+**Sources:** `quality-enforcement.md` (SSOT H-01–H-33), `JERRY_CONSTITUTION.md` (P-001–P-043), `architecture-standards.md` (H-07, H-10), `coding-standards.md` (H-11), `testing-standards.md` (H-20), `markdown-navigation-standards.md` (H-23)
 
 **Templates:** s-003-steelman (before), s-002-devils-advocate (after), s-014-llm-as-judge (scoring), s-010-self-refine (H-15)
 
@@ -488,7 +488,7 @@ Use this checklist to validate this S-007 template against TEMPLATE-FORMAT.md v1
 
 - [x] All 8 canonical sections present (Identity, Purpose, Prerequisites, Execution Protocol, Output Format, Scoring Rubric, Examples, Integration)
 - [x] H-23: Navigation table present
-- [x] H-24: Navigation table uses anchor links
+- [x] H-23: Navigation table uses anchor links
 - [x] Metadata blockquote header present
 - [x] File length under 500 lines (currently ~480)
 - [x] Identity: 7 required fields + criticality tier table

--- a/.context/templates/adversarial/s-014-llm-as-judge.md
+++ b/.context/templates/adversarial/s-014-llm-as-judge.md
@@ -89,7 +89,7 @@ S-014 should NOT be applied in these scenarios:
 
 1. **Early-stage brainstorming or ideation** — S-014 evaluates structured deliverables against completion criteria. Use S-003 (Steelman) or S-013 (Inversion) for exploratory work. Redirect to S-003 for idea strengthening before scoring.
 
-2. **Code implementation (non-design)** — S-014 is optimized for documentation, analysis, design, and research deliverables. Use H-20/H-21 (test-first BDD, coverage requirements) for code quality. Redirect to testing-standards.md.
+2. **Code implementation (non-design)** — S-014 is optimized for documentation, analysis, design, and research deliverables. Use H-20 (test-first BDD, coverage requirements) for code quality. Redirect to testing-standards.md.
 
 3. **C1 Routine work where quality scoring is optional** — For reversible single-session work (<3 files), S-010 (Self-Refine) alone may suffice. S-014 is optional at C1 criticality. Use judgment based on user needs.
 
@@ -841,8 +841,8 @@ Dependencies flow inward: Interface → Application → Domain. Infrastructure i
 
 ### Phase 1: Foundation (Week 1)
 - Create directory structure: `src/domain/`, `src/application/`, `src/infrastructure/`, `src/interface/`
-- Implement bootstrap.py composition root (H-09 compliance)
-- Add architecture tests validating layer dependencies (H-07, H-08)
+- Implement bootstrap.py composition root (H-07 compliance)
+- Add architecture tests validating layer dependencies (H-07)
 
 ### Phase 2: Migration (Weeks 2-3)
 - Migrate one domain aggregate (WorkItem) to hexagonal structure as a reference implementation
@@ -856,7 +856,7 @@ Dependencies flow inward: Interface → Application → Domain. Infrastructure i
 ### Success Criteria
 - All domain layer tests run without database or HTTP mocks (target: <1s test suite execution)
 - CLI and web API share identical application layer code (no duplication)
-- Architecture tests pass (no H-07, H-08 violations)
+- Architecture tests pass (no H-07 violations)
 
 ## Traceability
 - **Requirements:** FEAT-042 (CLI support), TECH-DEBT-018 (testability issues)
@@ -980,7 +980,7 @@ Use this checklist to validate this S-014 template against TEMPLATE-FORMAT.md v1
 
 - [x] All 8 canonical sections present in order (Identity, Purpose, Prerequisites, Execution Protocol, Output Format, Scoring Rubric, Examples, Integration)
 - [x] H-23: Navigation table present with Document Sections
-- [x] H-24: Navigation table uses anchor links
+- [x] H-23: Navigation table uses anchor links
 - [x] Metadata blockquote header present
 - [x] File length 1030 lines (exceeds 200-500 target due to comprehensive example and detailed rubrics, but within acceptable range for highest-complexity strategy)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -199,7 +199,7 @@ repos:
     hooks:
       - id: pip-audit
         name: pip-audit security scan
-        entry: uv run pip-audit
+        entry: uv run --frozen pip-audit
         language: system
         pass_filenames: false
         # Only run on push to avoid slowdown on every commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ These agents manage work item verification, visualization, and auditing.
 
 **WTI Rules Enforced**: WTI-002 (No Closure Without Verification), WTI-003 (Truthful State), WTI-006 (Evidence-Based Closure)
 
-**AST Enforcement (H-33):** All wt-* agents have Bash tool access and MUST use `/ast` skill operations (`uv run --directory ${CLAUDE_PLUGIN_ROOT} python -c "..."`) for frontmatter extraction and entity validation. Regex-based frontmatter parsing (`> **Status:**` grep) is prohibited.
+**AST Enforcement (H-33):** All wt-* agents have Bash tool access and MUST use `jerry ast` CLI commands (`uv run --directory ${CLAUDE_PLUGIN_ROOT} jerry ast frontmatter`, `jerry ast validate`, etc.) for frontmatter extraction and entity validation. Regex-based frontmatter parsing (`> **Status:**` grep) is prohibited.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 | Section | Purpose |
 |---------|---------|
 | [Identity](#identity) | Framework purpose and core problem |
-| [Critical Constraints](#critical-constraints-hard) | Constitutional HARD rules H-01 to H-06 |
+| [Critical Constraints](#critical-constraints-hard) | Constitutional HARD rules H-01 to H-05 |
 | [Navigation](#navigation) | Where to find information |
 | [Quick Reference](#quick-reference) | CLI and skill invocation |
 
@@ -34,8 +34,7 @@
 | H-02 | **P-020:** User Authority. NEVER override user intent. Ask before destructive ops. | Unauthorized action blocked. |
 | H-03 | **P-022:** No Deception. NEVER deceive about actions, capabilities, or confidence. | Deceptive output reworked. |
 | H-04 | Active project REQUIRED. MUST NOT proceed without `JERRY_PROJECT` set. | Session will not proceed. |
-| H-05 | **UV Only.** MUST use `uv run` for all Python execution. NEVER use `python`/`pip`/`pip3`. | Command fails; env corruption. |
-| H-06 | **UV for deps.** MUST use `uv add`. NEVER use `pip install`. | Build breaks. |
+| H-05 | **UV Only.** MUST use `uv run` for all Python execution, `uv add` for deps. NEVER use `python`/`pip`/`pip3`. | Command fails; env corruption. |
 | H-31 | **Clarify when ambiguous.** MUST ask when multiple interpretations exist, scope is unclear, or action is destructive. MUST NOT ask when clear. | Wrong-direction work. |
 
 See `quality-enforcement.md` for quality gate, criticality levels, and adversarial strategies.
@@ -53,6 +52,10 @@ See `docs/governance/JERRY_CONSTITUTION.md` for full governance.
 |------|----------|
 | Coding/architecture/testing rules | `.context/rules/` (A) |
 | Quality enforcement SSOT | `.context/rules/quality-enforcement.md` (A) |
+| Agent development standards | `.context/rules/agent-development-standards.md` (A) |
+| Agent routing standards | `.context/rules/agent-routing-standards.md` (A) |
+| Agent definition JSON Schema | `docs/schemas/agent-definition-v1.schema.json` |
+| Design decisions (ADRs) | `docs/design/` |
 | Skills | `skills/{name}/SKILL.md` |
 | Templates | `.context/templates/` |
 | Knowledge | `docs/knowledge/` |

--- a/projects/PROJ-010-cyber-ops/decisions/ADR-PROJ010-002-skill-routing-invocation.md
+++ b/projects/PROJ-010-cyber-ops/decisions/ADR-PROJ010-002-skill-routing-invocation.md
@@ -75,7 +75,7 @@ Phase 1 research across 6 streams and 20 artifacts provides the definitive speci
 
 | Constraint | Source | Impact on Routing |
 |------------|--------|-------------------|
-| H-25 through H-30 | skill-standards | SKILL.md structure, naming, registration requirements |
+| H-25, H-26 | skill-standards | SKILL.md structure, naming, registration requirements |
 | H-22 | mandatory-skill-usage | Proactive skill invocation; /eng-team and /red-team must register trigger keywords |
 | AD-001 | Methodology-First Design | All routing produces methodology guidance, not execution automation |
 | AD-002 | 21-Agent Roster | Routing must address 10 /eng-team + 11 /red-team agents |
@@ -89,7 +89,7 @@ Phase 1 research across 6 streams and 20 artifacts provides the definitive speci
 
 ### 1. SKILL.md Structure
 
-Both /eng-team and /red-team follow Jerry's skill standard (H-25 through H-30). Each SKILL.md file provides the routing entry point for its skill.
+Both /eng-team and /red-team follow Jerry's skill standard (H-25, H-26). Each SKILL.md file provides the routing entry point for its skill.
 
 #### /eng-team SKILL.md Location and Structure
 
@@ -120,9 +120,9 @@ agents:
   - eng-incident
 ```
 
-**Description compliance (H-28):** WHAT: secure engineering methodology guidance across 10 agents. WHEN: system design, implementation, code review, testing, CI/CD, incident response with security context. Triggers listed. Under 1024 characters. No XML.
+**Description compliance (H-26):** WHAT: secure engineering methodology guidance across 10 agents. WHEN: system design, implementation, code review, testing, CI/CD, incident response with security context. Triggers listed. Under 1024 characters. No XML.
 
-**Agent definitions location (H-29):** `skills/eng-team/agents/{agent-name}.md` using full repo-relative paths.
+**Agent definitions location (H-26):** `skills/eng-team/agents/{agent-name}.md` using full repo-relative paths.
 
 #### /red-team SKILL.md Location and Structure
 
@@ -154,7 +154,7 @@ agents:
   - red-social
 ```
 
-#### Registration Requirements (H-30)
+#### Registration Requirements (H-26)
 
 Both skills MUST be registered in:
 - `CLAUDE.md` Quick Reference skills table
@@ -565,7 +565,7 @@ On /red-team skill invocation:
 | Purple team integration through defined cross-skill integration points | Enables the adversarial-collaborative dynamic that drives security improvement | HIGH -- 4 integration points derived from A-004 with elite organization validation |
 | /eng-team workflow traces to established SDLC models (MS SDL, SSDF, SAMM, SLSA) | Every agent activity has standards traceability for audit and compliance | HIGH -- F-001 mapping provides practice-level traceability |
 | Safety alignment compatibility without circumvention | Legitimate security work proceeds without triggering safety filters | HIGH -- methodology-first design validated by D-002 and Convergence 1 |
-| Jerry routing standards compliance (H-22, H-25-H-30) | Both skills integrate seamlessly with existing Jerry infrastructure | HIGH -- architectural requirements are well-defined |
+| Jerry routing standards compliance (H-22, H-25, H-26) | Both skills integrate seamlessly with existing Jerry infrastructure | HIGH -- architectural requirements are well-defined |
 
 ### Negative
 
@@ -627,10 +627,10 @@ Three convergence findings from S-001 directly validate this ADR's design decisi
 | H-22 (Proactive skill invocation) | COMPLIANT | Trigger maps in Section 2 and 6 registered for mandatory-skill-usage.md |
 | H-25 (SKILL.md exactly, case-sensitive) | COMPLIANT | Section 1 specifies `SKILL.md` for both skills |
 | H-26 (Kebab-case folder, matches name) | COMPLIANT | `skills/eng-team/` matches `name: eng-team`; `skills/red-team/` matches `name: red-team` |
-| H-27 (No README.md in skill folder) | COMPLIANT | Neither skill folder contains README.md |
-| H-28 (Description: WHAT+WHEN+triggers, <1024 chars, no XML) | COMPLIANT | Both descriptions specify what, when, and triggers; under 1024 characters; no XML |
-| H-29 (Full repo-relative paths) | COMPLIANT | Agent definitions at `skills/{skill}/agents/{agent}.md` |
-| H-30 (Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md) | COMPLIANT | Section 6 specifies all three registration points |
+| H-25 (No README.md in skill folder) | COMPLIANT | Neither skill folder contains README.md |
+| H-26 (Description: WHAT+WHEN+triggers, <1024 chars, no XML) | COMPLIANT | Both descriptions specify what, when, and triggers; under 1024 characters; no XML |
+| H-26 (Full repo-relative paths) | COMPLIANT | Agent definitions at `skills/{skill}/agents/{agent}.md` |
+| H-26 (Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md) | COMPLIANT | Section 6 specifies all three registration points |
 | H-31 (Clarify when ambiguous) | COMPLIANT | Disambiguation rules default to /eng-team and confirm with user when ambiguous |
 | P-003 (No recursive subagents) | COMPLIANT | Skills invoke agents as workers; no agent-spawns-agent chains |
 | P-020 (User authority) | COMPLIANT | ADR status is PROPOSED; requires user ratification |
@@ -724,7 +724,7 @@ Three convergence findings from S-001 directly validate this ADR's design decisi
 | CLAUDE.md | `CLAUDE.md` | Identity, HARD constraints, skill quick reference |
 | mandatory-skill-usage.md | `.context/rules/mandatory-skill-usage.md` | H-22 trigger map pattern, proactive invocation rules |
 | quality-enforcement.md | `.context/rules/quality-enforcement.md` | Quality gate (>= 0.92), criticality levels, strategy catalog |
-| skill-standards (H-25 to H-30) | `.context/rules/` | SKILL.md naming, folder structure, description, registration |
+| skill-standards (H-25, H-26) | `.context/rules/` | SKILL.md naming, folder structure, description, registration |
 
 ### External Standards Referenced
 

--- a/projects/PROJ-010-cyber-ops/work/EPIC-003-eng-team-build/FEAT-020-eng-skill-routing/FEAT-020-eng-skill-routing.md
+++ b/projects/PROJ-010-cyber-ops/work/EPIC-003-eng-team-build/FEAT-020-eng-skill-routing/FEAT-020-eng-skill-routing.md
@@ -28,7 +28,7 @@
 
 ## Summary
 
-Create the /eng-team SKILL.md file with keyword trigger map, routing table, agent registry, and workflow definitions. Must comply with H-25 through H-30 (skill standards). This is the foundational skill definition that all other EPIC-003 features depend on for agent routing and workflow orchestration.
+Create the /eng-team SKILL.md file with keyword trigger map, routing table, agent registry, and workflow definitions. Must comply with H-25 and H-26 (skill standards). This is the foundational skill definition that all other EPIC-003 features depend on for agent routing and workflow orchestration.
 
 ---
 
@@ -36,9 +36,9 @@ Create the /eng-team SKILL.md file with keyword trigger map, routing table, agen
 
 - [ ] SKILL.md created per skill-standards (H-25: exactly SKILL.md, case-sensitive)
 - [ ] Folder uses kebab-case matching name field (H-26)
-- [ ] No README.md inside skill folder (H-27)
-- [ ] Description: WHAT + WHEN + triggers, <1024 chars, no XML (H-28)
-- [ ] Full repo-relative paths (H-29)
+- [ ] No README.md inside skill folder (H-25)
+- [ ] Description: WHAT + WHEN + triggers, <1024 chars, no XML (H-26)
+- [ ] Full repo-relative paths (H-26)
 - [ ] Keyword trigger map for /eng-team invocation
 - [ ] Agent routing table (8 agents mapped to contexts)
 - [ ] Workflow definitions (sequential, parallel, review gates)

--- a/projects/PROJ-010-cyber-ops/work/EPIC-006-documentation-guides/FEAT-054-framework-registration/framework-registration-report.md
+++ b/projects/PROJ-010-cyber-ops/work/EPIC-006-documentation-guides/FEAT-054-framework-registration/framework-registration-report.md
@@ -4,19 +4,19 @@
 > **Project:** PROJ-010 Cyber Ops | EPIC-006 Documentation & Guides
 > **Date:** 2026-02-22
 > **Status:** Complete
-> **Governing Rule:** H-30 (Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md if proactive)
-> **SSOT References:** `.context/rules/skill-standards.md` (H-25 through H-30), `.context/rules/quality-enforcement.md`, `AGENTS.md`, `CLAUDE.md`, `.context/rules/mandatory-skill-usage.md`
+> **Governing Rule:** H-26 (Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md if proactive)
+> **SSOT References:** `.context/rules/skill-standards.md` (H-25, H-26), `.context/rules/quality-enforcement.md`, `AGENTS.md`, `CLAUDE.md`, `.context/rules/mandatory-skill-usage.md`
 
 ## Document Sections
 
 | Section | Purpose |
 |---------|---------|
-| [Registration Requirements](#registration-requirements) | H-30 checklist and scope of changes |
+| [Registration Requirements](#registration-requirements) | H-26 checklist and scope of changes |
 | [AGENTS.md Registration Block](#agentsmd-registration-block) | Ready-to-insert agent registry content for 21 agents |
 | [CLAUDE.md Registration Block](#claudemd-registration-block) | Ready-to-insert Quick Reference skill table rows |
 | [mandatory-skill-usage.md Registration Block](#mandatory-skill-usagemd-registration-block) | Ready-to-insert trigger map and H-22 rule entries |
 | [MCP Tool Access Registration Block](#mcp-tool-access-registration-block) | Ready-to-insert Context7 agent matrix entries |
-| [Verification Checklist](#verification-checklist) | H-25 through H-30 compliance verification for both skills |
+| [Verification Checklist](#verification-checklist) | H-25 and H-26 compliance verification for both skills |
 
 ---
 
@@ -31,15 +31,15 @@ PROJ-010 Cyber Ops has produced two skills containing 21 agents total:
 | `/eng-team` | 10 | eng-architect, eng-lead, eng-backend, eng-frontend, eng-infra, eng-devsecops, eng-qa, eng-security, eng-reviewer, eng-incident | `skills/eng-team/SKILL.md` |
 | `/red-team` | 11 | red-lead, red-recon, red-vuln, red-exploit, red-privesc, red-lateral, red-persist, red-exfil, red-reporter, red-infra, red-social | `skills/red-team/SKILL.md` |
 
-### H-30 Registration Targets
+### H-26 Registration Targets
 
-Per H-30, new skills MUST be registered in three locations:
+Per H-26, new skills MUST be registered in three locations:
 
 | Target File | Registration Type | Required |
 |-------------|-------------------|----------|
-| `AGENTS.md` | Agent registry entries for all 21 agents, navigation table update, agent summary update, MCP tool access update | Yes (H-30) |
-| `CLAUDE.md` | Quick Reference Skills table -- 2 new rows | Yes (H-30) |
-| `.context/rules/mandatory-skill-usage.md` | Trigger Map entries + H-22 rule update for proactive invocation | Yes (H-30, both skills require proactive invocation per H-22) |
+| `AGENTS.md` | Agent registry entries for all 21 agents, navigation table update, agent summary update, MCP tool access update | Yes (H-26) |
+| `CLAUDE.md` | Quick Reference Skills table -- 2 new rows | Yes (H-26) |
+| `.context/rules/mandatory-skill-usage.md` | Trigger Map entries + H-22 rule update for proactive invocation | Yes (H-26, both skills require proactive invocation per H-22) |
 
 ### Auto-Escalation Note
 
@@ -389,14 +389,14 @@ Add to the `**Not included (by design):**` section:
 | eng-team | `skills/eng-team/` | Yes | Yes (`name: eng-team`) | PASS |
 | red-team | `skills/red-team/` | Yes | Yes (`name: red-team`) | PASS |
 
-### H-27: No README.md in Skill Folder
+### H-25: No README.md in Skill Folder
 
 | Skill | README.md present | Status |
 |-------|-------------------|--------|
 | eng-team | No | PASS |
 | red-team | No | PASS |
 
-### H-28: Description Field Compliance
+### H-26: Description Field Compliance
 
 | Requirement | eng-team | red-team |
 |-------------|----------|----------|
@@ -407,14 +407,14 @@ Add to the `**Not included (by design):**` section:
 | No XML tags | Yes | Yes |
 | Status | PASS | PASS |
 
-### H-29: Full Repo-Relative Paths
+### H-26: Full Repo-Relative Paths
 
 | Skill | All file references repo-relative | Status |
 |-------|-----------------------------------|--------|
 | eng-team | Yes (e.g., `skills/eng-team/agents/eng-architect.md`, `skills/eng-team/output/{engagement-id}/`) | PASS |
 | red-team | Yes (e.g., `skills/red-team/agents/red-lead.md`, `skills/red-team/output/{engagement-id}/`) | PASS |
 
-### H-30: Registration Completeness
+### H-26: Registration Completeness
 
 | Registration Target | eng-team | red-team | Status |
 |---------------------|----------|----------|--------|
@@ -472,7 +472,7 @@ All model tiers verified against agent frontmatter `model:` field:
 
 ## Summary
 
-This report provides complete, ready-to-insert registration content for all three H-30 registration targets plus the MCP tool standards file. All 21 agents across the `/eng-team` and `/red-team` skills have been verified against H-25 through H-30 compliance requirements.
+This report provides complete, ready-to-insert registration content for all three H-26 registration targets plus the MCP tool standards file. All 21 agents across the `/eng-team` and `/red-team` skills have been verified against H-25 and H-26 compliance requirements.
 
 **Registration blocks produced:**
 
@@ -488,4 +488,4 @@ This report provides complete, ready-to-insert registration content for all thre
 *Report produced: 2026-02-22*
 *FEAT-054: Framework Registration*
 *PROJ-010: Cyber Ops -- EPIC-006 Documentation & Guides*
-*Governing rule: H-30 (skill-standards.md)*
+*Governing rule: H-26 (skill-standards.md)*

--- a/scripts/check_hard_rule_ceiling.py
+++ b/scripts/check_hard_rule_ceiling.py
@@ -31,7 +31,7 @@ from pathlib import Path
 # Even if quality-enforcement.md's ceiling value is tampered with, the
 # absolute maximum provides an independent hard stop. The SSOT ceiling
 # MUST be <= this value. Changes to this constant require C4 review.
-_ABSOLUTE_MAX_CEILING = 35
+_ABSOLUTE_MAX_CEILING = 28
 
 
 def find_quality_enforcement() -> Path:

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -402,8 +402,8 @@ All architecture work adheres to the **Jerry Constitution v1.0**:
 | P-004: Explicit Provenance | Reasoning and sources documented | ADRs include context, alternatives considered, consequences |
 | P-011: Evidence-Based | Recommendations tied to evidence | Architecture reviews cite specific violations or compliance |
 | H-07: Domain Layer Isolation | Domain MUST NOT import external layers | `analyze` command verifies import boundaries |
-| H-08: Application Layer Isolation | Application MUST NOT import infrastructure/interface | `analyze` command verifies layer dependencies |
-| H-09: Composition Root Exclusivity | Only bootstrap.py instantiates infrastructure | Architecture test enforces this rule |
+| H-07: Application Layer Isolation | Application MUST NOT import infrastructure/interface | `analyze` command verifies layer dependencies |
+| H-07: Composition Root Exclusivity | Only bootstrap.py instantiates infrastructure | Architecture test enforces this rule |
 | H-10: One Class Per File | Each file contains exactly ONE public class | AST check enforces this rule |
 
 ---

--- a/skills/eng-team/templates/engagement-playbook.md
+++ b/skills/eng-team/templates/engagement-playbook.md
@@ -102,7 +102,7 @@ This playbook codifies the /eng-team's 8-step sequential phase-gate workflow int
 | **Agent** | eng-qa |
 | **Input** | Implementation artifacts, scan results from Step 4 |
 | **Output** | Test results, coverage reports, fuzzing findings |
-| **Quality Gate** | >= 90% line coverage (H-21), all critical test cases pass |
+| **Quality Gate** | >= 90% line coverage (H-20), all critical test cases pass |
 | **Templates** | [Security Test Plan](security-test-plan.md) (testing section) |
 
 **Actions:**

--- a/skills/eng-team/templates/security-test-plan.md
+++ b/skills/eng-team/templates/security-test-plan.md
@@ -132,7 +132,7 @@ This template guides security test planning per SSDF PW.8 (Test executable code 
 |-----------|---------|----------|-------------|
 | `sast_tools` | auto-detect | semgrep, codeql, bandit | SAST tool selection |
 | `dast_tools` | OWASP ZAP | burp, zap, nuclei | DAST tool selection |
-| `minimum_code_coverage` | 90% | 0-100% | Line coverage threshold (H-21) |
+| `minimum_code_coverage` | 90% | 0-100% | Line coverage threshold (H-20) |
 | `fuzzing_duration_hours` | 4 | 1-48 | Minimum fuzzing campaign duration |
 | `asvs_verification_level` | Level 2 | Level 1-3 | ASVS depth |
 | `scan_frequency` | per-commit | nightly, per-commit, manual | Automated scan schedule |

--- a/skills/shared/README.md
+++ b/skills/shared/README.md
@@ -243,7 +243,7 @@ Common tasks for skill authors and which shared resource to use:
 1. **Create skill directory:** `skills/{skill-name}/`
 2. **Create SKILL.md:** Copy structure from `skills/problem-solving/SKILL.md` or `skills/orchestration/SKILL.md`
    - Include triple-lens audience table
-   - Add navigation table (H-23/H-24)
+   - Add navigation table (H-23)
    - Document purpose, capabilities, when to use
    - List available agents/commands
    - Add constitutional compliance section
@@ -274,7 +274,7 @@ Shared resources adhere to the **Jerry Constitution v1.0**:
 | P-004: Explicit Provenance | Reasoning documented | Agent template includes provenance checklist |
 | P-022: No Deception | Transparent limitations | Playbook template includes anti-pattern catalog |
 | H-23: Navigation Tables | Required for 30+ line docs | All shared docs include navigation tables |
-| H-24: Anchor Links | Required in nav tables | All section names use correct anchor syntax |
+| H-23: Anchor Links | Required in nav tables | All section names use correct anchor syntax |
 
 **Self-Critique Checklist:**
 - [ ] P-002: Does agent template enforce file output?
@@ -282,7 +282,7 @@ Shared resources adhere to the **Jerry Constitution v1.0**:
 - [ ] P-004: Do templates include provenance/reasoning sections?
 - [ ] P-022: Are limitations and anti-patterns documented?
 - [ ] H-23: Do all docs over 30 lines have navigation tables?
-- [ ] H-24: Are anchor links correct in navigation tables?
+- [ ] H-23: Are anchor links correct in navigation tables?
 
 ---
 

--- a/tests/architecture/test_ast_enforcement.py
+++ b/tests/architecture/test_ast_enforcement.py
@@ -21,7 +21,7 @@ artifacts that constitute system behavior for LLM agents.
 
 References:
     - H-33: AST-based parsing REQUIRED for worktracker entity ops
-    - H-30: Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md
+    - H-26: Register in CLAUDE.md + AGENTS.md + mandatory-skill-usage.md
     - quality-enforcement.md: HARD Rule Index, L2-REINJECT markers
     - AE-002: .context/rules/ changes auto-escalate to C3
 """
@@ -177,10 +177,10 @@ class TestH31RuleRegistration:
     def test_hard_rule_index_when_checked_then_header_references_h31(
         self, quality_enforcement_content: str
     ) -> None:
-        """Section header must reference H-33 range (H-01 through H-33)."""
+        """Section header must reference H-33+ range (H-01 through H-36 post-EN-002)."""
         # Arrange/Act/Assert
-        assert "H-01 through H-33" in quality_enforcement_content, (
-            "quality-enforcement.md section header does not reference 'H-01 through H-33'"
+        assert "H-01 through H-36" in quality_enforcement_content, (
+            "quality-enforcement.md section header does not reference 'H-01 through H-36'"
         )
 
     def test_l2_reinject_when_checked_then_rank9_exists(
@@ -210,15 +210,17 @@ class TestH31RuleRegistration:
     def test_l2_reinject_when_checked_then_rank9_references_ast_functions(
         self, quality_enforcement_content: str
     ) -> None:
-        """L2-REINJECT rank=10 must reference both AST functions within the same directive."""
-        # Arrange — match within a single HTML comment to ensure both functions
-        # are in the same L2-REINJECT directive, not scattered across separate markers
-        pattern = r"<!--[^>]*rank=10[^>]*query_frontmatter\(\)[^>]*validate_file\(\)[^>]*-->"
+        """L2-REINJECT rank=10 must reference AST CLI commands within the same directive."""
+        # Arrange — match within a single HTML comment to ensure both CLI commands
+        # are in the same L2-REINJECT directive, not scattered across separate markers.
+        # EN-002 updated from Python function names to CLI commands:
+        # "jerry ast frontmatter" and "jerry ast validate"
+        pattern = r"<!--[^>]*rank=10[^>]*jerry ast frontmatter[^>]*jerry ast validate[^>]*-->"
 
         # Act/Assert
         assert re.search(pattern, quality_enforcement_content, re.DOTALL), (
-            "L2-REINJECT rank=10 does not reference query_frontmatter() and validate_file() "
-            "within the same HTML comment directive"
+            "L2-REINJECT rank=10 does not reference 'jerry ast frontmatter' and "
+            "'jerry ast validate' within the same HTML comment directive"
         )
 
     def test_l2_reinject_when_checked_then_rank9_content_is_substantive(
@@ -434,7 +436,7 @@ class TestWorktrackerAgentPluginRoot:
 
 
 class TestAstSkillRegistration:
-    """/ast skill must be registered per H-30 and source artifacts must exist."""
+    """/ast skill must be registered per H-26 and source artifacts must exist."""
 
     def test_claude_md_when_checked_then_ast_in_quick_reference(
         self, claude_md_content: str

--- a/tests/architecture/test_context_monitoring_boundaries.py
+++ b/tests/architecture/test_context_monitoring_boundaries.py
@@ -11,14 +11,14 @@ Enforces hexagonal layer boundaries:
     - Composition root is the only place that wires adapters to ports
 
 Acceptance Criteria Coverage:
-    - AC-FEAT001-009: Hexagonal architecture boundaries (H-07, H-08)
-    - AC-FEAT001-010: Port/adapter structural compliance (H-09)
+    - AC-FEAT001-009: Hexagonal architecture boundaries (H-07)
+    - AC-FEAT001-010: Port/adapter structural compliance (H-07)
     - AC-FEAT001-011: One class per file (H-10)
 
 References:
     - H-07: Domain layer: no external imports
-    - H-08: Application layer: no infra/interface imports
-    - H-09: Composition root exclusivity
+    - H-07: Application layer: no infra/interface imports
+    - H-07: Composition root exclusivity
     - FEAT-001: Context Detection
     - PROJ-004: Context Resilience
 """
@@ -210,14 +210,14 @@ class TestDomainLayerBoundaries:
 
 
 # =============================================================================
-# Application Layer Boundary (H-08)
+# Application Layer Boundary (H-07)
 # =============================================================================
 
 
 class TestApplicationLayerBoundaries:
     """Architecture: Application layer has no infrastructure or interface imports.
 
-    References: H-08 (architecture-standards), FEAT-001 (EN-003), PROJ-004
+    References: H-07 (architecture-standards), FEAT-001 (EN-003), PROJ-004
     """
 
     def test_application_has_no_infrastructure_imports(self) -> None:
@@ -259,7 +259,7 @@ class TestApplicationLayerBoundaries:
 class TestInfrastructureLayerBoundaries:
     """Architecture: Infrastructure may import domain and application ports only.
 
-    References: H-07/H-08 (architecture-standards), PROJ-004
+    References: H-07 (architecture-standards), PROJ-004
     """
 
     def test_infrastructure_has_no_interface_imports(self) -> None:
@@ -285,7 +285,7 @@ class TestInfrastructureLayerBoundaries:
 class TestPortAdapterStructure:
     """Architecture: Ports are protocols, adapters implement them.
 
-    References: H-09 (architecture-standards), FEAT-001 (EN-003), PROJ-004
+    References: H-07 (architecture-standards), FEAT-001 (EN-003), PROJ-004
     """
 
     def test_ports_directory_exists(self) -> None:

--- a/tests/e2e/test_context_monitoring_e2e.py
+++ b/tests/e2e/test_context_monitoring_e2e.py
@@ -166,8 +166,8 @@ class TestPromptSubmitHookE2E:
         assert result.returncode == 0
         data = json.loads(result.stdout.strip())
         additional = data.get("additionalContext", "")
-        # Quality reinforcement injects L2-REINJECT constitutional principles
-        assert "Constitutional" in additional
+        # Quality reinforcement injects L2-REINJECT content (EN-002 format)
+        assert "H-33" in additional or "AE-006" in additional
 
 
 # =============================================================================

--- a/tests/e2e/test_quality_framework_e2e.py
+++ b/tests/e2e/test_quality_framework_e2e.py
@@ -233,8 +233,8 @@ class TestCrossLayerInteractions:
         # Check that the enforcement architecture section exists with token data
         assert "Enforcement Architecture" in content
         assert "Tokens" in content
-        # L2 should have ~600 per prompt
-        assert "600" in content
+        # L2 should have ~850 per prompt (EN-002 updated from ~600)
+        assert "850" in content
 
     def test_ssot_references_when_checked_then_adr_sources_present(self) -> None:
         """SSOT references its source ADRs for traceability."""

--- a/tests/integration/test_userpromptsubmit_hook_integration.py
+++ b/tests/integration/test_userpromptsubmit_hook_integration.py
@@ -84,8 +84,8 @@ class TestUserPromptSubmitHookIntegration:
         assert exit_code == 0
         assert stdout_json is not None
         additional_context = stdout_json.get("additionalContext", "")
-        # Should contain constitutional principle references
-        assert "P-003" in additional_context or "HARD" in additional_context, (
+        # Should contain L2-REINJECT quality reinforcement content (EN-002 format)
+        assert "H-33" in additional_context or "AE-006" in additional_context, (
             f"Expected quality reinforcement. Got: {additional_context[:200]}..."
         )
 

--- a/tests/system/test_context_monitoring_system.py
+++ b/tests/system/test_context_monitoring_system.py
@@ -26,7 +26,7 @@ Acceptance Criteria Coverage:
 References:
     - FEAT-001: Context Detection (EN-003, EN-004)
     - PROJ-004: Context Resilience
-    - H-09: Composition root exclusivity (note: system tests wire manually
+    - H-07: Composition root exclusivity (note: system tests wire manually
       because the production bootstrap requires a full project environment;
       composition root testing is covered by E2E tests via the actual CLI)
 """

--- a/tests/unit/enforcement/test_hard_rule_ceiling.py
+++ b/tests/unit/enforcement/test_hard_rule_ceiling.py
@@ -113,14 +113,14 @@ class TestReadCeiling:
         assert result == 25
 
     def test_ceiling_when_different_value_then_returns_it(self) -> None:
-        # M-08: Value must be <= _ABSOLUTE_MAX_CEILING (35)
-        content = SAMPLE_QE_CONTENT.replace("<= 25", "<= 35")
+        # M-08: Value must be <= _ABSOLUTE_MAX_CEILING (28)
+        content = SAMPLE_QE_CONTENT.replace("<= 25", "<= 28")
         result = read_ceiling(content)
-        assert result == 35
+        assert result == 28
 
     def test_ceiling_when_exceeds_absolute_max_then_exits(self) -> None:
         # M-08: Independent hard stop prevents self-referential bypass
-        content = SAMPLE_QE_CONTENT.replace("<= 25", "<= 40")
+        content = SAMPLE_QE_CONTENT.replace("<= 25", "<= 30")
         with pytest.raises(SystemExit):
             read_ceiling(content)
 

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "jerry"
-version = "0.11.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Summary

- Restores EN-002 governance consolidation changes that were regressed by PR #52's bad merge
- Reconciles EN-002 changes with PROJ-010 additions (eng-team, red-team) so both coexist
- Updates all retired H-rule ID references across 17 files
- Lowers `_ABSOLUTE_MAX_CEILING` to 28 to match consolidated state (25 rules, ceiling 25)

### Governance file reconciliation

| File | What was restored | PROJ-010 content preserved |
|------|-------------------|---------------------------|
| `quality-enforcement.md` | v1.6.0: rule consolidation (33 to 25), Two-Tier Model, Ceiling Derivation, Retired Rule IDs, H-34/H-36 | N/A (no PROJ-010 changes) |
| `mandatory-skill-usage.md` | 5-column trigger map with negative keywords, priority, compound triggers | /eng-team + /red-team rows, disambiguation note |
| `skill-standards.md` | v1.2.0 consolidated H-25/H-26 compound rules | N/A |
| `project-workflow.md` | PM-M-001 Workflow Methodology section | N/A |
| `CLAUDE.md` | EN-002 nav entries, consolidated H-05 | /eng-team + /red-team skill entries |
| `AGENTS.md` | H-33 `jerry ast` CLI reference | All PROJ-010 agent sections |
| `.pre-commit-config.yaml` | `--frozen` flag on pip-audit | N/A |

### Rule renumbering (17 files)

Updated all references to retired H-rule IDs per EN-002 consolidation:
H-06 to H-05, H-08/H-09 to H-07, H-12 to H-11, H-21 to H-20, H-24 to H-23, H-27 to H-25, H-28/H-29/H-30 to H-26

## Test plan

- [x] `uv run python scripts/check_hard_rule_ceiling.py` shows: PASS, count=25, ceiling=25
- [x] Trigger map has 5 columns and 10 data rows
- [x] All 4700+ tests pass
- [x] All pre-commit hooks pass
- [x] CI green

Generated with [Claude Code](https://claude.com/claude-code)