### PR TITLE
fix(theme): add code syntax highlighting to saucer-boy-dark

### DIFF
--- a/docs/stylesheets/saucer-boy.css
+++ b/docs/stylesheets/saucer-boy.css
@@ -102,6 +102,22 @@
   --md-shadow-z2: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.3), 0 0 0.05rem rgba(0, 0, 0, 0.15);
   --md-shadow-z3: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.4), 0 0 0.05rem rgba(0, 0, 0, 0.15);
 
+  /* Code syntax highlighting — matches Material slate scheme */
+  --md-code-hl-color:           #2977ff;
+  --md-code-hl-color--light:    rgba(41, 119, 255, 0.1);
+  --md-code-hl-number-color:    #e6695b;
+  --md-code-hl-special-color:   #f06090;
+  --md-code-hl-function-color:  #c973d9;
+  --md-code-hl-constant-color:  #9383e2;
+  --md-code-hl-keyword-color:   #6791e0;
+  --md-code-hl-string-color:    #2fb170;
+  --md-code-hl-name-color:      var(--md-code-fg-color);
+  --md-code-hl-operator-color:  var(--md-default-fg-color--light);
+  --md-code-hl-punctuation-color: var(--md-default-fg-color--light);
+  --md-code-hl-comment-color:   var(--md-default-fg-color--light);
+  --md-code-hl-generic-color:   var(--md-default-fg-color--light);
+  --md-code-hl-variable-color:  var(--md-default-fg-color--light);
+
   /* Footer */
   --md-footer-bg-color:         #0D0818;
   --md-footer-bg-color--dark:   #060410;


### PR DESCRIPTION
## Summary

- Adds 14 missing --md-code-hl-* CSS variables to the saucer-boy-dark scheme
- Without these, code syntax highlighting (comments, keywords, strings, etc.) falls back to light-mode colors — black text on dark purple background
- Values match Material slate scheme for consistent dark mode code rendering

## Root Cause

The custom saucer-boy-dark scheme does not match Material's [data-md-color-scheme=slate] selector, so none of the slate-specific code highlight variables were applied. The default (light mode) values use dark colors designed for white backgrounds.

## Test plan

- [ ] Verify code blocks render with colored syntax highlighting in dark mode
- [ ] Verify comments appear in light gray (rgba(255,255,255,0.54)) not black
- [ ] Verify keywords, strings, functions show distinct colors

Generated with [Claude Code](https://claude.com/claude-code)