### PR TITLE
docs: restore archived research and ADRs from orphan branch

### DIFF
--- a/docs/archive/projects-archive/PLAN.md
+++ b/docs/archive/projects-archive/PLAN.md
@@ -1,0 +1,530 @@
+# Jerry Work Tracker v3.0 - Comprehensive Implementation Plan
+
+> **Status:** APPROVED - READY FOR IMPLEMENTATION
+> **Created:** 2026-01-07
+> **Last Updated:** 2026-01-07
+> **Author:** Claude (Distinguished Systems Engineer persona)
+> **Approval:** User approved 2026-01-07
+
+---
+
+## Executive Summary
+
+This plan implements the Jerry Work Tracker skill with:
+- **Graph-Ready Data Model** with Vertex/Edge abstractions (Gremlin-compatible)
+- **Hexagonal Architecture** (Ports & Adapters)
+- **Domain-Driven Design** with three Aggregate Roots
+- **Event Sourcing** with CloudEvents 1.0
+- **CQRS** (Command Query Responsibility Segregation)
+- **Self-Healing Aspirations** (MAPE-K patterns)
+- **Three-Tier Enforcement** (Soft → Medium → Hard)
+
+### Key Design Decisions
+
+| Decision | Choice | Evidence |
+|----------|--------|----------|
+| **Data Model** | Property Graph (Vertex/Edge) | Gremlin compatibility; GRAPH_DATA_MODEL_ANALYSIS.md |
+| **Primary AR** | Task | Vernon's small aggregates; ECW performance issues |
+| **Secondary ARs** | Phase, Plan | Eventual consistency; ID references only |
+| **Event Schema** | CloudEvents 1.0 | User hard requirement; CNCF standard |
+| **Identity Objects** | Strongly Typed (VertexId subclasses) | User requirement; graph compatibility |
+| **Persistence** | File-based → SQLite → Graph DB | Phased migration path |
+
+---
+
+## 1. Problem Statement (5W1H Analysis)
+
+### WHO is affected?
+- Claude Code instances tracking multi-phase work
+- Users managing complex projects across sessions
+- Future graph database migrations
+
+### WHAT problem are we solving?
+- Context rot degrades LLM performance in long sessions
+- Need persistent work tracking that survives context compaction
+- ECW had Plan AR = slow, Phase AR = still slow
+- Need graph-ready model for future extensibility
+
+### WHERE does the problem manifest?
+- Claude Code sessions with >256k token context
+- Large work trackers with 50+ tasks
+- Complex dependency relationships between tasks
+
+### WHEN does it occur?
+- During multi-hour coding sessions
+- When projects grow beyond initial scope
+- When querying task dependencies or progress
+
+### WHY does it matter?
+- Losing work state disrupts productivity
+- Graph queries enable powerful analytics
+- Future-proofing for graph database migration
+
+### HOW will we solve it?
+- Graph-ready data model (Vertex/Edge abstractions)
+- Task-level Aggregate Root for minimal contention
+- CloudEvents for auditable event sourcing
+- Strongly typed IDs as VertexId subclasses
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 Graph-Ready Data Model
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        PROPERTY GRAPH MODEL                                  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│    VERTICES (Nodes)                    EDGES (Relationships)                 │
+│    ─────────────────                   ──────────────────────                │
+│    • Plan (AR #3)                      • CONTAINS (parent→child)            │
+│    • Phase (AR #2)                     • BELONGS_TO (child→parent)          │
+│    • Task (AR #1)                      • DEPENDS_ON (task→task)             │
+│    • Subtask (Entity)                  • EMITTED (aggregate→event)          │
+│    • Actor (Reference)                 • PERFORMED_BY (event→actor)         │
+│    • Event (CloudEvent)                • REFERENCES (task→evidence)         │
+│                                                                              │
+│    Base Classes:                       Common Properties:                    │
+│    • Vertex (id, label, properties)    • sequence (ordering)                │
+│    • Edge (id, label, outV, inV)       • created_at (audit)                 │
+│    • VertexId (strongly typed)         • dependency_type (semantic)         │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Graph Schema
+
+```
+                              ┌─────────────┐
+                              │    ACTOR    │
+                              │  (Vertex)   │
+                              └──────┬──────┘
+                                     │
+                         PERFORMED_BY│
+                                     │
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│   ┌────────────┐   CONTAINS    ┌────────────┐   CONTAINS   ┌──────────┐     │
+│   │    PLAN    │──────────────►│   PHASE    │─────────────►│   TASK   │     │
+│   │  (AR #3)   │               │  (AR #2)   │  (ID ref)    │ (AR #1)  │     │
+│   │  Vertex    │               │  Vertex    │              │  Vertex  │     │
+│   └─────┬──────┘               └─────┬──────┘              └────┬─────┘     │
+│         │                            │                          │           │
+│         │ EMITTED                    │ EMITTED                  │ CONTAINS  │
+│         ▼                            ▼                          ▼           │
+│   ┌────────────┐               ┌────────────┐            ┌──────────┐       │
+│   │   EVENT    │               │   EVENT    │            │ SUBTASK  │       │
+│   │  Vertex    │               │  Vertex    │            │  Vertex  │       │
+│   │(CloudEvent)│               │(CloudEvent)│            │ (Entity) │       │
+│   └────────────┘               └────────────┘            └──────────┘       │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 Hexagonal Architecture with Graph Abstractions
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                         INTERFACE LAYER (Primary Adapters)                   │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                          │
+│  │  CLI (wt)   │  │ Skill REPL  │  │ Sub-agents  │                          │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘                          │
+└─────────┼────────────────┼────────────────┼──────────────────────────────────┘
+          │         PRIMARY PORTS           │
+┌─────────┼────────────────┼────────────────┼──────────────────────────────────┐
+│         │   APPLICATION LAYER (CQRS)      │                                  │
+│  ┌──────┴─────────────────────────────────┴──────┐                          │
+│  │ Commands              │ Queries               │                          │
+│  │ • CreateTask          │ • GetTask             │                          │
+│  │ • CompleteTask        │ • GetProgress         │                          │
+│  │ • AddSubtask          │ • TraversePath        │                          │
+│  └───────────────────────┴───────────────────────┘                          │
+│                          │                                                   │
+│                    Dispatcher + Middleware                                   │
+└──────────────────────────┼───────────────────────────────────────────────────┘
+                           │
+┌──────────────────────────┼───────────────────────────────────────────────────┐
+│                          │  DOMAIN LAYER (Zero Dependencies)                 │
+│  ┌───────────────────────┼───────────────────────────────────┐              │
+│  │ Graph Primitives      │       Aggregates                  │              │
+│  │ • Vertex (base)       │       • Task (AR, Vertex)         │              │
+│  │ • Edge (base)         │       • Phase (AR, Vertex)        │              │
+│  │ • VertexId (base)     │       • Plan (AR, Vertex)         │              │
+│  │                       │                                   │              │
+│  │ Value Objects         │       Domain Events               │              │
+│  │ • TaskId (VertexId)   │       • CloudEventVertex          │              │
+│  │ • PhaseId (VertexId)  │       • TaskCreatedEvent          │              │
+│  │ • PlanId (VertexId)   │       • TaskCompletedEvent        │              │
+│  │ • EdgeLabels          │                                   │              │
+│  └───────────────────────┴───────────────────────────────────┘              │
+│                          │                                                   │
+│                   SECONDARY PORTS                                            │
+│            ┌─────────────┴─────────────┐                                    │
+│            │ IGraphRepository<T>       │                                    │
+│            │ IEventStore               │                                    │
+│            │ IEventBus                 │                                    │
+│            └─────────────┬─────────────┘                                    │
+└──────────────────────────┼───────────────────────────────────────────────────┘
+                           │
+┌──────────────────────────┼───────────────────────────────────────────────────┐
+│                          │  INFRASTRUCTURE LAYER (Adapters)                  │
+│  ┌─────────────┐  ┌──────┴──────┐  ┌─────────────┐  ┌─────────────┐         │
+│  │ FileGraph   │  │  SQLite     │  │  Graph DB   │  │ InMemory    │         │
+│  │ Repository  │  │ Repository  │  │  Adapter    │  │ EventBus    │         │
+│  │ (Phase 1)   │  │ (Phase 2)   │  │ (Phase 3)   │  │             │         │
+│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘         │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Strongly Typed Identity Objects (Graph-Ready)
+
+```python
+# Inheritance hierarchy:
+VertexId (base, graph primitive)
+├── PlanId      "PLAN-{uuid8}"
+├── PhaseId     "PHASE-{uuid8}"
+├── TaskId      "TASK-{uuid8}"
+├── SubtaskId   "TASK-xxx.{sequence}"
+├── ActorId     "ACTOR-{type}-{id}"
+└── EventId     "EVT-{uuid}"
+
+EdgeId (base, graph primitive)
+└── Generated: "{outV}--{label}-->{inV}"
+```
+
+---
+
+## 4. CloudEvents Domain Events
+
+### 4.1 Event Type Hierarchy
+
+| Event Type | Aggregate | Trigger |
+|------------|-----------|---------|
+| `com.jerry.task.created.v1` | Task | Task.create() |
+| `com.jerry.task.started.v1` | Task | Task.start() |
+| `com.jerry.task.completed.v1` | Task | Task.complete() |
+| `com.jerry.task.blocked.v1` | Task | Task.block() |
+| `com.jerry.subtask.added.v1` | Task | Task.add_subtask() |
+| `com.jerry.subtask.checked.v1` | Task | Subtask.check() |
+| `com.jerry.phase.created.v1` | Phase | Phase.create() |
+| `com.jerry.phase.task_added.v1` | Phase | Phase.add_task_ref() |
+| `com.jerry.plan.created.v1` | Plan | Plan.create() |
+
+### 4.2 CloudEvent as Graph Vertex
+
+```json
+{
+  "specversion": "1.0",
+  "type": "com.jerry.task.completed.v1",
+  "source": "/jerry/tasks/TASK-ABC123",
+  "id": "EVT-a1b2c3d4",
+  "time": "2026-01-07T14:30:00Z",
+  "subject": "TASK-ABC123",
+  "datacontenttype": "application/json",
+  "data": {
+    "task_id": "TASK-ABC123",
+    "phase_id": "PHASE-001",
+    "completed_by": {"type": "CLAUDE", "id": "main"},
+    "subtasks_completed": 5
+  }
+}
+```
+
+---
+
+## 5. Eventual Consistency Event Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    TASK COMPLETION EVENT FLOW                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  1. User: "mark task 5.3 complete"                                          │
+│     │                                                                        │
+│     ▼                                                                        │
+│  2. Load Task vertex (TASK-ABC123)  ← Fast: single vertex only              │
+│     │                                                                        │
+│     ▼                                                                        │
+│  3. Task.complete(actor)                                                    │
+│     ├── Validate: all subtasks checked? ✓                                   │
+│     ├── Validate: evidence attached? ✓                                      │
+│     └── Create: TaskCompletedEvent vertex                                   │
+│     │                                                                        │
+│     ▼                                                                        │
+│  4. Persist to Graph Store:                                                 │
+│     ├── Update Task vertex (status)                                         │
+│     └── Create EMITTED edge → Event vertex                                  │
+│     │                                                                        │
+│     ▼                                                                        │
+│  5. Return success immediately                                               │
+│                                                                              │
+│  ═══════════════════════════════════════════════════════════════════════════│
+│                    EVENTUAL CONSISTENCY BOUNDARY                             │
+│  ═══════════════════════════════════════════════════════════════════════════│
+│                                                                              │
+│  6. EventBus publishes TaskCompletedEvent                                   │
+│     │                                                                        │
+│     ▼                                                                        │
+│  7. ProgressProjection traverses graph:                                     │
+│     g.V('PHASE-001').out('CONTAINS').hasLabel('Task').group().by('status')  │
+│     │                                                                        │
+│     ▼                                                                        │
+│  8. Update Phase progress (derived from task states)                        │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Directory Structure
+
+```
+jerry/
+├── src/
+│   ├── __init__.py
+│   ├── domain/                          # Zero external dependencies
+│   │   ├── __init__.py
+│   │   ├── graph/                       # Graph primitives
+│   │   │   ├── __init__.py
+│   │   │   ├── primitives.py            # Vertex, Edge, VertexId, EdgeId
+│   │   │   └── edge_labels.py           # EdgeLabels constants
+│   │   ├── aggregates/
+│   │   │   ├── __init__.py
+│   │   │   ├── task.py                  # Task (AR, extends Vertex)
+│   │   │   ├── phase.py                 # Phase (AR, extends Vertex)
+│   │   │   └── plan.py                  # Plan (AR, extends Vertex)
+│   │   ├── entities/
+│   │   │   ├── __init__.py
+│   │   │   └── subtask.py               # Subtask (extends Vertex)
+│   │   ├── value_objects/
+│   │   │   ├── __init__.py
+│   │   │   ├── identifiers.py           # TaskId, PhaseId, PlanId, SubtaskId
+│   │   │   ├── status.py                # TaskStatus, PhaseStatus, PlanStatus
+│   │   │   └── actor.py                 # Actor, ActorType, ActorId
+│   │   ├── events/
+│   │   │   ├── __init__.py
+│   │   │   ├── base.py                  # CloudEventVertex base
+│   │   │   ├── task_events.py           # Task domain events
+│   │   │   ├── phase_events.py          # Phase domain events
+│   │   │   └── plan_events.py           # Plan domain events
+│   │   └── ports/
+│   │       ├── __init__.py
+│   │       ├── graph_repository.py      # IGraphRepository<T>
+│   │       ├── event_store.py           # IEventStore
+│   │       └── event_bus.py             # IEventBus
+│   ├── application/
+│   │   ├── __init__.py
+│   │   ├── dispatcher.py
+│   │   ├── commands/
+│   │   │   ├── task_commands.py
+│   │   │   └── phase_commands.py
+│   │   ├── queries/
+│   │   │   ├── task_queries.py
+│   │   │   └── progress_queries.py
+│   │   └── dtos/
+│   │       └── task_dto.py
+│   ├── infrastructure/
+│   │   ├── __init__.py
+│   │   ├── persistence/
+│   │   │   ├── file_graph_repository.py # Phase 1: File-based
+│   │   │   └── sqlite_graph_repository.py # Phase 2: SQLite
+│   │   └── projections/
+│   │       └── progress_projection.py
+│   └── interface/
+│       ├── __init__.py
+│       └── cli/
+│           └── main.py
+└── tests/
+    ├── unit/
+    │   └── domain/
+    │       ├── graph/
+    │       │   ├── test_vertex.py
+    │       │   └── test_edge.py
+    │       ├── value_objects/
+    │       │   ├── test_task_id.py
+    │       │   └── test_status.py
+    │       └── aggregates/
+    │           └── test_task.py
+    ├── integration/
+    ├── bdd/
+    │   └── features/
+    │       └── task_completion.feature
+    └── architecture/
+        └── test_dependencies.py
+```
+
+---
+
+## 7. Implementation Phases
+
+### Phase 1: Graph Primitives + Domain Layer
+
+| Task ID | Description | BDD Cycle | Verification |
+|---------|-------------|-----------|--------------|
+| DOM-001 | Implement Vertex base class | RED→GREEN→REFACTOR | Unit tests |
+| DOM-002 | Implement Edge base class | RED→GREEN→REFACTOR | Unit tests |
+| DOM-003 | Implement VertexId base class | RED→GREEN→REFACTOR | Unit tests |
+| DOM-004 | Implement EdgeId class | RED→GREEN→REFACTOR | Unit tests |
+| DOM-005 | Implement EdgeLabels constants | N/A | Code review |
+| DOM-006 | Implement TaskId (extends VertexId) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-007 | Implement PhaseId (extends VertexId) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-008 | Implement PlanId (extends VertexId) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-009 | Implement SubtaskId (composite) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-010 | Implement TaskStatus state machine | RED→GREEN→REFACTOR | Unit tests |
+| DOM-011 | Implement PhaseStatus state machine | RED→GREEN→REFACTOR | Unit tests |
+| DOM-012 | Implement PlanStatus state machine | RED→GREEN→REFACTOR | Unit tests |
+| DOM-013 | Implement Actor value object | RED→GREEN→REFACTOR | Unit tests |
+| DOM-014 | Implement CloudEventVertex base | RED→GREEN→REFACTOR | Unit tests |
+| DOM-015 | Implement task domain events | RED→GREEN→REFACTOR | Unit tests |
+| DOM-016 | Implement Subtask entity (Vertex) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-017 | Implement Task aggregate (Vertex) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-018 | Implement Phase aggregate (Vertex) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-019 | Implement Plan aggregate (Vertex) | RED→GREEN→REFACTOR | Unit tests |
+| DOM-020 | Define IGraphRepository port | N/A | Interface review |
+| DOM-021 | Define IEventStore port | N/A | Interface review |
+| DOM-022 | Define IEventBus port | N/A | Interface review |
+
+### Phase 2: Application Layer
+
+| Task ID | Description | BDD Cycle | Verification |
+|---------|-------------|-----------|--------------|
+| APP-001 | Implement command dispatcher | RED→GREEN→REFACTOR | Unit tests |
+| APP-002 | Implement CreateTaskCommand | RED→GREEN→REFACTOR | Unit tests |
+| APP-003 | Implement CompleteTaskCommand | RED→GREEN→REFACTOR | Unit tests |
+| APP-004 | Implement AddSubtaskCommand | RED→GREEN→REFACTOR | Unit tests |
+| APP-005 | Implement CheckSubtaskCommand | RED→GREEN→REFACTOR | Unit tests |
+| APP-006 | Implement GetTaskQuery | RED→GREEN→REFACTOR | Unit tests |
+| APP-007 | Implement GetProgressQuery | RED→GREEN→REFACTOR | Unit tests |
+| APP-008 | Implement TraversePathQuery | RED→GREEN→REFACTOR | Unit tests |
+| APP-009 | Implement TaskDTO | N/A | Schema validation |
+
+### Phase 3: Infrastructure Layer
+
+| Task ID | Description | BDD Cycle | Verification |
+|---------|-------------|-----------|--------------|
+| INF-001 | Implement FileGraphRepository | RED→GREEN→REFACTOR | Integration tests |
+| INF-002 | Implement FileEventStore | RED→GREEN→REFACTOR | Integration tests |
+| INF-003 | Implement InMemoryEventBus | RED→GREEN→REFACTOR | Integration tests |
+| INF-004 | Implement ProgressProjection | RED→GREEN→REFACTOR | Integration tests |
+| INF-005 | Implement JSON serialization | RED→GREEN→REFACTOR | Contract tests |
+
+### Phase 4: Interface Layer
+
+| Task ID | Description | BDD Cycle | Verification |
+|---------|-------------|-----------|--------------|
+| INT-001 | Implement CLI entry point | RED→GREEN→REFACTOR | E2E tests |
+| INT-002 | Implement task subcommands | RED→GREEN→REFACTOR | E2E tests |
+| INT-003 | Implement output formatters | RED→GREEN→REFACTOR | E2E tests |
+
+### Phase 5: Testing & Validation
+
+| Task ID | Description | Verification |
+|---------|-------------|--------------|
+| TST-001 | Achieve 95% domain test coverage | Coverage report |
+| TST-002 | BDD feature tests complete | All scenarios pass |
+| TST-003 | Architecture dependency tests | No violations |
+| TST-004 | CloudEvents contract tests | Schema validation |
+| TST-005 | Graph traversal tests | Gremlin pattern compliance |
+
+---
+
+## 8. BDD Test Specifications
+
+### Feature: Task as Graph Vertex
+
+```gherkin
+Feature: Task Graph Operations
+  As a developer
+  I want Tasks to be graph vertices
+  So that I can traverse relationships
+
+  Scenario: Create task creates vertex with ID
+    Given a phase "PHASE-001" exists
+    When I create a task "Implement feature"
+    Then a Task vertex should exist
+    And the vertex should have a strongly-typed TaskId
+    And the vertex should have label "Task"
+
+  Scenario: Add subtask creates CONTAINS edge
+    Given a task "TASK-001" exists
+    When I add subtask "Write tests"
+    Then a Subtask vertex should exist
+    And a CONTAINS edge should exist from Task to Subtask
+    And the edge should have sequence property
+
+  Scenario: Complete task emits event as vertex
+    Given a task "TASK-001" with all subtasks checked
+    When I complete the task
+    Then an Event vertex should exist
+    And an EMITTED edge should connect Task to Event
+    And the Event should be CloudEvents 1.0 compliant
+```
+
+### Feature: Graph Traversal
+
+```gherkin
+Feature: Graph Traversal Queries
+  As a user
+  I want to traverse task relationships
+  So that I can understand dependencies
+
+  Scenario: Traverse phase to tasks
+    Given a phase with 3 tasks
+    When I traverse CONTAINS edges from phase
+    Then I should get 3 Task vertices
+
+  Scenario: Calculate progress via traversal
+    Given a phase with tasks: 2 complete, 1 pending
+    When I query phase progress
+    Then the progress should be 66%
+```
+
+---
+
+## 9. Risk Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Graph abstraction overhead | Medium | Medium | Benchmark against direct storage |
+| Gremlin compatibility gaps | Low | Medium | Test patterns early |
+| Event schema evolution | Medium | High | Version from day 1 |
+| Context compaction | High | Medium | Frequent commits; detailed WORKTRACKER.md |
+
+---
+
+## 10. References
+
+### Research Documents
+1. `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md` - Graph model design
+2. `docs/research/AGGREGATE_ROOT_ANALYSIS.md` - AR sizing decision
+3. `docs/research/ECW_COMPREHENSIVE_LESSONS_LEARNED.md` - ECW patterns
+
+### External References
+4. Apache TinkerPop - https://tinkerpop.apache.org/
+5. Practical Gremlin - https://www.kelvinlawrence.net/book/PracticalGremlin.html
+6. CloudEvents 1.0 - https://cloudevents.io/
+7. Vaughn Vernon - Implementing DDD
+
+---
+
+## 11. Approval
+
+**Status:** ✅ APPROVED
+
+**Approved Items:**
+- [x] Graph-ready data model (Vertex/Edge)
+- [x] Task-level Aggregate Root design
+- [x] CloudEvents 1.0 schema
+- [x] Three-Tier Enforcement patterns (aspirational)
+- [x] Eventual consistency event flows
+- [x] Self-healing architecture (aspirational)
+- [x] Implementation phase sequence
+
+---
+
+*Document Version: 2.0*
+*Last Updated: 2026-01-07*

--- a/docs/archive/projects-archive/WORKTRACKER.md
+++ b/docs/archive/projects-archive/WORKTRACKER.md
@@ -1,0 +1,889 @@
+# Jerry Framework - Work Tracker
+
+> Persistent work tracking for long-running sessions. Survives context compaction.
+
+**Last Updated**: 2026-01-09T04:00:00Z
+**Current Phase**: Phase 3.6 - Knowledge Architecture (IN PROGRESS)
+**Current Task**: WORK-035 - ADR Comparison & Direction Decision
+**Session ID**: MG1nh
+**Branch**: claude/create-code-plugin-skill-MG1nh
+
+---
+
+## Quick Status
+
+| Phase | Status | Progress |
+|-------|--------|----------|
+| Phase 0: Research & Analysis | ✅ COMPLETED | 100% |
+| Phase 1: Governance Layer | ✅ COMPLETED | 100% |
+| Phase 2: Skills Interface Layer | ✅ COMPLETED | 100% |
+| Phase 2.5: Deep Analysis | ✅ COMPLETED | 100% |
+| Phase 3: Hexagonal Core | ⏸️ PAUSED | 25% |
+| Phase 3.5: Agent Reorganization | ✅ COMPLETED | 100% |
+| **Phase 3.6: Knowledge Architecture** | 🔄 IN PROGRESS | 75% |
+| Phase 4: Testing & Validation | ⏳ PENDING | 0% |
+
+---
+
+## Active Work Items (Current Session)
+
+| Work Item | Status | Artifacts | Size | Last Commit |
+|-----------|--------|-----------|------|-------------|
+| WORK-031 | ✅ COMPLETE (ADR PROPOSED) | 9 files | 394KB | c956cb0 |
+| WORK-032 | ✅ COMPLETE (APPROVED W/CONDITIONS) | 9 files | 457KB | 2e7ee7c |
+| WORK-033 | ✅ COMPLETE (ADR-033 PROPOSED) | 5 files | 266KB | 36ca4b1 |
+| WORK-034 | ✅ COMPLETE (ADR-034 APPROVED) | 6 files | 349KB | 6aa3904 |
+| WORK-035 | ⏳ PENDING | - | - | - |
+| WORK-036 | ⏳ PENDING (13 sub-tasks) | - | - | - |
+| WORK-037 | ⏳ PENDING (8 sub-tasks) | - | - | - |
+
+### Recent Commits (This Session - After Author Fix)
+```
+a7d5d4b fix(tracking): Correct artifact counts and sizes in WORKTRACKER
+475229d docs(tracking): Mark WORK-033 Step 2 complete, proceed to Step 3
+b78b419 feat(design): Complete WORK-033 Step 2 - ps-architect unified KM design
+eafe0cb docs(tracking): Mark WORK-033 Step 1 complete, update status
+b80389f feat(research): Complete WORK-033 Step 1 - ps-researcher integration analysis
+bbf8543 docs(tracking): Mark WORK-032 complete, start WORK-033
+2e7ee7c feat(validation): Complete WORK-032 Step 5 - ps-validator approval
+698bc0d feat(decisions): Complete WORK-032 Step 4 - ADR-032 KM Integration
+```
+
+---
+
+## Phase 0: Research & Analysis (COMPLETED)
+
+### WORK-001: Technology Stack Analysis ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/TECHNOLOGY_STACK_ANALYSIS.md`
+- **Decision**: Python with zero/minimal dependencies
+
+### WORK-002: Polyglot Architecture Analysis ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/POLYGLOT_ARCHITECTURE_ANALYSIS.md`
+- **Decision**: Python-first, TypeScript at network layer if needed
+
+---
+
+## Phase 1: Governance Layer (COMPLETED)
+
+### WORK-003: Agent Personas ✅
+- **Status**: COMPLETED
+- **Files**: `.claude/agents/{orchestrator,qa-engineer,security-auditor}.md`
+
+### WORK-004: Slash Commands ✅
+- **Status**: COMPLETED
+- **Files**: `.claude/commands/{architect,release}.md`
+
+### WORK-005: Hooks Implementation ✅
+- **Status**: COMPLETED
+- **Files**: `.claude/hooks/{pre_tool_use,subagent_stop}.py`
+
+### WORK-006: Rules & Settings ✅
+- **Status**: COMPLETED
+- **Files**: `.claude/rules/coding-standards.md`, `.claude/settings.json`
+
+---
+
+## Phase 2: Skills Interface Layer (COMPLETED)
+
+### WORK-007: Work Tracker Skill ✅
+- **Status**: COMPLETED
+- **File**: `skills/worktracker/SKILL.md`
+
+### WORK-008: Architecture Skill ✅
+- **Status**: COMPLETED
+- **File**: `skills/architecture/SKILL.md`
+
+### WORK-009: Problem-Solving Skill ✅
+- **Status**: COMPLETED
+- **File**: `skills/problem-solving/SKILL.md`
+
+---
+
+## Phase 2.5: Deep Analysis of ECW Artifacts (NEW - COMPLETED)
+
+### WORK-015: ECW Lessons Learned Analysis ✅
+- **Status**: COMPLETED
+- **Input**: `docs/knowledge/dragonsbelurkin/glimmering-brewing-lake.md`
+- **Findings**:
+  - 108+ use cases documented
+  - State machines for Initiative/Phase/Task/Subtask
+  - CloudEvents 1.0 schema already defined
+  - 4 Bounded Contexts: Work Management, Knowledge Capture, Identity & Access, Reporting
+
+### WORK-016: Aggregate Root Sizing Research ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/AGGREGATE_ROOT_ANALYSIS.md`
+- **Key Finding**: Task as primary AR, Phase/Plan as secondary ARs
+- **Sources**: Vaughn Vernon (Implementing DDD), Eric Evans, ProjectOvation case study
+
+### WORK-017: CloudEvents Schema Analysis ✅
+- **Status**: COMPLETED
+- **Input**: `src/infrastructure/schemas/json/external/cloudevents-base.schema.json`
+- **Decision**: Adopt CloudEvents 1.0 with Jerry-specific extensions
+
+### WORK-018: Graph Data Model Research ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md`
+- **Key Findings**:
+  - Property Graph model (Vertex, Edge, Properties) for Gremlin compatibility
+  - VertexId as base class for all strongly typed identifiers
+  - Phased migration: File → SQLite → Graph DB
+  - CloudEvents stored as graph vertices with EMITTED edges
+  - Gremlin traversal patterns for future graph queries
+
+---
+
+## Phase 3: Hexagonal Core (IN PROGRESS - REVISED)
+
+### WORK-010: Design & Planning ✅
+- **Status**: COMPLETED
+- **Output**: `docs/PLAN.md` (v3.0 - Graph-Ready)
+- **Key Artifacts Created**:
+  - `docs/PLAN.md` - Comprehensive implementation plan with graph model
+  - `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md` - Gremlin research
+  - `docs/research/AGGREGATE_ROOT_ANALYSIS.md` - AR sizing research
+  - `docs/research/ECW_COMPREHENSIVE_LESSONS_LEARNED.md` - ECW analysis
+
+#### Completed Sub-tasks:
+- [x] WORK-010.1: Analyze ECW v3 lessons learned
+- [x] WORK-010.2: Research aggregate root sizing (Vernon, Evans)
+- [x] WORK-010.3: Document aggregate root decision
+- [x] WORK-010.4: Revise Bounded Context Diagram (3 ARs) → in PLAN.md
+- [x] WORK-010.5: Revise Domain Entity Class Diagrams → in PLAN.md
+- [x] WORK-010.6: Define strongly typed identity objects → VertexId hierarchy
+- [x] WORK-010.7: Define CloudEvents-based domain events → in PLAN.md
+- [x] WORK-010.8: Create eventual consistency event flow diagrams → in PLAN.md
+- [x] WORK-010.9: Revise Use Case specifications → in PLAN.md
+- [x] WORK-010.10: Research graph data model (Gremlin) → GRAPH_DATA_MODEL_ANALYSIS.md
+- [x] WORK-010.11: Define BDD test specifications → in PLAN.md
+
+### WORK-011: Domain Layer Implementation 🔄
+- **Status**: READY TO BEGIN
+- **Reference**: See `docs/PLAN.md` Section 5 (DOM-001 to DOM-022)
+
+#### **REVISED Sub-tasks - Three Aggregate Roots:**
+
+**WORK-011.1: Strongly Typed Identity Objects**
+- [ ] RED: Write failing tests for TaskId
+- [ ] GREEN: Implement TaskId value object
+- [ ] RED: Write failing tests for PhaseId
+- [ ] GREEN: Implement PhaseId value object
+- [ ] RED: Write failing tests for PlanId
+- [ ] GREEN: Implement PlanId value object
+- [ ] RED: Write failing tests for SubtaskId
+- [ ] GREEN: Implement SubtaskId value object
+
+**WORK-011.2: Status Value Objects with State Machines**
+- [ ] RED: Write failing tests for TaskStatus
+- [ ] GREEN: Implement TaskStatus with valid transitions
+- [ ] RED: Write failing tests for PhaseStatus
+- [ ] GREEN: Implement PhaseStatus
+- [ ] RED: Write failing tests for PlanStatus
+- [ ] GREEN: Implement PlanStatus
+
+**WORK-011.3: CloudEvents Domain Events**
+- [ ] RED: Write failing tests for CloudEvent base
+- [ ] GREEN: Implement CloudEvent base class
+- [ ] RED: Write failing tests for TaskCreatedEvent
+- [ ] GREEN: Implement TaskCreatedEvent
+- [ ] Continue for all task/phase/plan events...
+
+**WORK-011.4: Task Aggregate Root (Primary AR)**
+- [ ] RED: Write failing tests for Task creation
+- [ ] GREEN: Implement Task.create()
+- [ ] RED: Write failing tests for Subtask management
+- [ ] GREEN: Implement add_subtask, check_subtask, remove_subtask
+- [ ] RED: Write failing tests for status transitions
+- [ ] GREEN: Implement start, complete, block, unblock
+- [ ] RED: Write failing tests for completion guards
+- [ ] GREEN: Implement all_subtasks_checked, evidence_attached guards
+
+**WORK-011.5: Phase Aggregate Root (Secondary AR)**
+- [ ] RED: Write failing tests for Phase creation
+- [ ] GREEN: Implement Phase.create()
+- [ ] RED: Write failing tests for task ID reference management
+- [ ] GREEN: Implement add_task_ref, remove_task_ref
+- [ ] Note: Progress derived from projections (eventual consistency)
+
+**WORK-011.6: Plan Aggregate Root (Tertiary AR)**
+- [ ] RED: Write failing tests for Plan creation
+- [ ] GREEN: Implement Plan.create()
+- [ ] RED: Write failing tests for phase ID reference management
+- [ ] GREEN: Implement add_phase_ref, remove_phase_ref
+- [ ] Note: Progress derived from projections (eventual consistency)
+
+**WORK-011.7: Domain Ports (Interfaces)**
+- [ ] Define IEventStore port
+- [ ] Define ITaskRepository port
+- [ ] Define IPhaseRepository port
+- [ ] Define IPlanRepository port
+- [ ] Define IEventBus port
+
+### WORK-012: Application Layer Implementation ⏳
+- **Status**: PENDING
+
+### WORK-013: Infrastructure Layer Implementation ⏳
+- **Status**: PENDING
+
+### WORK-014: Interface Layer Implementation ⏳
+- **Status**: PENDING
+
+---
+
+## Phase 3.5: Agent Reorganization (IN PROGRESS - NEW PRIORITY)
+
+> **Plan Document:** `docs/plans/AGENT_REORGANIZATION_PLAN.md`
+> **Research:** `docs/research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md`
+> **Focus:** Advisory, Soft, Medium enforcement (defer Hard)
+
+### WORK-019: Agent Enforcement Research ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md`
+- **Key Findings**:
+  - 4-Tier Progressive Enforcement (Advisory → Soft → Medium → Hard)
+  - Industry consensus: 75% soft enforcement, 25% hard
+  - Constitutional AI as foundation for self-governing agents
+  - Sources: Anthropic, OpenAI, Google DeepMind, academic research
+
+### WORK-020: Agent Reorganization Plan ✅
+- **Status**: COMPLETED
+- **Output**: `docs/plans/AGENT_REORGANIZATION_PLAN.md`
+- **Scope**: 8 ps-*.md agents, architecture skill cleanup
+
+### WORK-021: Create Jerry Constitution ✅
+- **Status**: COMPLETED
+- **Output**: `docs/governance/JERRY_CONSTITUTION.md`
+- **Key Deliverables**:
+  - Jerry Constitution v1.0 with 13 principles across 5 articles
+  - BEHAVIOR_TESTS.md with 14 test scenarios (golden dataset)
+  - Agent TEMPLATE.md with constitutional compliance built-in
+  - CLAUDE.md updated with constitution reference and quick reference table
+- **Industry Prior Art**:
+  - Anthropic Constitutional AI, SHADE-Arena adversarial testing
+  - OpenAI Model Spec, Confessions Framework
+  - DeepEval G-Eval, LLM-as-a-Judge pattern
+  - Datadog golden dataset methodology
+- **Sub-tasks** (all completed):
+  - [x] AGT-001.1: Draft constitution with 13 numbered principles
+  - [x] AGT-001.2: Create BEHAVIOR_TESTS.md with 14 test scenarios
+  - [x] AGT-002: Update CLAUDE.md with constitution reference
+  - [x] AGT-003: Create simplified agent template
+- **Discoveries**: DISC-069
+
+### WORK-022: Refactor ps-*.md Agents ✅
+- **Status**: COMPLETED (8/8 complete)
+- **Research**: `docs/research/PS_AGENT_REFACTORING_STRATEGY.md` ✅
+- **Template**: `skills/problem-solving/agents/PS_AGENT_TEMPLATE.md` ✅
+- **Discoveries**: DISC-049 through DISC-053 (5 agent design discoveries)
+- **Sub-tasks**:
+  - [x] AGT-010: Refactor ps-researcher.md v2.0.0
+  - [x] AGT-011: Refactor ps-analyst.md v2.0.0
+  - [x] AGT-012: Refactor ps-architect.md v2.0.0
+  - [x] AGT-013: Refactor ps-validator.md v2.0.0
+  - [x] AGT-014: Refactor ps-synthesizer.md v2.0.0
+  - [x] AGT-015: Refactor ps-reviewer.md v2.0.0
+  - [x] AGT-016: Refactor ps-investigator.md v2.0.0
+  - [x] AGT-017: Refactor ps-reporter.md v2.0.0
+  - [ ] AGT-018: Clean up architecture SKILL.md (deferred to WORK-030)
+
+### WORK-023: Implement Soft Enforcement ⏳
+- **Status**: PENDING
+- **Sub-tasks**:
+  - [ ] AGT-020: Implement self-monitoring interface
+  - [ ] AGT-021: Add reflection prompts
+  - [ ] AGT-022: Create warning message patterns
+  - [ ] AGT-023: Implement consent request pattern
+
+### WORK-024: Implement Medium Enforcement ⏳
+- **Status**: PENDING
+- **Sub-tasks**:
+  - [ ] AGT-030: Define trust levels
+  - [ ] AGT-031: Implement tool restriction enforcement
+  - [ ] AGT-032: Create escalation trigger patterns
+
+### WORK-025: TOON Format Research ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/TOON_FORMAT_ANALYSIS.md`
+- **Key Findings**:
+  - 30-60% token reduction vs JSON for LLM prompts
+  - 74% LLM accuracy vs JSON's 70%
+  - Lossless JSON ↔ TOON conversion
+  - Python implementation: `python-toon` package
+  - Specification v3.0 (November 2025)
+- **Discoveries**: DISC-044 through DISC-048
+- **Decision**: Add TOON as secondary serialization format for LLM-facing operations
+
+### WORK-026: Address PROP-001 User Feedback ✅
+- **Status**: COMPLETED
+- **Input**: User feedback (AN: prefixed) in PS_EXPORT_DOMAIN_ALIGNMENT.md
+- **Output**: Revised PROP-001 v1.1
+- **Feedback Addressed**:
+  - [x] IAuditable fields (created_by, updated_by)
+  - [x] Hash algorithm indicator property
+  - [x] Version property (Date+Hash composite)
+  - [x] Slug max length (75 chars per SEO best practices)
+  - [x] ID as object (JerryId)
+  - [x] Metadata dictionary for extensibility
+  - [x] Tags array for categorization
+  - [x] Relationship representation (Edge entities)
+  - [x] Markdown table formatting
+- **Discoveries**: DISC-054 through DISC-056
+- **Citations**: Clean DDD (UNIL), Backlinko SEO, Vernon/Evans DDD
+
+### WORK-027: Jerry URI Scheme Specification ✅
+- **Status**: COMPLETED
+- **Output**: `docs/specifications/JERRY_URI_SPECIFICATION.md`
+- **User Proposal**: Unified URN/URI for all resources (entities, events, commands, schemas)
+- **Pattern**: `jer[+scheme_version]:<partition>:[tenant_id]:<domain>:<resource>[+version]`
+- **Key Features**:
+  - Multi-tenancy native (tenant_id component)
+  - Versioning (scheme + resource)
+  - CloudEvents `type` field compatible
+  - JSON Schema `$id` compatible
+- **Prior Art**: RFC 8141 (URN), AWS ARN
+- **Discoveries**: DISC-057
+- **Sub-tasks**:
+  - [x] WORK-027.1: Create JERRY_URI_SPECIFICATION.md
+  - [x] WORK-027.2: Add ABNF grammar and JerryUri value object
+  - [x] WORK-027.3: Update PROP-001 v1.2 with uri property in EntityBase
+  - [x] WORK-027.4: Update GRAPH_DATA_MODEL_ANALYSIS.md v1.1 with URI integration
+
+### WORK-028: LLM Behavioral Governance Testing Research ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md`
+- **Purpose**: Validate testing approach for Jerry Constitution behavioral directives
+- **Key Findings**:
+  - LLM-as-a-Judge is industry standard (DeepEval, Datadog, Anthropic)
+  - Scenario-based testing with golden datasets validated (Datadog)
+  - Adversarial red-team testing essential (Anthropic SHADE-Arena, OpenAI)
+  - G-Eval with Chain-of-Thought enables custom criteria scoring
+  - Multi-attempt Attack Success Rate (ASR) measures robustness
+- **Industry Sources**:
+  - Anthropic: Frontier Red Team, SHADE-Arena, Modular Scaffold
+  - OpenAI: Safety Evaluations Hub, Confessions Framework
+  - Datadog: LLM Evaluation Framework Best Practices
+  - DeepEval: Open-source LLM testing with 50+ metrics
+- **Discoveries**: DISC-058 through DISC-063
+- **Decision**: Proceed with validated testing approach for WORK-021
+
+### WORK-029: Address Graph Data Model Feedback (AN.Q.1-3) ✅
+- **Status**: COMPLETED
+- **Output**: `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md` v1.2 (Section 11-12)
+- **User Questions Addressed**:
+  - AN.Q.1: Python graph libraries (kglab, RDFLib, NetworkX, rdf2gremlin)
+  - AN.Q.1.a: Analysis documented in Section 11
+  - AN.Q.2: RDF/OWL alignment strategy (4-phase path)
+  - AN.Q.3: Netflix Knowledge Graph insights (UDA, "Model Once, Represent Everywhere")
+- **Key Findings**:
+  - **kglab** recommended as abstraction layer (RDF + NetworkX + Pandas)
+  - Jerry URI scheme already RDF-compatible
+  - Netflix UDA validates Jerry's EntityBase → multiple serialization approach
+  - Named-Graph-First pattern aligns with Jerry URI structure
+- **Industry Sources**:
+  - Netflix: UDA, Entertainment Knowledge Graph
+  - DerwenAI: kglab library
+  - Semantic Arts: Property Graph → Knowledge Graph path
+  - W3C: RDF*, OWL standards
+- **Discoveries**: DISC-064 through DISC-068
+
+### WORK-030: Refactor problem-solving/SKILL.md ✅
+- **Status**: COMPLETED
+- **Priority**: HIGH (User requested)
+- **Issue Fixed**: DISC-070 - Replaced 1722-line work-tracker content with proper problem-solving skill
+- **Final State**: 265-line clean SKILL.md + PLAYBOOK.md + ORCHESTRATION.md
+- **Deliverables**:
+  - `skills/problem-solving/SKILL.md` - Clean skill definition (265 lines)
+  - `skills/problem-solving/PLAYBOOK.md` - User guide with examples
+  - `skills/problem-solving/docs/ORCHESTRATION.md` - Technical orchestration guide
+- **Sub-tasks**:
+  - [x] SKILL-001: Analyzed current SKILL.md - found work-tracker content (wrong!)
+  - [x] SKILL-002: Created new SKILL.md with proper frontmatter and content
+  - [x] SKILL-003: Created PLAYBOOK.md - User guide (invocation, examples)
+  - [x] SKILL-004: Created ORCHESTRATION.md - Technical orchestration patterns
+
+### WORK-031: Knowledge Architecture Research ✅
+- **Status**: COMPLETED (ADR PROPOSED - awaiting human approval)
+- **Priority**: HIGH (User requested - orchestration verification)
+- **Purpose**: Verify ps-* agent orchestration while researching knowledge architecture
+- **Extends**: GRAPH_DATA_MODEL_ANALYSIS.md, Netflix UDA, kglab analysis
+- **Research Tracks** (Parallel ps-researcher invocations):
+  - [x] R1: Graph modeling best practices (58KB) - commit 6d57ac4
+  - [x] R2: Semantic knowledge representations (37KB) - commit 6d57ac4
+  - [x] R3: Technologies for semantic presentation (57KB) - commit 6d57ac4
+  - [x] R4: Enabling semantics in data (42KB) - commit 6d57ac4
+  - [x] R5: LLM semantic grounding (53KB) - commit 6d57ac4
+- **Workflow** (Full decision pattern from ORCHESTRATION.md):
+  - [x] Step 1: ps-researcher × 5 (247KB) - commit 6d57ac4
+  - [x] Step 2: ps-synthesizer (44KB, 10 patterns) - commit 775587c
+  - [x] Step 3: ps-analyst (34KB, trade-offs) - commit c71135b
+  - [x] Step 4: ps-architect (42KB, ADR-031) - commit a874fa7
+  - [x] Step 5: ps-validator (33KB, APPROVED) - commit c956cb0
+- **Deliverables**:
+  - `docs/research/work-031-e-001-gremlin-modeling.md` ✅
+  - `docs/research/work-031-e-002-semantic-representations.md` ✅
+  - `docs/research/work-031-e-003-semantic-technologies.md` ✅
+  - `docs/research/work-031-e-004-semantic-data.md` ✅
+  - `docs/research/work-031-e-005-llm-grounding.md` ✅
+  - `docs/synthesis/work-031-e-006-synthesis.md` ✅
+  - `docs/analysis/work-031-e-007-trade-off-analysis.md` ✅
+  - `docs/decisions/ADR-031-knowledge-architecture.md` ✅ (PROPOSED)
+  - `docs/validation/work-031-e-009-validation-report.md` ✅
+- **Decision**: Hybrid Property + RDF Architecture (22/25, 88%)
+- **Total Artifacts**: 400KB across 9 files
+
+### WORK-032: Knowledge Management Domain Research ✅
+- **Status**: COMPLETED (APPROVED WITH CONDITIONS - 25/25)
+- **Priority**: HIGH (User requested)
+- **Purpose**: Deep research into KM domain for Jerry integration
+- **Workflow** (ps-* agent orchestration):
+  - [x] **Step 1: ps-researcher × 5** (PARALLEL - Fan-Out)
+    - [x] R1: KM Fundamentals (44KB) → `work-032-e-001-km-fundamentals.md`
+    - [x] R2: KM Protocols (67KB) → `work-032-e-002-km-protocols.md`
+    - [x] R3: KM Products (63KB) → `work-032-e-003-km-products.md`
+    - [x] R4: Python KM SDKs (98KB) → `work-032-e-004-python-km-sdks.md`
+    - [x] R5: KM Frameworks (86KB) → `work-032-e-005-km-frameworks.md`
+    - **Commit**: 281b93a | **Total**: 358KB, 9384 lines
+  - [x] **Step 2: ps-synthesizer** (Fan-In) ✅
+    - Input: 5 research documents from Step 1
+    - Output: `docs/synthesis/work-032-e-006-km-synthesis.md`
+    - Task: Braun & Clarke thematic analysis, PAT/LES/ASM generation
+    - **Commit**: 756d800 | **Size**: 37KB, 858 lines | **Patterns**: 7
+  - [x] **Step 3: ps-analyst** (Trade-off Analysis) ✅
+    - Input: Synthesis from Step 2
+    - Output: `docs/analysis/work-032-e-007-trade-off-analysis.md`
+    - Task: SWOT, decision matrix, risk analysis for KM options
+    - **Commit**: ef09ae7 | **Size**: 29KB, 780 lines | **Rec**: Lightweight KM
+  - [x] **Step 4: ps-architect** (ADR Creation) ✅
+    - Input: Analysis from Step 3
+    - Output: `docs/decisions/ADR-032-km-integration.md`
+    - Task: Michael Nygard ADR format, implementation roadmap
+    - **Commit**: d9849c9 | **Size**: 20KB, 548 lines | **Decision**: Lightweight KM
+  - [x] **Step 5: ps-validator** (Validation) ✅
+    - Input: ADR from Step 4
+    - Output: `docs/validation/work-032-e-009-validation-report.md`
+    - Task: Verify decision meets Jerry constraints, constitutional compliance
+    - **Commit**: 49e1b4a | **Size**: 19KB, 523 lines | **Verdict**: APPROVED W/CONDITIONS
+- **Decision**: Lightweight KM (NetworkX + FAISS + RDFLib) - 8.5/10
+- **Total Artifacts**: 463KB across 10 files
+- **Deliverables**:
+  - `docs/research/work-032-e-001-km-fundamentals.md` ✅
+  - `docs/research/work-032-e-002-km-protocols.md` ✅
+  - `docs/research/work-032-e-003-km-products.md` ✅
+  - `docs/research/work-032-e-004-python-km-sdks.md` ✅
+  - `docs/research/work-032-e-005-km-frameworks.md` ✅
+  - `docs/synthesis/work-032-e-006-km-synthesis.md` ✅ (756d800)
+  - `docs/analysis/work-032-e-007-trade-off-analysis.md` ✅ (ef09ae7)
+  - `docs/decisions/ADR-032-km-integration.md` ✅ (d9849c9)
+  - `docs/validation/work-032-e-009-validation-report.md` ✅ (49e1b4a)
+
+### WORK-033: Unified Design (WORK-031 + WORK-032) ✅
+- **Status**: COMPLETE
+- **Priority**: HIGH
+- **Purpose**: Merge knowledge architecture and KM domain research into unified design
+- **Depends On**: WORK-031 ✅, WORK-032 ✅
+- **Workflow** (ps-* agent orchestration):
+  - [x] **Step 1: ps-researcher** (Integration Analysis) ✅
+    - Input: ADR-031, WORK-032 synthesis
+    - Output: `docs/research/work-033-e-001-integration-analysis.md`
+    - Task: Analyze how WORK-031 + WORK-032 fit together
+    - **Commit**: 2aebff6 | **Size**: 72KB, 1464 lines | **Finding**: 95% compatibility
+  - [x] **Step 2: ps-architect** (Design Creation) ✅
+    - Input: Integration analysis from Step 1
+    - Output: `docs/design/work-033-e-002-unified-design.md`
+    - Task: Create unified domain model, Use Cases, diagrams
+    - **Commit**: a0ddf43 | **Size**: 64KB, 2012 lines | **Diagrams**: 5
+    - Sub-deliverables:
+      - [x] Component diagrams (Mermaid) ✅
+      - [x] Sequence diagrams for KM workflows ✅
+      - [x] Class diagrams for KM entities ✅
+      - [x] Ports/adapters for KM layer (hexagonal) ✅
+  - [x] **Step 3: ps-analyst** (Design Trade-offs) ✅
+    - Input: Design from Step 2
+    - Output: `docs/analysis/work-033-e-003-design-trade-offs.md`
+    - Task: Evaluate design options, complexity analysis
+    - **Commit**: e8477e6 | **Size**: 66KB, 1495 lines | **Winner**: Phased (92%)
+  - [x] **Step 4: ps-architect** (ADR Creation - RE-DONE) ✅
+    - Input: Trade-offs from Step 3
+    - Output: `docs/decisions/ADR-033-unified-km-architecture.md`
+    - Task: Final architecture decision record
+    - **Commit**: 1a1011b | **Size**: 44KB, 1124 lines | **Status**: PROPOSED
+    - Includes: Domain model, ports, adapters, CQRS, 10-risk register, appendices
+  - [x] **Step 5: ps-validator** (Validation) ✅
+    - Input: ADR from Step 4
+    - Output: `docs/validation/work-033-e-005-validation-report.md`
+    - Task: Verify against Jerry Constitution, hexagonal compliance
+    - **Commit**: f41b1c7 | **Size**: 19KB, 227 lines | **Verdict**: APPROVED (25/25)
+  - [x] **USER REVIEW** - Approved by user ✅
+- **Final Status**: ADR-033 PROPOSED (not yet committed to implementation)
+- **Deliverables**:
+  - `docs/research/work-033-e-001-integration-analysis.md`
+  - `docs/design/work-033-e-002-unified-design.md`
+  - `docs/analysis/work-033-e-003-design-trade-offs.md`
+  - `docs/decisions/ADR-033-unified-km-architecture.md`
+  - `docs/validation/work-033-e-005-validation-report.md`
+
+### WORK-034: Work Tracker + KM Unified Proposal 🔄
+- **Status**: IN PROGRESS
+- **Priority**: HIGH
+- **Purpose**: Create alternative architecture proposal using Work Tracker domain as KM proving ground
+- **Depends On**: WORK-033 ✅
+- **Rationale**: Work Tracker is a smaller, tactical domain that can validate KM patterns before scaling
+- **Input Documents**:
+  - WORK-033 outputs (266KB): ADR-033, integration analysis, design, trade-offs, validation
+  - `docs/plans/WORK_TRACKER_PLAN.md` (89KB): Comprehensive Work Tracker domain plan
+- **Technology Stack** (same as WORK-033):
+  - NetworkX 3.2.1 (graph operations)
+  - FAISS 1.7.4 (vector search)
+  - RDFLib 7.0.0 (semantic web)
+- **Key Difference**: Domain model starts with Work Tracker (Task, Phase, Plan) with bidirectional graph references to KM entities (KnowledgeItem, Pattern, Lesson, Assumption)
+- **Workflow** (ps-* agent orchestration):
+  - [x] **Step 1: ps-researcher** (Domain Analysis) ✅
+    - Input: WORK-033 outputs, WORK_TRACKER_PLAN.md
+    - Output: `docs/research/work-034-e-001-domain-analysis.md`
+    - Task: Analyze both domains, identify synergies, mapping, integration points
+    - **Commit**: c893c52 | **Size**: 93KB, 2202 lines | **Exceeds target**
+  - [x] **Step 2: ps-synthesizer** (Domain Merge) ✅
+    - Input: Domain analysis from Step 1
+    - Output: `docs/synthesis/work-034-e-002-domain-synthesis.md`
+    - Task: Merge domain models, identify common patterns, graph relationships
+    - **Commit**: c2fa4c4 | **Size**: 54KB, 1445 lines | **Diagrams**: 7
+  - [ ] **Step 3: ps-architect** (Unified Design)
+    - Input: Synthesis from Step 2
+    - Output: `docs/design/work-034-e-003-unified-design.md`
+    - Task: Create comprehensive design document (match WORK_TRACKER_PLAN.md detail)
+    - Sub-deliverables:
+      - [ ] 5W1H Analysis for unified approach
+      - [ ] Bounded Context Diagram (Work Tracker + KM)
+      - [ ] Domain Model Class Diagrams
+      - [ ] Use Case Specifications
+      - [ ] Sequence Diagrams
+      - [ ] BDD Test Specifications
+  - [ ] **Step 4: ps-analyst** (Trade-off Analysis)
+    - Input: Design from Step 3
+    - Output: `docs/analysis/work-034-e-004-trade-off-analysis.md`
+    - Task: SWOT, decision matrix, risk analysis for Work Tracker-first approach
+  - [ ] **Step 5: ps-architect** (ADR-034 Creation)
+    - Input: Trade-offs from Step 4
+    - Output: `docs/decisions/ADR-034-work-tracker-km-unified.md`
+    - Task: Comprehensive ADR (target ~40-50KB to match ADR-033 + WORK_TRACKER_PLAN detail)
+  - [ ] **Step 6: ps-validator** (Validation)
+    - Input: ADR from Step 5
+    - Output: `docs/validation/work-034-e-006-validation-report.md`
+    - Task: Validate against Jerry Constitution, hexagonal compliance
+- **Deliverables**:
+  - `docs/research/work-034-e-001-domain-analysis.md`
+  - `docs/synthesis/work-034-e-002-domain-synthesis.md`
+  - `docs/design/work-034-e-003-unified-design.md`
+  - `docs/analysis/work-034-e-004-trade-off-analysis.md`
+  - `docs/decisions/ADR-034-work-tracker-km-unified.md`
+  - `docs/validation/work-034-e-006-validation-report.md`
+
+### WORK-035: ADR Comparison & Direction Decision ⏳
+- **Status**: PENDING
+- **Priority**: HIGH
+- **Purpose**: Review ADR-033 vs ADR-034 and decide implementation direction
+- **Depends On**: WORK-034 (pending)
+- **Input Documents**:
+  - `docs/decisions/ADR-033-unified-km-architecture.md` (44KB) - Pure KM approach
+  - `docs/decisions/ADR-034-work-tracker-km-unified.md` (pending) - Work Tracker-first approach
+  - All supporting artifacts from WORK-033 and WORK-034
+- **Expected Output**: Very high fidelity decision document (~60-80KB)
+- **Workflow** (ps-* agent orchestration):
+  - [ ] **Step 1: ps-researcher** (Deep ADR Comparison)
+    - Input: ADR-033, ADR-034, all supporting documents
+    - Output: `docs/research/work-035-e-001-adr-comparison.md`
+    - Task: Side-by-side comparison, domain overlap, implementation complexity
+  - [ ] **Step 2: ps-synthesizer** (Synthesis of Approaches)
+    - Input: Comparison from Step 1
+    - Output: `docs/synthesis/work-035-e-002-approach-synthesis.md`
+    - Task: Synthesize pros/cons, alignment with Jerry goals, risk profiles
+  - [ ] **Step 3: ps-analyst** (Decision Analysis)
+    - Input: Synthesis from Step 2
+    - Output: `docs/analysis/work-035-e-003-decision-analysis.md`
+    - Task: Decision matrix comparing both approaches with weighted criteria
+  - [ ] **Step 4: ps-architect** (Direction Recommendation)
+    - Input: Analysis from Step 3
+    - Output: `docs/decisions/ADR-035-implementation-direction.md`
+    - Task: Final recommendation ADR with detailed rationale
+  - [ ] **Step 5: ps-validator** (Validation)
+    - Input: ADR from Step 4
+    - Output: `docs/validation/work-035-e-005-validation-report.md`
+    - Task: Validate recommendation against Jerry Constitution
+  - [ ] **USER REVIEW** - Final approval before proceeding to implementation
+- **Deliverables**:
+  - `docs/research/work-035-e-001-adr-comparison.md`
+  - `docs/synthesis/work-035-e-002-approach-synthesis.md`
+  - `docs/analysis/work-035-e-003-decision-analysis.md`
+  - `docs/decisions/ADR-035-implementation-direction.md`
+  - `docs/validation/work-035-e-005-validation-report.md`
+
+### WORK-036: KM Implementation Phase 1 ⏳ (was WORK-034)
+- **Status**: PENDING
+- **Priority**: MEDIUM
+- **Purpose**: Implement core KM functionality based on chosen direction (WORK-035)
+- **Depends On**: WORK-035 (pending)
+- **Note**: Sub-tasks will be refined based on WORK-035 direction decision
+- **Sub-tasks** (preliminary - subject to refinement):
+  - [ ] IMPL-001: RED - Write failing tests for KnowledgeItem entity
+  - [ ] IMPL-002: GREEN - Implement KnowledgeItem entity
+  - [ ] IMPL-003: RED - Write failing tests for Pattern (PAT) value object
+  - [ ] IMPL-004: GREEN - Implement Pattern value object
+  - [ ] IMPL-005: RED - Write failing tests for Lesson (LES) value object
+  - [ ] IMPL-006: GREEN - Implement Lesson value object
+  - [ ] IMPL-007: RED - Write failing tests for Assumption (ASM) value object
+  - [ ] IMPL-008: GREEN - Implement Assumption value object
+  - [ ] IMPL-009: RED - Write failing tests for KnowledgeRepository port
+  - [ ] IMPL-010: GREEN - Implement file-based KnowledgeRepository adapter
+  - [ ] IMPL-011: REFACTOR - Optimize and clean up KM domain layer
+  - [ ] IMPL-012: Integration tests for KM domain
+  - [ ] IMPL-013: Architecture tests for hexagonal compliance
+- **Deliverables**:
+  - `src/domain/knowledge/` - KM domain entities
+  - `src/infrastructure/persistence/knowledge_repository.py`
+  - `tests/unit/domain/knowledge/`
+  - `tests/integration/knowledge/`
+  - `tests/architecture/knowledge/`
+
+### WORK-037: Problem-Solving + KM Integration ⏳ (was WORK-035)
+- **Status**: PENDING
+- **Priority**: MEDIUM
+- **Purpose**: Integrate KM with problem-solving skill
+- **Depends On**: WORK-036 (pending)
+- **Sub-tasks**:
+  - [ ] INT-001: Define KM capture points in problem-solving workflow
+  - [ ] INT-002: Implement AAR (After Action Review) protocol
+  - [ ] INT-003: Implement lessons learned capture
+  - [ ] INT-004: Implement pattern detection and storage
+  - [ ] INT-005: Implement assumption tracking
+  - [ ] INT-006: Create KM-aware agent prompts
+  - [ ] INT-007: Integration tests for PS + KM
+  - [ ] INT-008: End-to-end tests for full workflow
+- **Deliverables**:
+  - Updated `skills/problem-solving/agents/*.md` with KM integration
+  - `src/application/use_cases/capture_knowledge.py`
+  - `src/application/use_cases/retrieve_knowledge.py`
+
+---
+
+## Phase BUGS
+
+> Track bugs discovered during development
+
+| ID | Title | Severity | Status | Phase Found |
+|----|-------|----------|--------|-------------|
+| (None yet) | | | | |
+
+---
+
+## Phase TECHDEBT
+
+> Track technical debt for future resolution
+
+| ID | Title | Priority | Status | Phase Found |
+|----|-------|----------|--------|-------------|
+| DEBT-001 | Consider mypy for type checking | Low | OPEN | Phase 0 |
+| DEBT-002 | Add pre-commit hooks for linting | Medium | OPEN | Phase 1 |
+| DEBT-003 | Consider pytest over unittest | Low | OPEN | Phase 0 |
+| DEBT-004 | ECW had 128+ failing tests (context isolation) | High | NOTED | Phase 2.5 |
+| DEBT-005 | Implement 26 Hard Rules as enforcement hooks | High | OPEN | Phase 2.5 |
+| DEBT-006 | Implement Three-Tier Enforcement (Soft→Medium→Hard) | High | OPEN | Phase 2.5 |
+| DEBT-007 | Add Context7 MCP integration for library docs | Medium | OPEN | Phase 2.5 |
+| DEBT-008 | Implement self-healing MAPE-K patterns | Medium | OPEN | Phase 2.5 |
+| DEBT-009 | Consider Redis Streams over file-based signals | Medium | OPEN | Phase 2.5 |
+| DEBT-010 | Add automated backup + health checks | High | OPEN | Phase 2.5 |
+
+---
+
+## Phase DISCOVERY
+
+> Track discoveries and insights for knowledge capture
+
+| ID | Title | Category | Status | Output |
+|----|-------|----------|--------|--------|
+| DISC-001 | Context rot threshold ~256k tokens | Research | CAPTURED | TECHNOLOGY_STACK_ANALYSIS.md |
+| DISC-002 | MCP has official Python SDK | Research | CAPTURED | POLYGLOT_ARCHITECTURE_ANALYSIS.md |
+| DISC-003 | Hexagonal enables polyglot adapters | Architecture | CAPTURED | POLYGLOT_ARCHITECTURE_ANALYSIS.md |
+| DISC-004 | **Small Aggregates Principle** - 70% of ARs are single entity + VOs | DDD | CAPTURED | AGGREGATE_ROOT_ANALYSIS.md |
+| DISC-005 | **Task as Primary AR** - Based on Vernon's ProjectOvation | DDD | CAPTURED | AGGREGATE_ROOT_ANALYSIS.md |
+| DISC-006 | **ECW Plan AR = Slow** - User confirmed performance issue | Performance | CAPTURED | AGGREGATE_ROOT_ANALYSIS.md |
+| DISC-007 | **ECW Phase AR = Still Slow** - User confirmed | Performance | CAPTURED | AGGREGATE_ROOT_ANALYSIS.md |
+| DISC-008 | **CloudEvents Required** - User hard requirement | Architecture | CAPTURED | User requirements |
+| DISC-009 | **Strongly Typed IDs Required** - User hard requirement | Architecture | CAPTURED | User requirements |
+| DISC-010 | ECW v3 had 108+ use cases documented | Knowledge | NOTED | glimmering-brewing-lake.md |
+| DISC-011 | **Blackboard Pattern** - 13-57% improvement over master-slave for LLM agents | Architecture | CAPTURED | ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| DISC-012 | **LES-030: Hook Subprocess Isolation** - Hooks cannot access MCP context | Constraint | CAPTURED | ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| DISC-013 | **c-015: No Recursive Subagents** - Task tool filtered at adapter level | Constraint | CAPTURED | ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| DISC-014 | **c-009: Mandatory Persistence** - All agent outputs must be files | Constraint | CAPTURED | ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| DISC-015 | **26 Hard Rules** - Behavioral gates for quality enforcement | Process | CAPTURED | hard-rules.md |
+| DISC-016 | **Three-Tier Enforcement** - Soft → Medium → Hard gates | Process | CAPTURED | sop.md |
+| DISC-017 | **MAPE-K Control Loop** - Self-healing architecture pattern | Resilience | CAPTURED | self-healing-architecture.md |
+| DISC-018 | **8 Specialized Agents** - ps-researcher, ps-analyst, ps-architect, etc. | Agents | CAPTURED | problem-solving/agents/*.md |
+| DISC-019 | **7-Step Problem-Solving Framework** - Frame → Classify → Diagnose → Ideate → Decide → Act → Verify | Process | CAPTURED | problem_solving_meta_framework.md |
+| DISC-020 | **Integration Theater Anti-Pattern** - Tests pass via mocks, real execution fails | Anti-Pattern | CAPTURED | hard-rules.md (Rules 20-22) |
+| DISC-021 | **SOP-I Implementation Standards** - BDD+TDD, test pyramid, no stubs | Process | CAPTURED | sop.md |
+| DISC-022 | **SOP-ENF Design Review** - HARD enforcement requiring approval | Process | CAPTURED | sop.md |
+| DISC-023 | **Event Schema Versioning** - Required from day 1 for CloudEvents | Architecture | CAPTURED | REVISED-ARCHITECTURE-v3.0.md |
+| DISC-024 | **Circuit Breaker Pattern** - CLOSED → HALF_OPEN → OPEN states | Resilience | CAPTURED | self-healing-guide.md |
+| DISC-025 | **Eventual Consistency Flow** - Task → Phase → Plan via domain events | Architecture | CAPTURED | ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| DISC-026 | **Property Graph Model** - Vertex/Edge abstractions for Gremlin compatibility | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-027 | **VertexId Base Class** - Strongly typed IDs extend graph primitive | DDD | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-028 | **Gremlin Traversal Patterns** - out(), in(), repeat(), tree() for graph queries | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-029 | **Events as Vertices** - CloudEvents stored as graph nodes with EMITTED edges | Event Sourcing | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-030 | **Phased Migration Path** - File → SQLite → Graph DB for persistence | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-031 | **4-Tier Progressive Enforcement** - Advisory → Soft → Medium → Hard (industry standard) | Enforcement | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-032 | **Constitutional AI** - Self-supervised alignment using principles not labeling (Anthropic) | AI Safety | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-033 | **75% Soft Enforcement** - Industry consensus favors soft over hard enforcement | Enforcement | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-034 | **Pro2Guard Framework** - Proactive runtime enforcement with probabilistic risk | Research | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-035 | **OpenAI Model Spec** - No single intervention is solution; layered defense required | AI Safety | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-036 | **DeepMind CCLs** - Critical Capability Levels for graduated risk assessment | AI Safety | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-037 | **Self-Monitoring Agents** - RLHF + self-critique for continuous alignment | AI Safety | CAPTURED | AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| DISC-038 | **VertexProperty vs EdgeProperty** - TinkerPop distinguishes: VP has meta-properties, EP is simple | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-039 | **Meta-Properties for Audit** - Properties on properties enable who/when tracking | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-040 | **Cardinality Control** - VertexProperty supports SINGLE/LIST/SET for multi-values | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-041 | **7-Step Problem-Solving** - Frame→Classify→Diagnose→Ideate→Decide→Act→Verify | Process | CAPTURED | problem_solving_meta_framework.md |
+| DISC-042 | **Cynefin Classification** - Simple/Complicated/Complex/Chaotic determines approach | Process | CAPTURED | framework_misuse_decision_tree.md |
+| DISC-043 | **Framework Misuse Anti-Pattern** - Using right framework in wrong context | Anti-Pattern | CAPTURED | framework_misuse_decision_tree.md |
+| DISC-044 | **TOON Token Reduction** - 30-60% token reduction vs JSON depending on data shape | Serialization | CAPTURED | TOON_FORMAT_ANALYSIS.md |
+| DISC-045 | **TOON Improves LLM Accuracy** - 74% accuracy vs JSON's 70% in benchmarks | Serialization | CAPTURED | TOON_FORMAT_ANALYSIS.md |
+| DISC-046 | **TOON Spec Maturity** - v3.0 with ABNF grammar, 349 test fixtures, conformance rules | Serialization | CAPTURED | TOON_FORMAT_ANALYSIS.md |
+| DISC-047 | **TOON Optimal Data Shapes** - Best for tabular arrays (40-60%), suboptimal for deep nesting | Serialization | CAPTURED | TOON_FORMAT_ANALYSIS.md |
+| DISC-048 | **TOON Python Integration** - `python-toon` package with encode/decode API, CLI tools | Serialization | CAPTURED | TOON_FORMAT_ANALYSIS.md |
+| DISC-049 | **XML-Structured Prompts** - Claude optimized for XML tags separating prompt components | Agent Design | CAPTURED | PS_AGENT_REFACTORING_STRATEGY.md |
+| DISC-050 | **Coordinator/Router Pattern** - LLM-based routing for agent selection (Google ADK, Azure) | Agent Design | CAPTURED | PS_AGENT_REFACTORING_STRATEGY.md |
+| DISC-051 | **State Management via output_key** - Google ADK pattern for sequential agent state sharing | Agent Design | CAPTURED | PS_AGENT_REFACTORING_STRATEGY.md |
+| DISC-052 | **Layered Security Defenses** - KnowBe4 5-layer defense: prompt separation, validation, filtering | Security | CAPTURED | PS_AGENT_REFACTORING_STRATEGY.md |
+| DISC-053 | **Monolith Anti-Pattern** - Single agent with many tasks degrades quality (ZenML research) | Anti-Pattern | CAPTURED | PS_AGENT_REFACTORING_STRATEGY.md |
+| DISC-054 | **IAuditable Interface** - DDD pattern for created_by/updated_by audit trail (Clean DDD) | DDD | CAPTURED | PS_EXPORT_DOMAIN_ALIGNMENT.md |
+| DISC-055 | **IVersioned Interface** - Composite version (timestamp+hash) for optimistic concurrency | DDD | CAPTURED | PS_EXPORT_DOMAIN_ALIGNMENT.md |
+| DISC-056 | **Slug Max Length** - 75 chars optimal for SEO per Backlinko (avg top-10 is 66 chars) | Constraint | CAPTURED | PS_EXPORT_DOMAIN_ALIGNMENT.md |
+| DISC-057 | **Jerry URI Scheme** - Unified multi-tenant resource naming (RFC 8141 + AWS ARN inspired) | Architecture | CAPTURED | JERRY_URI_SPECIFICATION.md |
+| DISC-058 | **LLM-as-a-Judge** - Industry standard for behavioral evaluation (DeepEval, Datadog, Anthropic) | Testing | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-059 | **G-Eval with CoT** - Custom criteria scoring using Chain-of-Thought (DeepEval) | Testing | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-060 | **OpenAI Confession Framework** - Self-compliance reporting for behavioral alignment | AI Safety | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-061 | **Anthropic SHADE-Arena** - Test suite for covert harmful behavior detection | Red Team | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-062 | **Multi-Attempt ASR** - Attack Success Rate across 1/10/100/200 attempts measures robustness | Metrics | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-063 | **Golden Datasets** - Annotated test cases with happy/edge/adversarial scenarios (Datadog) | Testing | CAPTURED | LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| DISC-064 | **Netflix UDA "Model Once, Represent Everywhere"** - Single domain model with multiple projections | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-065 | **kglab Abstraction Layer** - Unified Python API across RDF, NetworkX, Pandas, SHACL (MIT) | Libraries | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-066 | **RDF* for Edge Properties** - W3C extension to RDF supporting property graph edge attributes | Standards | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-067 | **Named-Graph-First Pattern** - Each named graph conforms to governing model in KG (Netflix) | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-068 | **Conceptual RDF, Flexible Physical** - Netflix uses RDF conceptually, not necessarily everywhere | Architecture | CAPTURED | GRAPH_DATA_MODEL_ANALYSIS.md |
+| DISC-069 | **Jerry Constitution v1.0** - Self-governing agent framework with 13 principles, 4-tier enforcement, behavioral tests | Governance | CAPTURED | JERRY_CONSTITUTION.md |
+| DISC-070 | **Skill Definition Cruft** - problem-solving/SKILL.md contains work-tracker content (1723 lines, wrong frontmatter name) | Bug | CAPTURED | WORK-030 |
+
+---
+
+## Session Context (for compaction survival)
+
+### Critical Information
+- **Branch**: `claude/create-code-plugin-skill-MG1nh`
+- **Framework**: Jerry - behavior/workflow guardrails with knowledge accrual
+- **First Skill**: Work Tracker (local Azure DevOps/JIRA)
+- **Architecture**: Hexagonal (Ports & Adapters) with DDD, Event Sourcing, CQRS
+- **Language**: Python 3.11+ (zero-dependency core where possible)
+
+### Key Decisions Made (Updated)
+1. Python over TypeScript for core (evidence: stdlib completeness)
+2. SQLite for persistence (stdlib, no external deps)
+3. TypeScript reserved for network adapters if needed
+4. BDD approach with Red/Green/Refactor cycle
+5. All tests must be real, no stubs/mocks for assertions
+6. **Task as Primary Aggregate Root** (Vernon's small aggregates)
+7. **Phase and Plan as Secondary ARs** (eventual consistency)
+8. **CloudEvents 1.0 for all events** (user requirement)
+9. **Strongly typed identity objects** (user requirement)
+10. **Property Graph Data Model** - Vertex/Edge abstractions for Gremlin compatibility
+11. **VertexId as base class** - All strongly typed IDs extend VertexId
+12. **Phased Migration Path** - File → SQLite → Graph DB
+13. **NEW: VertexProperty + EdgeProperty** - Separate property classes per TinkerPop (meta-property support)
+14. **NEW: 7-Step Problem-Solving** - ps-* agents align with Frame→Classify→Diagnose→Ideate→Decide→Act→Verify
+15. **NEW: Dual Serialization (JSON + TOON)** - JSON for persistence/API, TOON for LLM prompts (30-60% token savings)
+
+### Hard Requirements (From User)
+1. CloudEvents for event schema
+2. CloudEvents for persisting/transporting events
+3. Multiple Aggregate Roots (2-3) for large work trackers
+4. Strongly typed identity objects (not raw UUID/GUID)
+5. Must run in Claude Code Web Research Preview
+6. **Graph-ready data model** - Preparation for Gremlin/graph database
+7. **TOON + JSON serialization** - Domain entities must persist to both formats (cost optimization for LLM)
+
+### Next Actions
+1. ✅ ~~Update PLAN.md with revised aggregate root design~~
+2. ✅ ~~Research Gremlin data model for graph-readiness~~
+3. ✅ ~~Create GRAPH_DATA_MODEL_ANALYSIS.md~~
+4. ✅ ~~Research agent behavior enforcement best practices~~
+5. ✅ ~~Create Agent Reorganization Plan~~
+6. ✅ ~~Create Jerry Constitution v1.0~~ (WORK-021 complete)
+7. ✅ ~~Refactor ps-*.md agents~~ (WORK-022 complete)
+8. ✅ ~~Refactor problem-solving/SKILL.md~~ (WORK-030 complete)
+9. Phase 3 Hexagonal Core ready to resume
+
+---
+
+## Document History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-07 | Claude | Initial creation with Phases 0-3 |
+| 2026-01-07 | Claude | Added Phase 2.5: Deep Analysis |
+| 2026-01-07 | Claude | Revised Phase 3 based on aggregate root research |
+| 2026-01-07 | Claude | Added DISC-004 through DISC-010 |
+| 2026-01-07 | Claude | Updated Key Decisions with new findings |
+| 2026-01-07 | Claude | **MAJOR: Deep analysis of 60+ ECW artifacts** |
+| 2026-01-07 | Claude | Added DISC-011 through DISC-025 (15 new discoveries) |
+| 2026-01-07 | Claude | Added DEBT-005 through DEBT-010 (6 new tech debt items) |
+| 2026-01-07 | Claude | Created ECW_COMPREHENSIVE_LESSONS_LEARNED.md |
+| 2026-01-07 | Claude | **MAJOR: Graph data model research (Gremlin/TinkerPop)** |
+| 2026-01-07 | Claude | Added DISC-026 through DISC-030 (5 graph discoveries) |
+| 2026-01-07 | Claude | Added WORK-018: Graph Data Model Research |
+| 2026-01-07 | Claude | Completed WORK-010: Design & Planning |
+| 2026-01-07 | Claude | Updated Key Decisions with graph model decisions |
+| 2026-01-08 | Claude | **MAJOR: Agent Behavior Enforcement Research** |
+| 2026-01-08 | Claude | Added Phase 3.5: Agent Reorganization (new priority) |
+| 2026-01-08 | Claude | Created AGENT_REORGANIZATION_PLAN.md |
+| 2026-01-08 | Claude | Created AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| 2026-01-08 | Claude | Added DISC-031 through DISC-037 (7 enforcement discoveries) |
+| 2026-01-08 | Claude | Added WORK-019 through WORK-024 (agent reorganization tasks) |
+| 2026-01-08 | Claude | Paused Phase 3 Hexagonal Core for agent work |
+| 2026-01-08 | Claude | **USER FEEDBACK: VertexProperty vs EdgeProperty investigation** |
+| 2026-01-08 | Claude | Added Section 2.4 to GRAPH_DATA_MODEL_ANALYSIS.md |
+| 2026-01-08 | Claude | Added DISC-038 through DISC-043 (6 new discoveries) |
+| 2026-01-08 | Claude | Updated Key Decisions with VertexProperty + 7-Step Problem-Solving |
+| 2026-01-08 | Claude | **USER REQUIREMENT: TOON format for domain serialization** |
+| 2026-01-08 | Claude | Created TOON_FORMAT_ANALYSIS.md (comprehensive research) |
+| 2026-01-08 | Claude | Added DISC-044 through DISC-048 (5 TOON discoveries with L0/L1/L2) |
+| 2026-01-08 | Claude | Completed WORK-025: TOON Format Research |
+| 2026-01-08 | Claude | Updated Hard Requirements with TOON + JSON serialization |
+| 2026-01-08 | Claude | Added Key Decision 15: Dual Serialization Strategy |
+| 2026-01-08 | Claude | **RESEARCH: PS Agent Refactoring Strategy** |
+| 2026-01-08 | Claude | Created PS_AGENT_REFACTORING_STRATEGY.md with L0/L1/L2 levels |
+| 2026-01-08 | Claude | Added DISC-049 through DISC-053 (5 agent design discoveries) |
+| 2026-01-08 | Claude | Industry citations: Google ADK, Microsoft Azure, KnowBe4, Anthropic |
+| 2026-01-08 | Claude | Completed WORK-027: Jerry URI Scheme Specification (SPEC-001) |
+| 2026-01-08 | Claude | Updated PROP-001 v1.2 with uri property in EntityBase |
+| 2026-01-08 | Claude | Updated GRAPH_DATA_MODEL_ANALYSIS.md v1.1 with URI integration |
+| 2026-01-08 | Claude | **RESEARCH: LLM Behavioral Governance Testing** |
+| 2026-01-08 | Claude | Created LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md |
+| 2026-01-08 | Claude | Added DISC-058 through DISC-063 (6 testing discoveries) |
+| 2026-01-08 | Claude | Validated behavioral testing approach against industry (Anthropic, OpenAI, Datadog, DeepEval) |
+| 2026-01-08 | Claude | **RESEARCH: Graph Data Model AN.Q Feedback** |
+| 2026-01-08 | Claude | Updated GRAPH_DATA_MODEL_ANALYSIS.md v1.2 with AN.Q responses |
+| 2026-01-08 | Claude | Added Python graph libraries analysis (kglab, RDFLib, NetworkX) |
+| 2026-01-08 | Claude | Added RDF/OWL alignment strategy and Netflix UDA insights |
+| 2026-01-08 | Claude | Added DISC-064 through DISC-068 (5 graph/KG discoveries) |
+| 2026-01-08 | Claude | **MAJOR: Completed Jerry Constitution v1.0 (WORK-021)** |
+| 2026-01-08 | Claude | Created docs/governance/JERRY_CONSTITUTION.md (13 principles, 5 articles) |
+| 2026-01-08 | Claude | Created docs/governance/BEHAVIOR_TESTS.md (14 test scenarios) |
+| 2026-01-08 | Claude | Created .claude/agents/TEMPLATE.md (constitution-compliant agent template) |
+| 2026-01-08 | Claude | Updated CLAUDE.md with Agent Governance section |
+| 2026-01-08 | Claude | Added DISC-069 (Jerry Constitution) |
+| 2026-01-08 | Claude | **WORK-022 Progress**: Refactored ps-researcher, ps-analyst, ps-architect to v2.0.0 |
+| 2026-01-08 | Claude | Created PS_AGENT_TEMPLATE.md v2.0 (unified agent template) |
+| 2026-01-08 | Claude | Added WORK-030: Refactor problem-solving/SKILL.md |
+| 2026-01-08 | Claude | Added DISC-070 (SKILL.md cruft - work-tracker content in problem-solving) |
+| 2026-01-08 | Claude | **WORK-022 COMPLETED**: Refactored remaining 5 agents (ps-validator, ps-synthesizer, ps-reviewer, ps-investigator, ps-reporter) to v2.0.0 |
+| 2026-01-08 | Claude | **WORK-030 Progress**: Replaced 1722-line cruft SKILL.md with clean 265-line problem-solving skill definition |
+| 2026-01-08 | Claude | **WORK-030 COMPLETED**: Created PLAYBOOK.md (user guide) and ORCHESTRATION.md (technical docs) |

--- a/docs/archive/projects-archive/analysis/work-031-e-007-trade-off-analysis.md
+++ b/docs/archive/projects-archive/analysis/work-031-e-007-trade-off-analysis.md
@@ -1,0 +1,820 @@
+# WORK-031 Trade-off Analysis: Knowledge Architecture
+
+> **Analysis ID:** work-031-e-007
+> **Date:** 2026-01-08
+> **Method:** ATAM-inspired Quality Attribute Trade-off Analysis
+> **Agent:** ps-analyst (v2.0.0)
+> **Source:** docs/synthesis/work-031-e-006-synthesis.md
+> **Status:** DECISION-READY
+
+---
+
+## L0: Executive Summary (ELI5)
+
+### What This Analysis Covers
+
+This document evaluates the **trade-offs, risks, and strategic decisions** for Jerry's proposed hybrid knowledge architecture. Think of it as the "pros and cons list" for different ways Jerry could store and retrieve knowledge.
+
+### The Central Question
+
+Jerry needs to evolve from simple file storage to a sophisticated knowledge system that helps Claude Code agents avoid hallucinations and make better decisions. But which architectural approach should Jerry choose?
+
+### The Short Answer: Hybrid Wins, But With Caveats
+
+After analyzing strengths, weaknesses, opportunities, threats, quality attributes, and risks, the **Hybrid Property + RDF architecture emerges as the clear winner** with a score of **22/25** (88%). Here's why:
+
+**The Good News:**
+- Builds on what Jerry already has (property graph foundation)
+- Delivers 90% hallucination reduction through GraphRAG (proven in production)
+- Maintains fast performance while adding standards compliance incrementally
+- No vendor lock-in—can export to any RDF-compatible system
+- Incremental adoption means each phase delivers value independently
+
+**The Bad News:**
+- More complex than property graph alone (multiple representations to maintain)
+- Requires learning semantic web technologies (JSON-LD, RDF, SPARQL)
+- High risk of "supernode" performance problems if not careful (especially for Actor vertex)
+- Could become over-engineered if Jerry never needs advanced capabilities
+
+**The Bottom Line:**
+Proceed with hybrid architecture, but implement in phases with clear "go/no-go" gates. Don't build Phase 3-4 capabilities until Phase 2 proves valuable. Watch out for Actor vertex becoming a supernode.
+
+---
+
+## L1: Technical Analysis
+
+### SWOT Analysis: Hybrid Property Graph + RDF Architecture
+
+#### Strengths (Internal Advantages)
+
+1. **Leverages Existing Foundation**
+   - Jerry already has property graph abstractions (Vertex, Edge, VertexProperty) ✅
+   - Phase 1 complete—no need to throw away existing work
+   - Work Tracker provides real graph data for testing
+
+2. **Multi-Representation Flexibility (Netflix UDA Pattern)**
+   - Single domain model → multiple serializations (JSON, JSON-LD, RDF, TOON)
+   - Add new formats without changing business logic
+   - No representation lock-in
+
+3. **Performance-First Design**
+   - Property graph as primary storage (fast traversals)
+   - RDF serialization as export layer (no hot-path overhead)
+   - Embedded databases for zero infrastructure costs
+
+4. **Standards Compliance via Export**
+   - RDF-compatible without RDF end-to-end
+   - Jerry URI scheme already follows RDF conventions
+   - Can integrate with Schema.org ecosystem (45M+ websites)
+
+5. **Incremental Risk Mitigation**
+   - Each phase delivers value independently
+   - Can stop at Phase 2 if advanced features not needed
+   - Reversibility high in early phases (JSON-LD optional)
+
+6. **Production Validation**
+   - Netflix UDA pattern deployed at scale
+   - GraphRAG proven in production (FalkorDB, LinkedIn, Amazon)
+   - JSON-LD has 70% web adoption
+
+#### Weaknesses (Internal Disadvantages)
+
+1. **Architectural Complexity**
+   - Multiple representation formats to maintain
+   - Serialization adapters for each format (JSON, JSON-LD, Turtle, GraphSON, TOON)
+   - More code surface area = more bugs
+
+2. **Synchronization Challenges**
+   - Property graph and RDF representations must stay consistent
+   - Changes require updates across multiple serializers
+   - Test matrix explodes (property graph tests + RDF tests + JSON-LD tests)
+
+3. **Learning Curve**
+   - Semantic web technologies unfamiliar (SPARQL, SHACL, OWL)
+   - RDF tooling ecosystem less mature than property graph
+   - Steep ramp-up for contributors
+
+4. **Dependency Expansion**
+   - pyoxigraph (RDF storage)
+   - Embedding models (vector RAG)
+   - Potentially MiniCheck (grounding verification)
+   - Goes against Jerry's zero-dependency principle for domain layer
+
+5. **Multi-Layer Validation Overhead**
+   - Schema validation (property graph)
+   - SHACL constraints (RDF)
+   - Supernode detection (performance)
+   - Grounding verification (LLM accuracy)
+   - Each layer adds latency
+
+6. **Premature Optimization Risk**
+   - Building for scale Jerry may never need
+   - Phase 3-4 capabilities (SPARQL, reasoning, server-based) might never be used
+   - Time invested in semantic infrastructure vs domain features
+
+#### Opportunities (External Factors to Leverage)
+
+1. **LLM Grounding as Killer App**
+   - 90% hallucination reduction (FalkorDB case study)
+   - 63% faster ticket resolution (LinkedIn: 40hrs → 15hrs)
+   - 49% → 86% accuracy improvement (Amazon Finance)
+   - **This is strategic differentiation, not just technical infrastructure**
+
+2. **Semantic Web Pragmatic Turn (2024-2025)**
+   - JSON-LD at 70% web adoption (vs 3% RDFa, 46% Microdata)
+   - Modern tooling (Oxigraph in Rust/Python, not Java)
+   - Industry shift from "academic curiosity" to "production-ready"
+
+3. **Schema.org Ecosystem Integration**
+   - 45M+ websites use Schema.org
+   - Google Knowledge Graph integration potential
+   - Interoperability with external systems without custom APIs
+
+4. **5-Star Linked Open Data Status**
+   - Jerry at 4 stars (URIs to denote things)
+   - 5th star = link data to other data (JSON-LD + Schema.org)
+   - Enables ecosystem participation
+
+5. **Knowledge Architecture as Competitive Moat**
+   - Few AI agent frameworks have sophisticated knowledge systems
+   - GraphRAG provides measurable ROI (300-320% in case studies)
+   - Accumulated knowledge becomes durable asset
+
+6. **Emerging Standards Momentum**
+   - RDF 1.2 (RDF* for edge properties without reification)
+   - SPARQL 1.2 (improved performance)
+   - JSON-LD becoming de facto web standard
+
+#### Threats (External Risks)
+
+1. **Technology Churn in Semantic Web**
+   - Standards still evolving (RDF 1.2, SPARQL 1.2)
+   - Tool fragmentation (RDFLib, Oxigraph, Jena)
+   - Risk of backing wrong technology horse
+
+2. **Supernode Performance Degradation**
+   - Actor vertex HIGH risk (Claude could create thousands of tasks)
+   - Graph traversals become O(n) where n = edge count
+   - Catastrophic performance failure if not prevented
+   - **This is Jerry's #1 architectural threat per synthesis document**
+
+3. **Vendor Lock-In at Phase 4**
+   - Server-based migration (Neptune, Fuseki) creates dependencies
+   - Cloud costs escalate with scale
+   - Difficult to reverse once migrated
+
+4. **Limited Python Ecosystem for Semantic Web**
+   - RDFLib slower than Java-based Jena
+   - Fewer SPARQL endpoint options than Java/JVM
+   - May hit tooling limitations in Phase 3
+
+5. **Complexity Slowing Development Velocity**
+   - Time spent on knowledge infrastructure vs domain features
+   - Contributor onboarding harder with semantic web prereqs
+   - Risk of over-engineering
+
+6. **LLM Grounding ROI Unproven for Jerry's Use Case**
+   - Case studies are for enterprise (LinkedIn, Amazon)
+   - Jerry is single-user, not high-volume ticket system
+   - 90% hallucination reduction may not matter if baseline is already low
+
+---
+
+### Quality Attribute Trade-offs (ATAM-Style)
+
+#### Trade-off 1: Performance vs Semantic Richness
+
+**Scenario:** Agent queries Work Tracker for "What tasks block TASK-042?"
+
+| Approach | Query Time | Semantic Capabilities | Analysis |
+|----------|------------|----------------------|----------|
+| **Property Graph** | 5-10ms (O(1) edge traversal) | Implicit schema, no reasoning | Fast but limited to explicit relationships |
+| **RDF/SPARQL** | 50-500ms (depends on triple count, optimizer) | Explicit ontology, OWL reasoning, inference | Slower but can infer implicit relationships |
+| **Hybrid** | 5-10ms (property graph primary) + on-demand RDF export | Fast queries + semantic export when needed | Best of both: optimize hot path, export for integration |
+
+**Trade-off Resolution:**
+- **Hot path** (operational queries): Use property graph + Gremlin (fast)
+- **Cold path** (export, integration): Use RDF serialization (standards-compliant)
+- **Result:** 90% of queries use fast path, 10% use semantic export
+
+**Sensitivity Point:** If SPARQL queries become > 10% of workload, may need server-based triple store.
+
+**Risk:** Property graph queries tightly coupled to schema; changes break traversals.
+
+---
+
+#### Trade-off 2: Simplicity vs Extensibility
+
+**Scenario:** Jerry needs to add new entity type (e.g., Decision, Experiment)
+
+| Approach | Initial Complexity | Extension Complexity | Long-term Maintainability |
+|----------|-------------------|---------------------|---------------------------|
+| **Simple (Property Graph + JSON)** | Low (1 class, 1 serializer) | Low (add properties ad-hoc) | Medium (implicit schema, drift risk) |
+| **Extensible (Hybrid + RDF + Ontology)** | High (1 class, 5 serializers, SHACL shapes) | Medium (explicit ontology, validation) | High (explicit contracts, versioning) |
+
+**Trade-off Resolution:**
+- **Phase 1-2**: Accept higher initial complexity for future extensibility
+- **Rationale**: Jerry is evolving system; explicit schema prevents drift
+- **Mechanism**: Netflix UDA pattern—model once, represent everywhere
+
+**Sensitivity Point:** If entity types stabilize, semantic layer overhead may not be worth it.
+
+**Risk:** Over-engineering for extensibility Jerry never needs.
+
+---
+
+#### Trade-off 3: Embedded vs Server-Based Deployment
+
+**Scenario:** Jerry scales from 1,000 entities to 10M+ entities
+
+| Approach | Setup Complexity | Performance | Cost | Scale Limit |
+|----------|-----------------|-------------|------|-------------|
+| **Embedded (pyoxigraph, SQLite)** | Low (pip install) | High (in-process) | $0 infrastructure | 10M triples, single-user |
+| **Server-Based (Fuseki, Neptune)** | High (infrastructure, monitoring) | Medium (network overhead) | $100-1000/month | Unlimited, multi-tenant |
+
+**Trade-off Resolution:**
+- **Phase 1-3**: Embedded (Jerry single-user, < 10M entities expected)
+- **Phase 4**: Server-based only if thresholds crossed:
+  - Multi-user access required
+  - > 10M entities
+  - Clustering/HA needed
+
+**Sensitivity Point:** If Jerry becomes SaaS offering, server-based required earlier.
+
+**Risk:** Premature Phase 4 migration wastes effort; waiting too long causes performance crisis.
+
+---
+
+#### Trade-off 4: Standards Compliance vs Implementation Speed
+
+**Scenario:** Ship Jerry Phase 2 with semantic capabilities
+
+| Approach | Time to Ship | Interoperability | Maintenance Burden |
+|----------|-------------|------------------|-------------------|
+| **Custom (Jerry-specific formats)** | 2-4 weeks (fast) | Low (Jerry-only) | High (proprietary) |
+| **Standards (RDF, JSON-LD, SPARQL)** | 8-12 weeks (learning curve) | High (W3C specs) | Medium (community tools) |
+| **Hybrid (Custom + Standards Export)** | 6-8 weeks (moderate) | High (standards export) | Medium (adapters needed) |
+
+**Trade-off Resolution:**
+- **Optimize for:** Implementation speed in hot path + standards in cold path
+- **Strategy:** Property graph for speed, RDF export for interoperability
+- **Netflix UDA:** "Conceptual RDF, Flexible Physical"
+
+**Sensitivity Point:** If external integration becomes primary use case, full RDF-first may be better.
+
+**Risk:** Adapter layer becomes maintenance burden if formats diverge.
+
+---
+
+### Decision Matrix: Architectural Options
+
+Scoring each option on 1-5 scale (1=poor, 5=excellent):
+
+| Option | Performance | Maintainability | Scalability | Cost | Standards | **Total** |
+|--------|-------------|-----------------|-------------|------|-----------|-----------|
+| **Property Graph Only** | 5 (fast traversals) | 4 (simple) | 3 (scale limits) | 5 (embedded) | 1 (proprietary) | **18/25 (72%)** |
+| **RDF/Semantic Only** | 2 (slow SPARQL) | 2 (complex) | 4 (scales well) | 3 (infrastructure) | 5 (W3C specs) | **16/25 (64%)** |
+| **Hybrid Property + RDF** ⭐ | 5 (PG primary) | 3 (adapters) | 4 (incremental) | 5 (embedded) | 5 (RDF export) | **22/25 (88%)** |
+| **Vector DB Only** | 4 (semantic search) | 3 (embeddings) | 4 (scales well) | 3 (infrastructure) | 2 (limited) | **16/25 (64%)** |
+| **HybridRAG (Vector + Graph)** | 4 (balanced) | 2 (complex) | 4 (scales well) | 4 (embedded vector) | 4 (JSON-LD) | **18/25 (72%)** |
+
+#### Scoring Justifications
+
+##### Performance (1=slow, 5=fast)
+
+- **Property Graph Only: 5** — O(1) edge traversals, in-memory operations, no serialization overhead
+- **RDF/Semantic Only: 2** — SPARQL query optimization challenging, triple store lookups slower than pointer-chasing
+- **Hybrid Property + RDF: 5** — Hot path uses property graph (fast), cold path uses RDF export (doesn't affect performance)
+- **Vector DB Only: 4** — Fast cosine similarity, but can't answer relational queries ("what blocks this task?")
+- **HybridRAG: 4** — Combines vector (fast) + graph (moderate), requires merging results
+
+##### Maintainability (1=complex, 5=simple)
+
+- **Property Graph Only: 4** — Single representation, straightforward code, but implicit schema risks drift
+- **RDF/Semantic Only: 2** — SPARQL queries brittle, ontology evolution complex, semantic web learning curve
+- **Hybrid Property + RDF: 3** — Multiple serializers to maintain, adapter layer, synchronization concerns
+- **Vector DB Only: 3** — Embedding pipeline, index updates, dimension management, chunk boundaries
+- **HybridRAG: 2** — Most complex: property graph + RDF + vector embeddings + context merger
+
+##### Scalability (1=limited, 5=unlimited)
+
+- **Property Graph Only: 3** — Embedded file storage limits at ~10M entities, no clustering
+- **RDF/Semantic Only: 4** — Triple stores designed for billions of triples, server-based clustering
+- **Hybrid Property + RDF: 4** — Embedded Phase 1-3, migrate to server Phase 4 if needed
+- **Vector DB Only: 4** — Vector databases scale horizontally (Pinecone, Weaviate, etc.)
+- **HybridRAG: 4** — Both graph and vector components scale independently
+
+##### Cost (1=expensive, 5=cheap)
+
+- **Property Graph Only: 5** — $0 infrastructure, embedded storage, no dependencies
+- **RDF/Semantic Only: 3** — Server-based triple store requires infrastructure ($100-1000/month cloud)
+- **Hybrid Property + RDF: 5** — Embedded Phase 1-3 ($0), defer server costs to Phase 4
+- **Vector DB Only: 3** — Cloud vector DBs expensive (Pinecone $70-700/month), embeddings API costs
+- **HybridRAG: 4** — Embedded vector storage possible (FAISS, ChromaDB), lower cost than cloud
+
+##### Standards Compliance (1=proprietary, 5=standards-compliant)
+
+- **Property Graph Only: 1** — Gremlin is Apache standard but property graph schema is Jerry-specific
+- **RDF/Semantic Only: 5** — Full W3C compliance (RDF, SPARQL, OWL), maximum interoperability
+- **Hybrid Property + RDF: 5** — RDF export provides W3C compliance, JSON-LD for web integration
+- **Vector DB Only: 2** — No standard for vector databases (proprietary formats)
+- **HybridRAG: 4** — JSON-LD provides standards compliance, but vector layer proprietary
+
+#### Decision Matrix Insights
+
+1. **Hybrid Property + RDF is clear winner (22/25, 88%)**
+   - Highest performance (property graph primary)
+   - Highest standards compliance (RDF export)
+   - Lowest cost (embedded)
+   - Scalability good enough for Jerry's expected workload
+
+2. **Property Graph Only is strong second (18/25, 72%)**
+   - Simpler to maintain
+   - Best performance
+   - But lacks interoperability and future extensibility
+
+3. **RDF/Semantic Only is weakest (16/25, 64%)**
+   - Poor performance
+   - High complexity
+   - Only advantage is standards compliance, which hybrid also provides
+
+4. **HybridRAG is strategic but complex (18/25, 72%)**
+   - Provides LLM grounding capabilities (90% hallucination reduction)
+   - But highest maintenance complexity (2/5)
+   - Best deployed as **enhancement to Hybrid Property + RDF** rather than standalone
+
+**Strategic Recommendation:** Implement **Hybrid Property + RDF** in Phase 2, add **HybridRAG** in Phase 3 as enhancement layer.
+
+---
+
+## L2: Strategic Recommendations
+
+### Risk Analysis
+
+#### Risk 1: Supernode Performance Degradation (Actor Vertex)
+
+**Description:** Actor vertex (representing Claude) could accumulate thousands of edges as it creates tasks, leading to catastrophic O(n) traversal performance.
+
+**Probability:** HIGH (synthesis document rates Actor as HIGH risk)
+
+**Impact:** HIGH (performance degradation affects all agents, user experience)
+
+**Risk Score:** 9/9 (Critical)
+
+**Mitigation Strategies:**
+
+1. **Preventive:** Implement edge count monitoring
+   ```python
+   class SupernodeValidator:
+       WARN_THRESHOLD = 100
+       ERROR_THRESHOLD = 1000
+
+       def validate_vertex_degree(self, vertex_id, edge_label, edge_count):
+           if edge_count >= ERROR_THRESHOLD:
+               raise SupernodeError(f"Vertex {vertex_id} has {edge_count} edges")
+           elif edge_count >= WARN_THRESHOLD:
+               log.warning(f"Vertex {vertex_id} approaching supernode ({edge_count} edges)")
+   ```
+
+2. **Temporal Partitioning:** Use time-based edge labels
+   - Bad: `CREATED_BY` (generic)
+   - Good: `CREATED_BY_2026_01` (time-partitioned)
+
+3. **Hierarchical Decomposition:** Create intermediate Actor nodes
+   - `Actor:Claude` → `Actor:Claude:Session:2026-01-08` → Tasks
+
+4. **Monitoring:** Add CloudEvent on edge count warnings
+   - Alert when Actor vertex hits 80 edges (80% of WARN_THRESHOLD)
+   - Dashboard showing vertex degree distribution
+
+**Validation:** Test with 10,000 synthetic tasks to verify mitigation effectiveness.
+
+**Residual Risk:** LOW (if mitigations implemented in Phase 2)
+
+---
+
+#### Risk 2: Complexity Overhead Slowing Development Velocity
+
+**Description:** Multi-representation architecture (property graph + RDF + JSON-LD + TOON + GraphSON) creates maintenance burden, slowing feature development.
+
+**Probability:** MEDIUM (synthesis shows 5 serializers needed)
+
+**Impact:** MEDIUM (slower velocity, but not catastrophic)
+
+**Risk Score:** 4/9 (Moderate)
+
+**Mitigation Strategies:**
+
+1. **Netflix UDA Pattern Enforcement:**
+   - Single domain model (EntityBase)
+   - Serializers as pure functions (no business logic)
+   - Test serializers independently
+
+2. **Automated Serializer Testing:**
+   ```python
+   @pytest.mark.parametrize("serializer", [
+       JsonSerializer, ToonSerializer, JsonLdSerializer, RdfSerializer, GraphSonSerializer
+   ])
+   def test_round_trip(serializer):
+       task = Task(title="Test")
+       serialized = serializer.serialize(task)
+       deserialized = serializer.deserialize(serialized)
+       assert task == deserialized
+   ```
+
+3. **Defer Complex Serializers to Phase 3:**
+   - Phase 2: JSON, TOON, JSON-LD (essential)
+   - Phase 3: Turtle, GraphSON (optional)
+
+4. **Contributor Documentation:**
+   - Create `docs/contributing/SERIALIZATION_GUIDE.md`
+   - Clear examples of adding new entity types
+   - Explain Netflix UDA pattern
+
+**Validation:** Track time-to-implement for new entity types (target: < 2 hours including all serializers).
+
+**Residual Risk:** MEDIUM (complexity inherent to multi-representation architecture)
+
+---
+
+#### Risk 3: Premature Phase 4 Migration (Server-Based Infrastructure)
+
+**Description:** Migrating to server-based triple store (Fuseki, Neptune) before necessary, incurring infrastructure costs and operational overhead.
+
+**Probability:** LOW (Phase 4 clearly marked as "if scale demands")
+
+**Impact:** HIGH (monthly costs $100-1000, migration effort weeks)
+
+**Risk Score:** 3/9 (Low-Moderate)
+
+**Mitigation Strategies:**
+
+1. **Explicit Trigger Conditions (Assumptions ASM-001, ASM-002):**
+   - Trigger 1: Multi-user access required
+   - Trigger 2: > 10M entities
+   - Trigger 3: Clustering/HA required
+   - **Do NOT migrate unless one trigger condition met**
+
+2. **Quantitative Monitoring:**
+   - Track entity count (alert at 8M = 80% of 10M threshold)
+   - Track query latency (alert if P95 > 500ms)
+   - Track concurrent users (alert if > 1)
+
+3. **Phase 4 Evaluation Checklist:**
+   ```markdown
+   ## Phase 4 Migration Checklist
+
+   Only proceed if answering YES to one or more:
+   - [ ] Multi-tenant SaaS offering planned?
+   - [ ] > 8M entities in production?
+   - [ ] P95 query latency > 500ms?
+   - [ ] Clustering/HA required for uptime SLA?
+
+   If all NO, remain on embedded Phase 2-3 architecture.
+   ```
+
+4. **Budget Approval Gate:**
+   - Phase 4 requires explicit user approval for infrastructure costs
+   - Cost-benefit analysis: cloud costs vs performance gains
+
+**Validation:** Review trigger conditions quarterly in Work Tracker.
+
+**Residual Risk:** LOW (clear gates prevent premature migration)
+
+---
+
+#### Risk 4: Schema Evolution Breaking Graph Traversals
+
+**Description:** Changes to graph schema (vertex types, edge labels, property names) break existing Gremlin queries and agent traversal logic.
+
+**Probability:** MEDIUM (Jerry is evolving system, schema changes inevitable)
+
+**Impact:** HIGH (breaks agent functionality, requires code updates across system)
+
+**Risk Score:** 6/9 (Moderate-High)
+
+**Mitigation Strategies:**
+
+1. **Schema Versioning:**
+   ```python
+   class SchemaVersion:
+       CURRENT = "v2.0.0"  # Semantic versioning
+
+       def validate_compatibility(self, entity_version: str) -> bool:
+           # Major version changes break compatibility
+           return entity_version.split('.')[0] == self.CURRENT.split('.')[0]
+   ```
+
+2. **Forward Migration Scripts:**
+   ```python
+   # migrations/001_add_blocking_reason.py
+   def migrate(graph: Graph):
+       for task in graph.V().hasLabel('Task'):
+           if not task.has('blocking_reason'):
+               task.property('blocking_reason', None)
+   ```
+
+3. **Rollback Migration Scripts:**
+   ```python
+   # migrations/001_add_blocking_reason_rollback.py
+   def rollback(graph: Graph):
+       for task in graph.V().hasLabel('Task'):
+           task.properties('blocking_reason').drop()
+   ```
+
+4. **Schema Changelog (Constitutional Requirement P-030):**
+   - Document all schema changes in `docs/specifications/SCHEMA_CHANGELOG.md`
+   - Require migration script for each breaking change
+   - Require rollback script for reversibility
+
+5. **Integration Tests for Traversals:**
+   ```python
+   def test_blocking_tasks_traversal():
+       # Ensure traversal works across schema versions
+       blocked_tasks = g.V(task_id).out('BLOCKS').toList()
+       assert len(blocked_tasks) > 0
+   ```
+
+**Validation:** All schema changes pass compatibility test suite before deployment.
+
+**Residual Risk:** MEDIUM (can't eliminate schema evolution, but can manage it)
+
+---
+
+#### Risk 5: LLM Grounding Verification False Positives
+
+**Description:** MiniCheck grounding verification incorrectly flags factually correct responses as "not supported," causing agent warnings and user confusion.
+
+**Probability:** MEDIUM (grounding models have error rates)
+
+**Impact:** LOW (warnings logged, but doesn't break functionality)
+
+**Risk Score:** 2/9 (Low)
+
+**Mitigation Strategies:**
+
+1. **Confidence Threshold Tuning:**
+   ```python
+   class GroundingVerifier:
+       CONFIDENCE_THRESHOLD = 0.7  # Tune based on false positive rate
+
+       def verify(self, claim: str, context: str) -> GroundingResult:
+           score = self.minicheck.check(claim, context)
+           if score < self.CONFIDENCE_THRESHOLD:
+               return GroundingResult.NOT_SUPPORTED
+           return GroundingResult.SUPPORTED
+   ```
+
+2. **Soft Warnings (Non-Blocking):**
+   - Emit CloudEvent warning, don't block response
+   - User can review and override if needed
+   - Log for analysis, not enforcement
+
+3. **Grounding Verification as Phase 3 (Optional):**
+   - Defer to Phase 3 when MiniCheck models mature
+   - Phase 2 uses simpler Jerry URI citation without verification
+
+4. **User Feedback Loop:**
+   - Allow users to mark false positives
+   - Retrain threshold based on feedback
+   - Track precision/recall metrics
+
+**Validation:** Measure false positive rate on golden dataset (target: < 5%).
+
+**Residual Risk:** LOW (soft warnings, not hard failures)
+
+---
+
+### Risk Summary Table
+
+| Risk ID | Risk Description | Probability | Impact | Score | Mitigation Quality | Residual Risk |
+|---------|-----------------|-------------|--------|-------|-------------------|---------------|
+| **RISK-1** | Supernode degradation (Actor vertex) | HIGH | HIGH | 9/9 | Strong (monitoring, partitioning) | LOW |
+| **RISK-2** | Complexity slowing development | MEDIUM | MEDIUM | 4/9 | Moderate (testing, documentation) | MEDIUM |
+| **RISK-3** | Premature Phase 4 migration | LOW | HIGH | 3/9 | Strong (gates, monitoring) | LOW |
+| **RISK-4** | Schema evolution breaking traversals | MEDIUM | HIGH | 6/9 | Strong (versioning, migrations) | MEDIUM |
+| **RISK-5** | Grounding verification false positives | MEDIUM | LOW | 2/9 | Moderate (soft warnings) | LOW |
+
+**Overall Risk Profile:** MODERATE (most high-impact risks have strong mitigations)
+
+---
+
+### Final Recommendation
+
+#### Primary Recommendation: Proceed with Hybrid Property + RDF Architecture
+
+**Decision:** Implement Phase 2 hybrid architecture as planned in synthesis document.
+
+**Evidence Supporting Decision:**
+
+1. **Quantitative:**
+   - Decision matrix score: 22/25 (88%)—highest of all options
+   - Production validation: 90% hallucination reduction (FalkorDB), 63% faster resolution (LinkedIn)
+   - Standards adoption: 70% JSON-LD adoption, 45M+ Schema.org websites
+
+2. **Qualitative:**
+   - Unanimous support across all 5 research documents (PAT-001, PAT-002)
+   - Netflix UDA pattern production-proven at scale
+   - Jerry's existing Phase 1 foundation reduces risk
+
+3. **Risk Management:**
+   - Top risk (supernode) has strong mitigations
+   - Incremental phases allow validation before deeper investment
+   - High reversibility in Phase 2 (JSON-LD optional)
+
+**Implementation Roadmap:**
+
+```markdown
+## Phase 2: Semantic Layer (Q1 2026)
+
+Week 1-2: Foundation
+├─ Create JSON-LD context (contexts/worktracker.jsonld)
+├─ Implement supernode validator (RISK-1 mitigation)
+├─ Add edge count monitoring to repository saves
+└─ Document Netflix UDA pattern in design docs
+
+Week 3-4: RDF Serialization
+├─ Install pyoxigraph: pip install pyoxigraph
+├─ Create RDF serialization adapter (Turtle, JSON-LD)
+├─ Implement Task/Phase/Plan RDF export
+└─ SHACL validation shapes
+
+Week 5-6: Vector RAG (Foundation for HybridRAG)
+├─ Index docs/ with text-embedding-3-small
+├─ Store embeddings in TOON format
+├─ Implement cosine similarity search
+└─ Test with Claude Code agent queries
+
+Week 7-8: Integration & Testing
+├─ Automated serializer round-trip tests
+├─ Schema evolution integration tests (RISK-4 mitigation)
+├─ Performance benchmarks (property graph vs RDF)
+└─ Documentation (SERIALIZATION_GUIDE.md)
+```
+
+**Success Criteria (Phase 2 Go/No-Go Gates):**
+
+| Criterion | Metric | Target | Measurement Method |
+|-----------|--------|--------|-------------------|
+| **Backward Compatibility** | % of existing tests passing | 100% | pytest suite |
+| **Performance** | Query latency P95 | < 50ms | Benchmark suite |
+| **Serialization** | Round-trip success rate | 100% | Parametrized tests |
+| **Supernode Prevention** | Edge count monitoring | Alerts working | Synthetic data test |
+| **Documentation** | Contributor onboarding time | < 4 hours | Time tracking |
+
+**Phase 3 Decision Gate:**
+
+Proceed to Phase 3 (SPARQL, reasoning, GraphRAG) ONLY IF:
+- ✅ Phase 2 success criteria met
+- ✅ User feedback validates semantic layer value
+- ✅ Use cases require SPARQL queries or reasoning
+- ✅ HybridRAG shows measurable hallucination reduction
+
+**Do NOT proceed to Phase 3 if:**
+- ❌ Phase 2 increases query latency > 100ms
+- ❌ Maintenance overhead slows development velocity > 30%
+- ❌ No external integration use cases emerge
+- ❌ User satisfaction with current capabilities
+
+---
+
+#### Secondary Recommendation: Constitutional Amendments
+
+**Decision:** Add three new principles to Jerry Constitution based on risk analysis.
+
+**Rationale:** Top risks (RISK-1, RISK-4) require governance-level enforcement to prevent.
+
+**Proposed Amendments:**
+
+```markdown
+## P-030: Schema Evolution Governance (Hard Principle)
+
+All graph schema changes MUST:
+1. Be documented in docs/specifications/SCHEMA_CHANGELOG.md
+2. Include forward migration script
+3. Include rollback migration script
+4. Pass integration test suite before deployment
+
+Enforcement: Hard (CI/CD blocks deployment without migration scripts)
+Rationale: Schema changes affect traversal semantics (RISK-4 mitigation)
+
+---
+
+## P-031: Supernode Prevention (Medium Principle)
+
+Vertices SHOULD be validated for edge degree:
+- Warning threshold: 100 edges of same label
+- Error threshold: 1000 edges of same label
+- HIGH-risk vertices (Actor) require mitigation strategy
+
+Enforcement: Medium (warnings logged, errors block saves)
+Rationale: Supernodes degrade performance catastrophically (RISK-1 mitigation)
+
+---
+
+## P-032: Phase Gate Compliance (Medium Principle)
+
+Knowledge architecture phases MUST NOT proceed without:
+1. Success criteria from previous phase met
+2. User feedback validates value
+3. Use case requires new capabilities
+4. Risk analysis updated
+
+Enforcement: Medium (Work Tracker gates, user approval)
+Rationale: Prevent premature optimization (RISK-3 mitigation)
+```
+
+**Implementation:** Add to `docs/governance/JERRY_CONSTITUTION.md` in Phase 2 Week 1.
+
+---
+
+#### Tertiary Recommendation: Monitoring Dashboard
+
+**Decision:** Create knowledge architecture health dashboard in Work Tracker.
+
+**Rationale:** Quantitative monitoring enables data-driven Phase 3/4 decisions.
+
+**Metrics to Track:**
+
+| Metric | Alert Threshold | Data Source | Review Frequency |
+|--------|----------------|-------------|------------------|
+| Entity count | 8M (80% of Phase 4 trigger) | Repository save events | Weekly |
+| Query latency P95 | > 500ms | Performance logs | Weekly |
+| Edge count per vertex | > 80 (80% of warning) | Supernode validator | Real-time |
+| Serialization round-trip time | > 100ms | Benchmark suite | Daily |
+| Schema version | Major version change | EntityBase metadata | On change |
+| False positive rate (grounding) | > 5% | CloudEvents | Monthly |
+
+**Visualization:** Cytoscape.js graph in Phase 3 showing vertex degree distribution.
+
+**Action:** If any threshold crossed, trigger Work Tracker review.
+
+---
+
+## Sources
+
+### Primary Source
+- **docs/synthesis/work-031-e-006-synthesis.md** — Cross-document synthesis of 5 research reports, including:
+  - PAT-001: Hybrid Property Graph + RDF Architecture
+  - PAT-002: Four-Phase Knowledge Architecture Maturity Model
+  - PAT-003: Netflix UDA "Model Once, Represent Everywhere"
+  - PAT-004: Supernode Detection and Mitigation
+  - PAT-005: JSON-LD as Pragmatic Semantic Layer
+  - PAT-006: HybridRAG (Vector + Graph Retrieval)
+  - PAT-007: Embedded-First, Scale-Later
+  - PAT-008: Schema.org First, Custom Vocabulary Second
+  - PAT-009: Grounding Verification as Quality Gate
+  - PAT-010: Content Negotiation for URI Dereferencing
+
+### Case Study Evidence (via Synthesis)
+- **FalkorDB Case Study:** 90% hallucination reduction with GraphRAG
+- **LinkedIn Case Study:** 63% faster ticket resolution (40hrs → 15hrs) with GraphRAG
+- **Amazon Finance Case Study:** 49% → 86% accuracy improvement with GraphRAG
+- **Netflix UDA Pattern:** Production validation at scale (cited in 4/5 research documents)
+
+### Standards References (via Synthesis)
+- **W3C RDF 1.2:** RDF* for edge properties without reification
+- **W3C SPARQL 1.2:** Improved query performance
+- **W3C JSON-LD:** 70% web adoption (Web Data Commons 2024)
+- **Schema.org:** 45M+ websites, 803 types, 1,461 properties
+- **Tim Berners-Lee 5-Star Linked Open Data:** Jerry at 4 stars, targeting 5 stars
+
+### Research Methods
+- **ATAM (Architecture Tradeoff Analysis Method):** Quality attribute scenario analysis from Carnegie Mellon SEI
+- **SWOT Analysis:** Strategic planning framework for identifying strengths, weaknesses, opportunities, threats
+- **Decision Matrix:** Multi-criteria decision analysis with weighted scoring
+- **Risk Matrix:** Probability × Impact scoring with mitigation strategies
+
+---
+
+## Validation Checklist
+
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| **Read synthesis document** | ✅ COMPLETE | 1,142 lines analyzed |
+| **Performed SWOT analysis** | ✅ COMPLETE | 6 strengths, 6 weaknesses, 6 opportunities, 6 threats |
+| **Analyzed quality attributes** | ✅ COMPLETE | 4 ATAM-style trade-offs with sensitivity points |
+| **Created decision matrix** | ✅ COMPLETE | 5 options scored on 5 criteria with justifications |
+| **Performed risk analysis** | ✅ COMPLETE | Top 5 risks with P/I/M and residual risk |
+| **Provided final recommendation** | ✅ COMPLETE | Clear recommendation with evidence and roadmap |
+| **Used Write tool** | ✅ COMPLETE | This file created via Write tool |
+| **L0 Executive Summary** | ✅ COMPLETE | ELI5 language, 2-3 paragraphs, key findings |
+| **L1 Technical Analysis** | ✅ COMPLETE | SWOT, quality attributes, decision matrix with scoring |
+| **L2 Strategic Recommendations** | ✅ COMPLETE | Risk analysis, final recommendation, implementation roadmap |
+| **Sources cited** | ✅ COMPLETE | Primary synthesis document + case studies + standards |
+
+---
+
+## Changelog
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-08 | ps-analyst (v2.0.0) | Initial trade-off analysis using ATAM methodology |
+
+---
+
+*Analysis Method: ATAM-inspired Quality Attribute Trade-off Analysis + SWOT + Decision Matrix + Risk Analysis*
+*Recommendation: Proceed with Hybrid Property + RDF (22/25, 88%) with phased gates*
+*Top Risk: Supernode degradation (9/9 Critical, strong mitigations)*
+*Agent: ps-analyst (v2.0.0)*
+*Constitution Compliance: P-001 (all claims cited), P-002 (analysis persisted to file)*

--- a/docs/archive/projects-archive/analysis/work-032-e-007-trade-off-analysis.md
+++ b/docs/archive/projects-archive/analysis/work-032-e-007-trade-off-analysis.md
@@ -1,0 +1,780 @@
+# Knowledge Management Integration Trade-off Analysis
+
+**PS ID:** work-032
+**Entry ID:** e-007
+**Topic:** KM Integration Trade-off Analysis
+**Date:** 2026-01-09
+**Agent:** ps-analyst v2.0.0
+**Analysis Method:** SWOT + Decision Matrix + Quality Attributes + Risk Analysis
+**Input:** `docs/synthesis/work-032-e-006-km-synthesis.md`
+
+---
+
+## L0: Executive Summary (ELI5)
+
+**What This Document Does:**
+
+Imagine you want to organize your closet. You have four options:
+1. **Do nothing** (just throw clothes in)
+2. **Buy simple hangers and bins** (cheap, works great)
+3. **Install a custom closet system** (expensive, powerful)
+4. **Hire a professional organizer** (very expensive, overkill)
+
+This document analyzes those same choices for how Jerry should organize its knowledge.
+
+**The Winner:**
+
+**Option 2: Lightweight KM** (NetworkX + FAISS + RDFLib)
+- Costs nothing (free libraries)
+- Adds powerful features (graphs, search, standards)
+- Fits Jerry's architecture perfectly
+- Can upgrade later if needed
+
+**Why Not the Others:**
+
+- Option 1 (Do Nothing): Jerry already outgrew it—we have hundreds of files
+- Option 3 (Full KM): Too heavy, needs databases we don't want yet
+- Option 4 (Enterprise): Way overkill for a personal/small team framework
+
+**The Math:**
+
+Lightweight KM scores **8.2/10** vs. Minimal (5.3), Full (6.8), and Enterprise (4.5).
+
+---
+
+## L1: Technical Analysis
+
+### 1. SWOT Analysis
+
+#### Option 1: Minimal KM (Current State)
+
+**Description:** Filesystem-only with markdown files, git versioning, no KM tooling.
+
+**Strengths:**
+- ✅ Zero dependencies (pure stdlib)
+- ✅ Simple mental model (files and folders)
+- ✅ Portable and future-proof (markdown)
+- ✅ Already working and familiar
+- ✅ Fast implementation (no work needed)
+- ✅ Git provides versioning
+
+**Weaknesses:**
+- ❌ No relationship discovery (can't find connections)
+- ❌ No semantic search (grep is limited to keywords)
+- ❌ Manual cross-referencing required
+- ❌ Knowledge fragmentation as corpus grows
+- ❌ No entity extraction or knowledge graph
+- ❌ Difficult to answer "what relates to X?" queries
+- ❌ Scales poorly beyond ~100 documents
+
+**Opportunities:**
+- 🔷 Serves as foundation for any future KM layer
+- 🔷 Human-readable format enables tool adoption
+- 🔷 Can add KM tools incrementally without migration
+
+**Threats:**
+- ⚠️ Context rot as corpus expands (proven problem)
+- ⚠️ Knowledge loss (can't find what you forgot exists)
+- ⚠️ Missed insights (relationships not visible)
+- ⚠️ Agent inefficiency (no semantic retrieval)
+
+**SWOT Score:** 6/10 strengths, 7/10 weaknesses, 3/10 opportunities, 8/10 threats = **5.3/10 overall**
+
+---
+
+#### Option 2: Lightweight KM (NetworkX + FAISS + RDFLib)
+
+**Description:** Add graph operations (NetworkX), vector search (FAISS), semantic web (RDFLib) to infrastructure layer. Filesystem remains source of truth.
+
+**Strengths:**
+- ✅ Pure Python libraries (no external services)
+- ✅ Minimal dependencies (3 packages, all pre-installable)
+- ✅ Hexagonal architecture fit (infrastructure adapters)
+- ✅ Proven at scale (14M+ downloads/week each)
+- ✅ Enables semantic search and relationship discovery
+- ✅ Standards-based (RDF, SPARQL)
+- ✅ Swappable via ports (NetworkX → igraph later)
+- ✅ Filesystem still source of truth (no lock-in)
+- ✅ Supports RAG implementation (FAISS + embeddings)
+- ✅ Graph visualization possible (NetworkX → Graphviz)
+
+**Weaknesses:**
+- ❌ Introduces external dependencies (breaks stdlib-only goal)
+- ❌ Requires learning curve (graph concepts, RDF, embeddings)
+- ❌ Performance limits (NetworkX <10K nodes, FAISS CPU-only)
+- ❌ Memory overhead (in-memory graphs and vectors)
+- ❌ Manual graph construction initially (no auto-extraction)
+- ❌ FAISS requires dimension management
+
+**Opportunities:**
+- 🔷 Foundation for advanced RAG/GraphRAG
+- 🔷 Enables ISO 30401 alignment path
+- 🔷 Knowledge graph as competitive advantage
+- 🔷 Migration path to production tools (Neo4j, Qdrant)
+- 🔷 Interoperability via RDF export
+- 🔷 Agent reasoning via graph traversal
+- 🔷 Community engagement (graph visualizations)
+
+**Threats:**
+- ⚠️ Library abandonment risk (low but possible)
+- ⚠️ API changes in dependencies
+- ⚠️ Performance ceiling could arrive sooner than expected
+- ⚠️ Complexity creep if not disciplined
+
+**SWOT Score:** 10/10 strengths, 6/10 weaknesses, 7/10 opportunities, 4/10 threats = **8.2/10 overall**
+
+---
+
+#### Option 3: Full KM (Neo4j + Qdrant + pyoxigraph)
+
+**Description:** Production-grade tools with native graph database (Neo4j), distributed vector store (Qdrant), advanced RDF processing (pyoxigraph). Requires external services.
+
+**Strengths:**
+- ✅ Production-ready scalability (billions of vectors, millions of nodes)
+- ✅ ACID transactions (Neo4j)
+- ✅ Advanced features (Cypher queries, graph algorithms)
+- ✅ Distributed architecture possible
+- ✅ Enterprise adoption proven (Neo4j: 75% Fortune 500)
+- ✅ Performance optimized (Rust cores)
+- ✅ Full-text search integrated (Neo4j, Qdrant)
+- ✅ Visualization tools included (Neo4j Browser)
+
+**Weaknesses:**
+- ❌ Requires external services (databases running)
+- ❌ Operational complexity (deployment, monitoring, backups)
+- ❌ Resource intensive (RAM, CPU, disk)
+- ❌ Cost (Neo4j Enterprise licensing)
+- ❌ Overkill for current corpus size (<500 docs)
+- ❌ Longer implementation time
+- ❌ Doesn't fit hexagonal architecture cleanly (service dependencies)
+- ❌ Migration effort from filesystem
+
+**Opportunities:**
+- 🔷 Ready for massive scale immediately
+- 🔷 Advanced analytics (PageRank, community detection)
+- 🔷 Multi-user collaboration features
+- 🔷 Cloud deployment options
+
+**Threats:**
+- ⚠️ Vendor lock-in (Neo4j proprietary features)
+- ⚠️ Cost escalation at scale
+- ⚠️ Operational burden (DevOps required)
+- ⚠️ Over-engineering risk (YAGNI violation)
+- ⚠️ Reduced portability (can't just copy docs/ folder)
+
+**SWOT Score:** 8/10 strengths, 8/10 weaknesses, 4/10 opportunities, 7/10 threats = **6.8/10 overall**
+
+---
+
+#### Option 4: Enterprise KM (Full ISO 30401 + Commercial Tools)
+
+**Description:** Complete ISO 30401 implementation with commercial KM platforms (e.g., Bloomfire, Guru, Confluence Enterprise), formal governance, dedicated KM roles.
+
+**Strengths:**
+- ✅ ISO 30401 certified (if pursued)
+- ✅ Comprehensive feature sets (wikis, forums, analytics)
+- ✅ Vendor support and SLAs
+- ✅ Proven at enterprise scale (thousands of users)
+- ✅ Compliance and audit features
+- ✅ Advanced permissions and governance
+
+**Weaknesses:**
+- ❌ Extremely expensive ($10K-$100K+ annually)
+- ❌ Massive overkill for 1-10 users
+- ❌ Requires organizational buy-in and culture change
+- ❌ Heavy onboarding and training
+- ❌ Cloud-dependent (no local-first option)
+- ❌ Vendor lock-in (proprietary formats)
+- ❌ Complexity adds friction
+- ❌ Contradicts Jerry's local-first philosophy
+- ❌ Implementation timeline: months to years
+
+**Opportunities:**
+- 🔷 Full enterprise readiness
+- 🔷 Certification and credibility
+- 🔷 Advanced collaboration at scale
+
+**Threats:**
+- ⚠️ Cost spiral (per-user pricing)
+- ⚠️ Vendor discontinuation or acquisition
+- ⚠️ Data sovereignty issues (cloud-only)
+- ⚠️ Adoption failure (cultural resistance)
+- ⚠️ Complexity paralysis (too many features)
+
+**SWOT Score:** 6/10 strengths, 9/10 weaknesses, 3/10 opportunities, 7/10 threats = **4.5/10 overall**
+
+---
+
+### 2. Decision Matrix
+
+Criteria are weighted based on Jerry's priorities (from Constitution and architecture docs).
+
+| Criterion | Weight | Minimal KM | Lightweight KM | Full KM | Enterprise KM |
+|-----------|--------|------------|----------------|---------|---------------|
+| **Architectural Fit** | 15% | 10 (perfect fit) | 9 (minor deps) | 5 (services) | 2 (contradicts) |
+| **Implementation Cost** | 10% | 10 (zero) | 10 (free libs) | 4 (infra) | 1 (expensive) |
+| **Operational Cost** | 10% | 10 (zero) | 9 (minimal) | 5 (DevOps) | 2 (licensing) |
+| **Capability** | 20% | 3 (basic) | 8 (strong) | 10 (excellent) | 10 (excellent) |
+| **Scalability** | 8% | 2 (poor) | 6 (moderate) | 10 (excellent) | 10 (excellent) |
+| **Local-First** | 12% | 10 (perfect) | 10 (perfect) | 3 (depends) | 1 (cloud-only) |
+| **Learning Curve** | 7% | 10 (none) | 7 (moderate) | 4 (steep) | 3 (very steep) |
+| **Time to Value** | 10% | 10 (immediate) | 8 (weeks) | 4 (months) | 2 (years) |
+| **Future-Proofing** | 8% | 3 (limiting) | 9 (ports) | 8 (proven) | 6 (vendor risk) |
+| **TOTAL SCORE** | 100% | **7.0** | **8.5** | **6.5** | **5.1** |
+
+**Weighted Scores:**
+1. **Lightweight KM: 8.5/10** ← Winner
+2. Minimal KM: 7.0/10
+3. Full KM: 6.5/10
+4. Enterprise KM: 5.1/10
+
+**Key Insights:**
+
+- **Lightweight KM wins** on balance of capability + cost + fit
+- **Minimal KM** competitive only because of zero cost, but lacks capability
+- **Full KM** and **Enterprise KM** hurt by operational burden and poor Jerry alignment
+- **Architectural Fit** and **Capability** are decisive factors
+
+---
+
+### 3. Quality Attribute Trade-offs
+
+Quality attributes per ISO 25010 software quality model.
+
+#### 3.1 Performance Efficiency
+
+| Approach | Time Behavior | Resource Utilization | Capacity | Analysis |
+|----------|---------------|----------------------|----------|----------|
+| **Minimal** | ⭐⭐⭐⭐⭐ (instant) | ⭐⭐⭐⭐⭐ (zero overhead) | ⭐⭐ (limited) | Fast but can't answer complex queries |
+| **Lightweight** | ⭐⭐⭐⭐ (fast) | ⭐⭐⭐⭐ (low RAM) | ⭐⭐⭐ (good) | Good balance; NetworkX <10K nodes, FAISS CPU acceptable |
+| **Full** | ⭐⭐⭐⭐⭐ (optimized) | ⭐⭐ (high RAM/CPU) | ⭐⭐⭐⭐⭐ (huge) | Excellent but overkill; requires dedicated resources |
+| **Enterprise** | ⭐⭐⭐⭐ (good) | ⭐ (very high) | ⭐⭐⭐⭐⭐ (unlimited) | Great capacity but expensive resource use |
+
+**Trade-off:** Lightweight KM sacrifices peak performance for low resource use. Acceptable given current corpus size.
+
+---
+
+#### 3.2 Maintainability
+
+| Approach | Modularity | Reusability | Modifiability | Testability |
+|----------|------------|-------------|---------------|-------------|
+| **Minimal** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Lightweight** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| **Full** | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| **Enterprise** | ⭐⭐ | ⭐⭐ | ⭐ | ⭐⭐ |
+
+**Trade-off:** Lightweight KM slightly reduces maintainability vs. Minimal (more code) but hexagonal architecture mitigates via ports.
+
+---
+
+#### 3.3 Portability
+
+| Approach | Adaptability | Installability | Replaceability |
+|----------|--------------|----------------|----------------|
+| **Minimal** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Lightweight** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Full** | ⭐⭐ | ⭐⭐ | ⭐⭐ |
+| **Enterprise** | ⭐ | ⭐ | ⭐ |
+
+**Trade-off:** Lightweight KM requires `pip install` but remains highly portable. Filesystem still source of truth.
+
+---
+
+#### 3.4 Functional Suitability
+
+| Approach | Completeness | Correctness | Appropriateness |
+|----------|--------------|-------------|-----------------|
+| **Minimal** | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
+| **Lightweight** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Full** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐ |
+| **Enterprise** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐ |
+
+**Trade-off:** Lightweight KM hits the "Goldilocks zone"—appropriate completeness without over-engineering.
+
+---
+
+#### 3.5 Usability
+
+| Approach | Learnability | Operability | User Error Protection |
+|----------|--------------|-------------|----------------------|
+| **Minimal** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
+| **Lightweight** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+| **Full** | ⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
+| **Enterprise** | ⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
+
+**Trade-off:** Lightweight KM adds conceptual complexity (graphs, embeddings) but remains developer-friendly.
+
+---
+
+#### 3.6 Security
+
+| Approach | Confidentiality | Integrity | Authenticity |
+|----------|-----------------|-----------|--------------|
+| **Minimal** | ⭐⭐⭐⭐⭐ (local) | ⭐⭐⭐⭐⭐ (git) | ⭐⭐⭐⭐⭐ (git) |
+| **Lightweight** | ⭐⭐⭐⭐⭐ (local) | ⭐⭐⭐⭐⭐ (git) | ⭐⭐⭐⭐⭐ (git) |
+| **Full** | ⭐⭐⭐⭐ (network) | ⭐⭐⭐⭐⭐ (ACID) | ⭐⭐⭐⭐ (auth) |
+| **Enterprise** | ⭐⭐⭐ (cloud) | ⭐⭐⭐⭐ (vendor) | ⭐⭐⭐⭐⭐ (SSO) |
+
+**Trade-off:** Lightweight KM maintains Minimal's security posture (local-first, no network services).
+
+---
+
+#### 3.7 Compatibility
+
+| Approach | Interoperability | Co-existence |
+|----------|------------------|--------------|
+| **Minimal** | ⭐⭐ (markdown only) | ⭐⭐⭐⭐⭐ |
+| **Lightweight** | ⭐⭐⭐⭐⭐ (RDF export) | ⭐⭐⭐⭐⭐ |
+| **Full** | ⭐⭐⭐⭐⭐ (APIs) | ⭐⭐⭐ |
+| **Enterprise** | ⭐⭐⭐⭐ (platform lock) | ⭐⭐ |
+
+**Trade-off:** Lightweight KM adds RDF interoperability, a major gain over Minimal.
+
+---
+
+#### Quality Attributes Summary
+
+| Attribute | Minimal | Lightweight | Full | Enterprise |
+|-----------|---------|-------------|------|------------|
+| Performance | 4.0 | 3.7 | 4.7 | 4.3 |
+| Maintainability | 5.0 | 4.3 | 2.8 | 1.8 |
+| Portability | 5.0 | 4.3 | 2.0 | 1.0 |
+| Functionality | 3.3 | 4.3 | 4.7 | 4.7 |
+| Usability | 4.3 | 4.0 | 2.7 | 2.7 |
+| Security | 5.0 | 5.0 | 4.3 | 4.0 |
+| Compatibility | 3.5 | 5.0 | 4.5 | 3.5 |
+| **AVERAGE** | **4.30** | **4.37** | **3.67** | **3.14** |
+
+**Conclusion:** Lightweight KM wins on quality attributes, balancing functionality gains with minimal sacrifice to maintainability and portability.
+
+---
+
+### 4. Risk Analysis
+
+Top 5 risks identified across all approaches, ranked by (probability × impact).
+
+---
+
+#### Risk #1: Knowledge Corpus Growth Exceeds Tool Capacity
+
+**Severity:** HIGH (P=60%, I=8, Score=4.8/10)
+
+**Description:** Jerry's knowledge base grows faster than anticipated, exceeding performance limits of chosen tools.
+
+**Affects:**
+- **Minimal KM:** Severe (can't find anything)
+- **Lightweight KM:** Moderate (NetworkX <10K nodes, FAISS CPU slow)
+- **Full KM:** Low (designed for scale)
+- **Enterprise KM:** Very Low (unlimited scale)
+
+**Mitigations:**
+
+| Approach | Mitigation Strategy | Effectiveness |
+|----------|---------------------|---------------|
+| **Minimal** | None available | ❌ (must migrate) |
+| **Lightweight** | Port/adapter pattern enables swap to igraph/graph-tool/Qdrant | ✅ High |
+| **Full** | Scaling built-in | ✅ Very High |
+| **Enterprise** | Scaling built-in | ✅ Very High |
+
+**Recommended Mitigation:** Choose Lightweight with ports designed for migration path. Monitor graph size quarterly.
+
+**Trigger:** Knowledge graph >5K nodes OR FAISS search >2 seconds.
+
+---
+
+#### Risk #2: Dependency Abandonment or Breaking Changes
+
+**Severity:** MEDIUM (P=20%, I=7, Score=1.4/10)
+
+**Description:** Key libraries (NetworkX, RDFLib, FAISS) become unmaintained or introduce breaking changes.
+
+**Affects:**
+- **Minimal KM:** None (no deps)
+- **Lightweight KM:** High (3 key dependencies)
+- **Full KM:** Medium (managed services less likely to abandon)
+- **Enterprise KM:** Low (vendor contracts and SLAs)
+
+**Mitigations:**
+
+| Approach | Mitigation Strategy | Effectiveness |
+|----------|---------------------|---------------|
+| **Minimal** | N/A | ✅ N/A |
+| **Lightweight** | 1) Use ports to isolate deps; 2) Pin versions; 3) Monitor health; 4) Fallback to stdlib where possible | ✅ Medium-High |
+| **Full** | Commercial support available (Neo4j, Qdrant) | ✅ High |
+| **Enterprise** | SLA guarantees | ✅ Very High |
+
+**Recommended Mitigation:**
+- Pin dependencies: `networkx==3.2.1, rdflib==7.0.0, faiss-cpu==1.7.4`
+- Quarterly health checks (GitHub activity, release cadence)
+- Hexagonal architecture allows adapter replacement
+- Document migration paths in advance
+
+**Health Indicators (Q1 2026):**
+- NetworkX: 14.9M downloads/week, active development ✅
+- RDFLib: 14M downloads/week, active development ✅
+- FAISS: Meta-backed, production-used ✅
+
+**Trigger:** 6 months without releases OR critical security vulnerability.
+
+---
+
+#### Risk #3: Implementation Complexity Delays Value Delivery
+
+**Severity:** MEDIUM (P=40%, I=5, Score=2.0/10)
+
+**Description:** Chosen approach takes too long to implement, delaying benefits and risking abandonment.
+
+**Affects:**
+- **Minimal KM:** None (no implementation)
+- **Lightweight KM:** Low-Medium (weeks to working state)
+- **Full KM:** High (months to production)
+- **Enterprise KM:** Very High (6-12 months typical)
+
+**Mitigations:**
+
+| Approach | Mitigation Strategy | Effectiveness |
+|----------|---------------------|---------------|
+| **Minimal** | N/A | ✅ N/A |
+| **Lightweight** | Phased rollout: Q1 libraries, Q2 graph, Q3 vectors | ✅ High |
+| **Full** | Start with Community Editions; defer advanced features | ✅ Medium |
+| **Enterprise** | Hire consultants (expensive) | 🟡 Medium |
+
+**Recommended Mitigation:**
+- **Phase 1 (Week 1):** Install libraries, basic ports
+- **Phase 2 (Week 2-3):** NetworkX adapter + simple graph operations
+- **Phase 3 (Week 4-6):** RDFLib adapter + SPARQL queries
+- **Phase 4 (Week 7-10):** FAISS adapter + semantic search
+- MVP at end of Phase 2 (2-3 weeks)
+
+**Success Metric:** Deliver tangible value (e.g., "find related docs") within 1 month.
+
+**Trigger:** If Phase 2 exceeds 4 weeks, descope or reassess.
+
+---
+
+#### Risk #4: User Adoption Failure (Protocols)
+
+**Severity:** MEDIUM (P=50%, I=4, Score=2.0/10)
+
+**Description:** Users don't complete AAR/A3 protocols, leading to sparse knowledge capture despite tooling.
+
+**Affects:**
+- All approaches equally (cultural issue, not technical)
+
+**Root Cause:** KM synthesis (e-006) found "Cultural issues, not technology, are usually the primary obstacle."
+
+**Mitigations:**
+
+| Strategy | Effectiveness |
+|----------|---------------|
+| **Start Simple:** AAR template with 3 questions, <5 minutes to complete | ✅ High |
+| **Show Value:** Generate "Lessons Applied" report showing reuse | ✅ High |
+| **Make Optional:** Don't enforce initially; encourage via Constitution | ✅ Medium |
+| **Automate:** Extract knowledge from commit messages, chat logs | 🟡 Medium |
+| **Gamify:** Track knowledge contributions, celebrate learners | 🟡 Medium |
+
+**Recommended Mitigation:**
+- Lightweight AAR (3 questions: What worked? What didn't? What next?)
+- Quarterly retrospective instead of per-task AAR initially
+- Work Tracker integration: "What did you learn?" field (optional)
+- Lead by example: Agent-generated AARs for complex tasks
+
+**Success Metric:** 50% of work items have associated learnings by Q2 2026.
+
+**Trigger:** If <20% compliance after 3 months, simplify or make automated.
+
+---
+
+#### Risk #5: Over-Engineering / Scope Creep
+
+**Severity:** MEDIUM (P=30%, I=6, Score=1.8/10)
+
+**Description:** KM implementation grows beyond needs, consuming time/resources without proportional value.
+
+**Affects:**
+- **Minimal KM:** None (under-engineering risk instead)
+- **Lightweight KM:** Low (well-scoped)
+- **Full KM:** High (feature-rich, tempting)
+- **Enterprise KM:** Very High (vast capabilities encourage creep)
+
+**Mitigations:**
+
+| Approach | Mitigation Strategy | Effectiveness |
+|----------|---------------------|---------------|
+| **Minimal** | N/A | ✅ N/A |
+| **Lightweight** | Strict phasing; defer Tier 2/3 features; YAGNI principle | ✅ High |
+| **Full** | Limited feature subset; disable advanced features initially | 🟡 Medium |
+| **Enterprise** | Executive sponsor to control scope | 🟡 Low-Medium |
+
+**Recommended Mitigation:**
+- **Strict Phase Gates:** Must demonstrate value before next phase
+- **YAGNI Discipline:** "You Aren't Gonna Need It"—defer speculative features
+- **Quarterly Review:** Assess ROI of KM efforts vs. other work
+- **Success Criteria:** Define "done" for each phase upfront
+
+**Success Criteria (Lightweight KM):**
+- Phase 1 Done: Can query "What docs reference concept X?"
+- Phase 2 Done: Can traverse "Show me related tasks"
+- Phase 3 Done: Can search "Find docs semantically similar to Y"
+
+**Trigger:** If KM work exceeds 20% of total dev time in any quarter, reassess.
+
+---
+
+#### Risk Summary Table
+
+| Risk | Probability | Impact | Score | Top Mitigation |
+|------|-------------|--------|-------|----------------|
+| **#1: Growth Exceeds Capacity** | 60% | 8 | 4.8 | Port/adapter pattern for migration |
+| **#2: Dependency Issues** | 20% | 7 | 1.4 | Pin versions + hexagonal architecture |
+| **#3: Implementation Delays** | 40% | 5 | 2.0 | Phased rollout with MVP in 1 month |
+| **#4: Low Adoption (Protocols)** | 50% | 4 | 2.0 | Simple templates + show value |
+| **#5: Over-Engineering** | 30% | 6 | 1.8 | Strict phase gates + YAGNI |
+
+**Risk Mitigation Effectiveness:**
+- **Minimal KM:** Low (no path to address Risk #1)
+- **Lightweight KM:** High (all risks have strong mitigations)
+- **Full KM:** Medium (avoids #1 but vulnerable to #3, #5)
+- **Enterprise KM:** Medium (avoids #1, #2 but very vulnerable to #3, #5)
+
+---
+
+## L2: Strategic Recommendation
+
+### Recommendation: Adopt Lightweight KM (NetworkX + FAISS + RDFLib)
+
+**Confidence Level:** HIGH (85%)
+
+**Rationale:**
+
+1. **Best Overall Score:**
+   - Decision Matrix: 8.5/10 (highest)
+   - SWOT: 8.2/10 (highest)
+   - Quality Attributes: 4.37/7 (highest)
+
+2. **Aligns with Jerry's Core Principles:**
+   - ✅ Hexagonal architecture (infrastructure adapters)
+   - ✅ Local-first (no external services)
+   - ✅ Progressive enhancement (filesystem remains source of truth)
+   - ✅ Future-proof (ports enable migration)
+   - ✅ Cost-effective (zero licensing)
+
+3. **Addresses Current Pain Points:**
+   - ✅ Enables relationship discovery (synthesis called this out)
+   - ✅ Supports semantic search (critical for agent reasoning)
+   - ✅ Provides standards-based export (RDF/SPARQL)
+   - ✅ Foundation for RAG implementation
+
+4. **Risk Profile Acceptable:**
+   - All 5 major risks have effective mitigations
+   - Port/adapter pattern de-risks dependency and growth concerns
+   - Phased rollout limits implementation risk
+   - Low operational burden (no services to manage)
+
+5. **Industry Validation:**
+   - KM synthesis (e-006) recommends this exact stack
+   - NetworkX: 14.9M downloads/week
+   - RDFLib: 14M downloads/week
+   - FAISS: Production-proven at Meta, used by LangChain/LlamaIndex
+
+6. **Clear Migration Path:**
+   - If corpus exceeds tool capacity → swap to igraph/graph-tool/Qdrant
+   - If need ACID/collaboration → add Neo4j via same port
+   - If need enterprise features → progressive adoption, not rip-and-replace
+
+---
+
+### Implementation Strategy
+
+#### Phase 1: Foundation (Q1 2026, Weeks 1-4)
+
+**Goal:** Working graph operations and semantic search.
+
+**Deliverables:**
+```python
+# Port definitions (domain layer, no dependencies)
+src/domain/ports/graph_port.py
+src/domain/ports/knowledge_port.py
+src/domain/ports/vector_store_port.py
+
+# Adapters (infrastructure layer)
+src/infrastructure/graph/networkx_adapter.py
+src/infrastructure/knowledge/rdflib_adapter.py
+src/infrastructure/embeddings/faiss_adapter.py
+
+# Dependencies
+pip install networkx==3.2.1 rdflib==7.0.0 faiss-cpu==1.7.4
+```
+
+**Success Criteria:**
+- [x] Can add nodes and edges to graph
+- [x] Can query "What docs reference concept X?"
+- [x] Can export knowledge graph to RDF/Turtle
+- [x] Can add document embeddings to FAISS
+- [x] Can search "Find top 5 docs similar to query"
+
+**Effort Estimate:** 20-30 hours (1-2 weeks part-time)
+
+---
+
+#### Phase 2: Integration (Q2 2026, Weeks 5-10)
+
+**Goal:** Automated knowledge graph construction from docs/.
+
+**Deliverables:**
+```python
+# Entity extraction
+src/infrastructure/extraction/markdown_entities.py
+
+# Graph builder
+src/application/commands/build_knowledge_graph.py
+
+# Query interface
+src/application/queries/find_related_docs.py
+src/application/queries/semantic_search.py
+```
+
+**Success Criteria:**
+- [x] Automatically index docs/ into graph on update
+- [x] Extract entities: Tasks, Phases, Plans, Concepts, Documents
+- [x] Extract relationships: REFERENCES, PART_OF, USES, IMPLEMENTS
+- [x] Provide CLI: `jerry knowledge graph --query "find related to X"`
+
+**Effort Estimate:** 30-40 hours (2-3 weeks part-time)
+
+---
+
+#### Phase 3: AI Integration (Q3 2026, Weeks 11-16)
+
+**Goal:** RAG over knowledge base for agent reasoning.
+
+**Deliverables:**
+```python
+# RAG implementation
+src/interface/rag/simple_rag.py
+
+# Agent integration
+skills/knowledge-search/SKILL.md
+```
+
+**Success Criteria:**
+- [x] Agents can query: "What do we know about topic X?"
+- [x] Retrieval includes top K relevant docs + citations
+- [x] Generation grounded in retrieved knowledge
+- [x] Source attribution always provided
+
+**Effort Estimate:** 20-30 hours (1-2 weeks part-time)
+
+---
+
+#### Phase 4: Optimization (Q4 2026+, As Needed)
+
+**Goal:** Performance tuning and advanced features.
+
+**Potential Upgrades:**
+- NetworkX → igraph (if graph >5K nodes)
+- FAISS CPU → FAISS GPU (if search >1 second)
+- Simple RAG → GraphRAG (if multi-hop reasoning needed)
+- Add Docling for PDF processing (if document processing needed)
+
+**Trigger-Based:** Only implement if performance issues arise or specific needs emerge.
+
+---
+
+### Success Metrics
+
+**Quantitative:**
+- Knowledge graph size: Target 500+ nodes by Q2 2026
+- Query performance: <500ms for graph queries, <2s for semantic search
+- Adoption: 50% of work items with associated knowledge by Q2 2026
+- Coverage: 80% of docs/ indexed in graph by Q3 2026
+
+**Qualitative:**
+- Agents demonstrate improved reasoning via knowledge retrieval
+- Users report faster discovery of related work
+- Knowledge reuse measurable (concepts applied to new problems)
+
+**ROI:**
+- Time saved finding information: 10-20% (industry average per KM research)
+- Reduced duplicate work: 15-25% (via "what already exists?" queries)
+- Improved decision quality: Qualitative (better-informed choices)
+
+---
+
+### Governance and Review
+
+**Quarterly Assessment:**
+1. Review knowledge graph growth vs. tool capacity
+2. Check dependency health (releases, vulnerabilities)
+3. Measure adoption metrics (AAR completion, knowledge queries)
+4. Assess ROI (time saved vs. maintenance burden)
+5. Decide: Continue current path, upgrade tools, or roll back
+
+**Off-Ramps:**
+- If adoption <20% by Q2 2026 → Simplify or defer
+- If maintenance burden >20% of dev time → Consider managed services
+- If performance issues arise → Trigger Phase 4 upgrades
+
+**Alignment Check:**
+- Constitutional compliance (P-002: File Persistence maintained)
+- Hexagonal architecture integrity (domain remains dependency-free)
+- Local-first principle upheld (no required cloud services)
+
+---
+
+### Alternative Recommendation (If Lightweight Rejected)
+
+**If Lightweight KM is rejected due to dependency concerns:**
+
+**Fallback: Enhanced Minimal KM**
+- Implement graph operations in pure Python (adjacency dict)
+- Use basic TF-IDF for document similarity (no FAISS)
+- Skip RDF/semantic web features
+- Accept performance and capability limitations
+
+**Trade-offs:**
+- ✅ Zero dependencies maintained
+- ❌ No standards interoperability (RDF)
+- ❌ Poor scaling (Python dict <1K nodes)
+- ❌ Limited search quality (keyword-based only)
+- ❌ More code to maintain (reinventing wheels)
+
+**Verdict:** Not recommended. The dependency cost (3 well-maintained libraries) is far outweighed by capability gains. Jerry's infrastructure layer is designed for selective dependencies.
+
+---
+
+## Conclusion
+
+**ADOPT LIGHTWEIGHT KM** (NetworkX + FAISS + RDFLib) with phased implementation starting Q1 2026.
+
+**Key Justifications:**
+1. Highest scores across all evaluation methods (Decision Matrix: 8.5, SWOT: 8.2, Quality: 4.37)
+2. Perfect alignment with Jerry's hexagonal architecture and local-first philosophy
+3. All major risks have effective mitigations via ports/adapters pattern
+4. Clear ROI: Enables semantic search, relationship discovery, RAG foundation
+5. Future-proof: Migration paths to production tools if needed
+6. Industry-validated: Synthesis of 358KB research points to this exact stack
+
+**Implementation Timeline:**
+- Q1 2026: Foundation (ports, adapters, basic features)
+- Q2 2026: Integration (automated graph building)
+- Q3 2026: AI Layer (RAG implementation)
+- Q4 2026+: Optimization (only if triggered by growth/performance needs)
+
+**Success Definition:**
+By Q3 2026, Jerry agents can answer "What do we know about X?" with semantically relevant results, sourced citations, and relationship context—capabilities impossible with filesystem-only approach.
+
+**Next Steps:**
+1. Approve recommendation (ps-validator)
+2. Create PLAN file for implementation (if approved)
+3. Begin Phase 1: Install dependencies and create port definitions
+4. Measure and iterate based on quarterly reviews
+
+---
+
+**File:** `/home/user/jerry/docs/analysis/work-032-e-007-trade-off-analysis.md`
+**Status:** COMPLETE
+**Word Count:** ~6,500 words
+**Recommendation:** Lightweight KM (NetworkX + FAISS + RDFLib)
+**Confidence:** 85% (HIGH)
+**Approval Required:** ps-validator → user

--- a/docs/archive/projects-archive/analysis/work-033-e-003-design-trade-offs.md
+++ b/docs/archive/projects-archive/analysis/work-033-e-003-design-trade-offs.md
@@ -1,0 +1,1495 @@
+# Unified Knowledge Management Design Trade-off Analysis
+# WORK-033 Entry 003: Strategic Decision Analysis
+
+**PS ID:** work-033
+**Entry ID:** e-003
+**Topic:** Trade-off Analysis for Unified KM Architecture
+**Type:** Analysis Document
+**Date:** 2026-01-09
+**Agent:** ps-analyst v2.0.0
+**Status:** PROPOSED
+
+---
+
+## Document Provenance
+
+This trade-off analysis synthesizes insights from:
+- **Unified Design** (work-033-e-002): 64KB architectural specification
+- **Integration Analysis** (work-033-e-001): 95% compatibility assessment
+- **ADR-031**: Knowledge Architecture (Hybrid Property + RDF, 22/25, 88%)
+- **ADR-032**: KM Integration (Lightweight Stack, 8.5/10, 85%)
+
+**Key Context:** Both decisions independently converged on identical architectural patterns (hybrid property graph + RDF + vectors), enabling seamless integration. This analysis evaluates three implementation strategies for the unified design.
+
+---
+
+# L0: Executive Summary (Plain Language)
+
+## What This Analysis Does
+
+Jerry needs to enhance its knowledge management capabilities to help agents find, understand, and reuse accumulated knowledge. Two major architectural decisions (WORK-031 and WORK-032) have been proposed, and they align remarkably well—95% compatible with no conflicts.
+
+This document analyzes **three ways to implement** the unified knowledge architecture:
+
+1. **Minimal** - Start small, build only essentials
+2. **Phased** - Incremental implementation over 8-12 months (recommended)
+3. **Full** - Build everything upfront in one go
+
+## The Three Options Explained
+
+### Option 1: Minimal Implementation ("Crawl")
+
+**What you get:**
+- Basic graph operations (track relationships between documents)
+- Simple keyword search (better than grep, not yet semantic)
+- RDF export for standards compliance
+- Timeline: 4-6 weeks
+- Cost: 30-50 hours of work
+
+**Trade-off:** Fast to build, but limited capabilities. You'd have relationship tracking but miss semantic search and AI grounding features that make knowledge graphs transformative.
+
+**Analogy:** Like buying a basic phone—it makes calls, but you miss apps and internet.
+
+---
+
+### Option 2: Phased Implementation ("Walk, Then Run") ← RECOMMENDED
+
+**What you get:**
+- **Phase 1 (8 weeks):** Foundation - ports, adapters, protocols
+- **Phase 2 (8 weeks):** RDF serialization + graph layer + vector search
+- **Phase 3 (12 weeks):** GraphRAG + SPARQL + grounding verification
+- **Phase 4 (triggered):** Scale only if needed (>10M entities, multi-tenant)
+- Timeline: 8-28 weeks (depending on go/no-go decisions)
+- Cost: 70-150 hours total across phases
+
+**Trade-off:** Moderate pace with clear value checkpoints. Each phase delivers working features before moving forward. Can stop at Phase 2 if advanced capabilities aren't needed.
+
+**Analogy:** Like building a house room-by-room—each room is livable before starting the next.
+
+---
+
+### Option 3: Full Implementation ("Sprint")
+
+**What you get:**
+- Everything at once: RDF + graph + vectors + SPARQL + GraphRAG + grounding
+- All features available immediately
+- Timeline: 12-16 weeks (single push)
+- Cost: 120-180 hours upfront
+
+**Trade-off:** Fastest to "complete," but highest risk. If priorities change or features aren't used, you've invested heavily upfront. No early feedback loops.
+
+**Analogy:** Like buying a fully-loaded car—you get all features, but pay for many you might never use.
+
+---
+
+## The Recommendation: Phased Implementation
+
+**Why?**
+
+1. **Lowest Risk:** Clear go/no-go gates after each phase. Can stop if value plateaus.
+2. **Early Value:** Phase 2 (week 8) delivers relationship discovery and semantic search—the core capabilities.
+3. **Learn as You Build:** User feedback shapes later phases. Don't build SPARQL if no one needs it.
+4. **Industry Validated:** Both WORK-031 and WORK-032 independently recommend phased approach. Netflix UDA pattern (production-proven) supports this.
+5. **Best Scores:** Wins on 4 of 5 decision criteria (see Decision Matrix below).
+
+**What You Sacrifice:**
+- Slightly longer timeline to "full" capability (28 weeks vs 16 weeks)
+- Must wait for advanced features (SPARQL, grounding verification)
+
+**What You Gain:**
+- Reduced risk of over-engineering
+- Early ROI (Phase 2 delivers value before Phase 3 even starts)
+- Flexibility to adapt based on actual usage patterns
+
+---
+
+## Key Trade-offs Visualized
+
+```
+         Minimal     Phased      Full
+         -------     ------      ----
+Speed    ★★★★★       ★★★         ★★
+Risk     ★★          ★★★★★       ★★
+Value    ★★          ★★★★        ★★★★★
+Cost     ★★★★★       ★★★★        ★★
+Flex     ★           ★★★★★       ★
+
+★ = Low/Poor, ★★★★★ = High/Excellent
+```
+
+**Key Insight:** Phased offers the best **balance** across all dimensions. Minimal is too limited, Full is too risky.
+
+---
+
+## Success Criteria (How We'll Know It's Working)
+
+**After Phase 2 (Week 8):**
+- ✅ Can answer "what relates to X?" via graph queries
+- ✅ Can find semantically similar documents via vector search
+- ✅ Can export knowledge graph as RDF (standards compliance)
+- ✅ Agents retrieve knowledge with Jerry URI citations
+- ✅ 10-20% time saved finding information (measured via surveys)
+
+**After Phase 3 (Week 28):**
+- ✅ GraphRAG demonstrates measurable improvement in agent reasoning
+- ✅ SPARQL endpoint functional (if external integration use cases emerge)
+- ✅ 15-25% reduced duplicate work (via "what exists?" query logs)
+- ✅ Knowledge reuse tracked ("which patterns applied to new problems?")
+
+**If triggers not met:** Don't proceed to Phase 4. Stay on embedded architecture.
+
+---
+
+## What Could Go Wrong (and How We'll Handle It)
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| **Knowledge corpus grows beyond tool capacity** | MEDIUM | Port/adapter pattern enables swap to igraph/Qdrant |
+| **Complexity overhead slows development** | MEDIUM | Netflix UDA pattern, automated testing, defer optional features |
+| **User adoption failure (protocols)** | MEDIUM | Lightweight AAR (3 questions, <5 min), show value via reports |
+| **Dependency abandonment** | LOW | Pin versions, hexagonal architecture isolates impact |
+| **Over-engineering** | MEDIUM | Strict phase gates, YAGNI discipline, quarterly ROI review |
+
+**Overall Risk:** MODERATE (acceptable). Combined mitigations from both decisions are stronger than either alone.
+
+---
+
+## The Bottom Line
+
+**Phased Implementation wins** because it balances:
+- **Speed to value:** Phase 2 delivers core capabilities in 8 weeks
+- **Risk management:** Clear stop points, reversible decisions
+- **Cost control:** Only invest in features that demonstrate value
+- **Industry alignment:** Both research syntheses recommend this approach
+
+**You can always speed up** (collapse phases) but can't easily reverse over-investment.
+
+---
+
+# L1: Technical Analysis
+
+## 1. SWOT Analysis: Unified KM Design
+
+### Strengths
+
+| Strength | Evidence | Impact |
+|----------|----------|--------|
+| **S1: Architectural Convergence** | Both WORK-031 and WORK-032 independently recommend hybrid property graph + RDF (95% compatibility) | Unified vision reduces implementation risk, no competing paradigms |
+| **S2: Production-Validated Patterns** | Netflix UDA (Model Once, Represent Everywhere), GraphRAG case studies (90% hallucination reduction) | De-risks architecture, proven at scale |
+| **S3: Hexagonal Architecture Fit** | All components (NetworkX, RDFLib, FAISS) integrate via infrastructure ports, zero domain dependencies | Clean separation of concerns, swappable implementations |
+| **S4: Backward Compatibility** | Phase 1 property graph foundation unchanged, filesystem remains source of truth (P-002) | No throwaway work, incremental enhancement |
+| **S5: Multiple Migration Paths** | NetworkX → igraph → graph-tool, FAISS → Qdrant, RDFLib → pyoxigraph | Not locked into initial tool choices |
+| **S6: Standards Compliance** | W3C RDF 1.2, SPARQL 1.2, JSON-LD 1.1, Schema.org integration | Interoperability, future-proofing, 5-star Linked Data |
+| **S7: Zero Operational Cost (Phase 2-3)** | Embedded databases (pyoxigraph, FAISS), no external services | No monthly bills, privacy-preserving, local-first |
+| **S8: Comprehensive Research Base** | 358KB research synthesis across 71+ citations, unanimous pattern support (5/5 documents) | Evidence-based decision, not speculative |
+
+**Strengths Summary:** The unified design leverages proven architectural patterns with strong research backing, maintains backward compatibility, and provides clear migration paths—minimizing risk while maximizing capability.
+
+---
+
+### Weaknesses
+
+| Weakness | Evidence | Impact |
+|----------|----------|--------|
+| **W1: Architectural Complexity** | 5 serialization formats (JSON, TOON, JSON-LD, Turtle, GraphSON), multi-layer validation | Higher maintenance burden, testing matrix explosion |
+| **W2: Learning Curve** | Semantic web concepts (RDF, SPARQL, SHACL), graph patterns (Gremlin), embeddings | Steeper contributor onboarding (target: <4 hours) |
+| **W3: Dependency Expansion** | 3 required libraries (NetworkX, RDFLib, FAISS), 3 optional (pyoxigraph, spaCy, Docling) | Violates zero-dependency aspiration (mitigated: infrastructure layer only) |
+| **W4: Tool Capacity Limits** | NetworkX <10K nodes, FAISS CPU-bound, in-memory overhead | 1-2 year runway before potential migration needed |
+| **W5: Multi-Representation Synchronization** | Property graph ↔ RDF consistency, schema versioning across formats | Risk of divergence (mitigated: automated round-trip tests) |
+| **W6: Performance Trade-offs** | RDF export 10x slower than property graph queries (50-500ms vs 5-10ms) | Acceptable for cold path, but must monitor hot path impact |
+
+**Weaknesses Summary:** Complexity and dependency expansion are the primary concerns. Mitigations exist (hexagonal architecture, Netflix UDA pattern, automated testing) but don't eliminate overhead.
+
+---
+
+### Opportunities
+
+| Opportunity | Evidence | Impact |
+|-------------|----------|--------|
+| **O1: LLM Grounding ROI** | 90% hallucination reduction (FalkorDB), 63% faster resolution (LinkedIn), 49%→86% accuracy (Amazon) | Competitive advantage via agent quality |
+| **O2: Knowledge as Competitive Moat** | 300-320% ROI from knowledge graph investments (industry benchmarks) | Accumulated knowledge compounds over time, defensible asset |
+| **O3: Community Collaboration** | Graph visualizations, RDF export enables sharing, Schema.org integration | External contributions, ecosystem growth |
+| **O4: Progressive ISO 30401 Alignment** | Phased approach maps to maturity model, optional certification path | Credibility, enterprise adoption potential |
+| **O5: Future AI Capabilities** | GraphRAG foundation enables multi-hop reasoning, ontology-based constraints | Unlock advanced agent capabilities (Phase 3+) |
+| **O6: Measured ROI Tracking** | "Lessons Applied" reports, knowledge reuse metrics, SECI internalization | Quantify value, justify continued investment |
+
+**Opportunities Summary:** The unified design positions Jerry to capitalize on LLM grounding trends, build defensible knowledge assets, and enable future AI capabilities—with measurable ROI.
+
+---
+
+### Threats
+
+| Threat | Evidence | Impact |
+|--------|----------|--------|
+| **T1: Premature Optimization** | Risk of building Phase 3-4 capabilities Jerry never needs | Wasted effort (mitigated: phase gates, trigger-based Phase 4) |
+| **T2: Over-Engineering vs Domain Features** | If KM work exceeds 20% of dev time, domain features suffer | Opportunity cost (mitigated: quarterly ROI review) |
+| **T3: Dependency Abandonment** | Libraries could be deprecated or introduce breaking changes | Disruption risk (mitigated: hexagonal architecture, version pinning) |
+| **T4: User Adoption Failure** | If AAR/A3 protocols <20% compliance, KM investment wasted | Low ROI (mitigated: lightweight protocols, value demonstration) |
+| **T5: Corpus Growth Exceeds Capacity** | Jerry knowledge >5K nodes, FAISS search >2s triggers migration | Migration effort (mitigated: predefined paths, monitoring) |
+| **T6: Schema Evolution Breaking Changes** | Graph schema changes break agent traversal logic | Agent failures (mitigated: P-030 schema governance, migration scripts) |
+
+**Threats Summary:** Primary threats are scope creep and premature optimization. Strong mitigations exist (phase gates, YAGNI discipline, constitutional requirements) but require ongoing governance.
+
+---
+
+### SWOT Scoring
+
+| Category | Count | Quality | Mitigation Strength | Net Score |
+|----------|-------|---------|---------------------|-----------|
+| **Strengths** | 8 | HIGH | N/A | +8 |
+| **Weaknesses** | 6 | MEDIUM | STRONG | -3 (halved) |
+| **Opportunities** | 6 | HIGH | N/A | +6 |
+| **Threats** | 6 | MEDIUM | STRONG | -3 (halved) |
+
+**Net SWOT Score:** +8 (Positive, with strong mitigations offsetting weaknesses/threats)
+
+**Interpretation:** The unified design has more strengths and opportunities than weaknesses and threats. Crucially, identified weaknesses and threats have effective mitigations, reducing their impact.
+
+---
+
+## 2. Decision Matrix: Implementation Strategy
+
+### Options Evaluated
+
+1. **Minimal Implementation** - Foundation only (ports, basic adapters, simple graph)
+2. **Phased Implementation** - Incremental rollout (Phase 1→2→3→4 with gates) ← RECOMMENDED
+3. **Full Implementation** - All features upfront (everything in 12-16 weeks)
+
+### Evaluation Criteria (Weighted)
+
+| Criterion | Weight | Rationale |
+|-----------|--------|-----------|
+| **Implementation Complexity** | 20% | Lower complexity = faster delivery, fewer bugs, easier onboarding |
+| **Time to Value** | 20% | How quickly do users see tangible benefits? |
+| **Risk Level** | 20% | Probability and impact of failure or over-investment |
+| **Alignment with Jerry Goals** | 20% | Fit with mission (knowledge accumulation + problem solving) |
+| **Maintainability** | 20% | Long-term burden (testing, dependencies, evolution) |
+
+**Total:** 100% (equal weighting reflects balanced priorities)
+
+---
+
+### Scoring (1-5 scale, 5 = best)
+
+| Criterion | Minimal | Phased | Full | Rationale |
+|-----------|---------|--------|------|-----------|
+| **Implementation Complexity** | ★★★★★ (5) | ★★★★ (4) | ★★ (2) | Minimal is simplest, Full has highest complexity (5 serializers, SPARQL, GraphRAG upfront) |
+| **Time to Value** | ★★ (2) | ★★★★★ (5) | ★★★ (3) | Phased delivers value at Week 8 (Phase 2), Minimal limited features, Full delayed (Week 16) |
+| **Risk Level** | ★★★ (3) | ★★★★★ (5) | ★★ (2) | Phased has gates (highest reversibility), Full highest risk (no checkpoints) |
+| **Alignment with Jerry Goals** | ★★ (2) | ★★★★★ (5) | ★★★★ (4) | Phased balances knowledge accumulation (mission) with pragmatism, Minimal too limited |
+| **Maintainability** | ★★★★ (4) | ★★★★ (4) | ★★ (2) | Minimal easiest to maintain, Full has most code surface area, Phased defers complexity |
+
+---
+
+### Weighted Scores
+
+| Option | Complexity (20%) | Time to Value (20%) | Risk (20%) | Alignment (20%) | Maintainability (20%) | **Total** |
+|--------|------------------|---------------------|------------|-----------------|------------------------|-----------|
+| **Minimal** | 5 × 0.2 = **1.0** | 2 × 0.2 = **0.4** | 3 × 0.2 = **0.6** | 2 × 0.2 = **0.4** | 4 × 0.2 = **0.8** | **3.2/5 (64%)** |
+| **Phased** | 4 × 0.2 = **0.8** | 5 × 0.2 = **1.0** | 5 × 0.2 = **1.0** | 5 × 0.2 = **1.0** | 4 × 0.2 = **0.8** | **4.6/5 (92%)** ✅ |
+| **Full** | 2 × 0.2 = **0.4** | 3 × 0.2 = **0.6** | 2 × 0.2 = **0.4** | 4 × 0.2 = **0.8** | 2 × 0.2 = **0.4** | **2.6/5 (52%)** |
+
+---
+
+### Decision Matrix Interpretation
+
+**Winner: Phased Implementation (4.6/5, 92%)**
+
+**Why Phased Wins:**
+- **Highest Score:** Leads by 44% over Minimal, 77% over Full
+- **Wins 4 of 5 Criteria:** Time to Value (5/5), Risk (5/5), Alignment (5/5), Maintainability (tie 4/5)
+- **Only Loses 1 Criterion:** Implementation Complexity (4/5 vs Minimal 5/5)—acceptable trade-off for significantly higher capabilities
+- **Industry Validation:** Both WORK-031 and WORK-032 independently recommend phased approach
+
+**Why Minimal Fails:**
+- Too limited: misses semantic search, RAG, GraphRAG—the transformative capabilities
+- Low alignment with Jerry's mission (knowledge accumulation requires discovery and reuse)
+- Time to value slow (limited features mean limited benefits)
+
+**Why Full Fails:**
+- Highest risk: no go/no-go gates, all-or-nothing investment
+- Time to value delayed: must build everything before seeing benefits (Week 16 vs Week 8)
+- Worst maintainability: most code surface area upfront
+- Premature optimization: SPARQL/GraphRAG might never be used
+
+---
+
+### Sensitivity Analysis
+
+**What if we change weights?**
+
+**Scenario A: Prioritize Speed (Complexity 40%, Time to Value 30%)**
+- Minimal: 1.0×0.4 + 0.4×0.3 + 0.6×0.1 + 0.4×0.1 + 0.8×0.1 = **0.68**
+- Phased: 0.8×0.4 + 1.0×0.3 + 1.0×0.1 + 1.0×0.1 + 0.8×0.1 = **0.90** ✅
+- Full: 0.4×0.4 + 0.6×0.3 + 0.4×0.1 + 0.8×0.1 + 0.4×0.1 = **0.50**
+
+**Scenario B: Prioritize Safety (Risk 40%, Maintainability 30%)**
+- Minimal: 1.0×0.1 + 0.4×0.1 + 0.6×0.4 + 0.4×0.1 + 0.8×0.3 = **0.62**
+- Phased: 0.8×0.1 + 1.0×0.1 + 1.0×0.4 + 1.0×0.1 + 0.8×0.3 = **0.94** ✅
+- Full: 0.4×0.1 + 0.6×0.1 + 0.4×0.4 + 0.8×0.1 + 0.4×0.3 = **0.46**
+
+**Scenario C: Prioritize Mission (Alignment 50%, Risk 30%)**
+- Minimal: 1.0×0.05 + 0.4×0.05 + 0.6×0.3 + 0.4×0.5 + 0.8×0.1 = **0.53**
+- Phased: 0.8×0.05 + 1.0×0.05 + 1.0×0.3 + 1.0×0.5 + 0.8×0.1 = **0.97** ✅
+- Full: 0.4×0.05 + 0.6×0.05 + 0.4×0.3 + 0.8×0.5 + 0.4×0.1 = **0.61**
+
+**Robustness:** Phased wins in **all scenarios**. Decision is insensitive to weight changes—strong indicator of robustness.
+
+---
+
+## 3. Risk Register
+
+### Risk Assessment Methodology
+
+**Probability Scale:**
+- LOW (10-30%): Unlikely to occur
+- MEDIUM (40-60%): Moderate likelihood
+- HIGH (70-90%): Likely to occur
+
+**Impact Scale (1-10):**
+- LOW (1-3): Minor disruption, easily mitigated
+- MEDIUM (4-7): Significant impact, requires planned response
+- HIGH (8-10): Critical impact, threatens project success
+
+**Risk Score = Probability (%) × Impact (1-10) ÷ 10**
+
+---
+
+### Top 10 Risks (Sorted by Score)
+
+#### RISK-1: Knowledge Corpus Growth Exceeds Tool Capacity
+
+**Description:** Jerry's knowledge graph grows beyond NetworkX capacity (<10K nodes) or FAISS performance limits (search >2s), requiring migration to production tools.
+
+**Probability:** MEDIUM (60%)
+**Impact:** HIGH (8/10)
+**Score:** 4.8/10 (CRITICAL)
+
+**Triggers:**
+- Knowledge graph >5K nodes (80% of 10K threshold)
+- FAISS vector search latency >1s (50% of 2s limit)
+- Memory usage >4GB for graph/vectors
+
+**Mitigations:**
+1. **Proactive Monitoring:** Dashboard alerts at 80% capacity (4K nodes, 1s search)
+2. **Port/Adapter Pattern:** Migration paths defined upfront (NetworkX → igraph → graph-tool, FAISS → Qdrant)
+3. **Incremental Optimization:** Try FAISS GPU, graph index tuning before full migration
+4. **Predefined Migration Scripts:** Test migration to igraph/Qdrant with synthetic data
+
+**Contingency Plan:**
+- If triggered: Evaluate igraph (C-based, 10x faster) or Neo4j Community (if ACID needed)
+- Budget 2-4 weeks for migration
+- Hexagonal architecture isolates domain layer from changes
+
+**Residual Risk:** MEDIUM (2.4/10) — Migration paths exist, but effort required
+
+---
+
+#### RISK-2: Supernode Performance Degradation (Actor Vertex)
+
+**Description:** Actor vertex (Claude) accumulates thousands of `CREATED_BY` edges, causing O(n) traversal performance degradation.
+
+**Probability:** HIGH (70%)
+**Impact:** HIGH (8/10)
+**Score:** 5.6/10 (CRITICAL)
+
+**Why High Probability:** Actor vertex is natural supernode—every task/phase/plan created by agents connects to it.
+
+**Mitigations:**
+1. **Temporal Partitioning:** Use time-based edge labels (`CREATED_BY_2026_01` not generic `CREATED_BY`)
+2. **Hierarchical Decomposition:** Intermediate nodes (`Actor:Claude:Session:2026-01-08`)
+3. **Edge Count Validator:** Alerts at 100 edges (warning), 1000 edges (error)
+4. **Constitutional Enforcement:** P-031 (Supernode Prevention) requires mitigation strategy for HIGH-risk vertices
+5. **Quantitative Testing:** Synthetic test with 10,000 tasks to verify mitigation effectiveness
+
+**Contingency Plan:**
+- If degradation detected: Refactor Actor vertex to hierarchical model retroactively
+- Budget 1 week for schema migration
+
+**Residual Risk:** LOW (1.4/10) — Strong mitigations if implemented in Phase 2 Week 1-2
+
+**Source:** WORK-031 RISK-1 (9/9 Critical in original ADR)
+
+---
+
+#### RISK-3: Architectural Complexity Slowing Development Velocity
+
+**Description:** Multi-representation architecture (5 serializers, validation layers, synchronization) adds 20-30% overhead to feature development.
+
+**Probability:** MEDIUM (50%)
+**Impact:** MEDIUM (6/10)
+**Score:** 3.0/10 (MODERATE)
+
+**Mitigations:**
+1. **Netflix UDA Pattern Enforcement:** Serializers as pure functions, no business logic
+2. **Automated Round-Trip Tests:** Catch divergence early (`test_round_trip` parametrized across all serializers)
+3. **Defer Optional Serializers:** Phase 2 focuses on JSON + TOON + JSON-LD (essential), defer Turtle + GraphSON to Phase 3
+4. **Contributor Documentation:** `docs/contributing/SERIALIZATION_GUIDE.md` with clear examples
+5. **Success Metric:** Time-to-implement new entity type <2 hours including all serializers
+
+**Contingency Plan:**
+- If velocity drops >30%: Pause feature development, refactor serialization layer
+- Consider code generation for serializers (reduce manual overhead)
+
+**Residual Risk:** MEDIUM (3.0/10) — Complexity inherent to multi-representation, but manageable
+
+**Source:** WORK-031 RISK-2, WORK-032 RISK-5
+
+---
+
+#### RISK-4: Schema Evolution Breaking Graph Traversals
+
+**Description:** Changes to graph schema (vertex types, edge labels, property names) break existing Gremlin queries and agent traversal logic.
+
+**Probability:** MEDIUM (50%)
+**Impact:** HIGH (7/10)
+**Score:** 3.5/10 (MODERATE)
+
+**Mitigations:**
+1. **Schema Versioning:** Semantic versioning (v2.0.0), major version = breaking changes
+2. **Forward Migration Scripts:** Every schema change includes migration (e.g., `migrations/001_add_blocking_reason.py`)
+3. **Rollback Migration Scripts:** Every change includes rollback for reversibility
+4. **Schema Changelog:** `docs/specifications/SCHEMA_CHANGELOG.md` (constitutional requirement P-030)
+5. **Integration Tests:** Traversal test suite runs against schema versions, catches breaks before deployment
+
+**Contingency Plan:**
+- If break detected: Rollback via migration script
+- Agents updated incrementally (not big-bang)
+
+**Residual Risk:** MEDIUM (3.5/10) — Can't eliminate schema evolution, but systematic management reduces impact
+
+**Source:** WORK-031 RISK-4
+
+---
+
+#### RISK-5: User Adoption Failure (AAR/A3 Protocols)
+
+**Description:** Users don't complete AAR (After-Action Review) or A3 protocols, leading to <20% compliance and low knowledge capture.
+
+**Probability:** MEDIUM (50%)
+**Impact:** MEDIUM (4/10)
+**Score:** 2.0/10 (MODERATE)
+
+**Mitigations:**
+1. **Lightweight Protocols:** AAR = 3 questions, <5 minutes to complete
+2. **Value Demonstration:** "Lessons Applied" reports show how past learnings inform new work
+3. **Integration with Workflow:** AAR triggered automatically at task/phase completion
+4. **Quarterly Retrospective:** Alternative to per-task AAR if adoption remains low
+5. **Gamification (Optional):** Knowledge contribution leaderboard, recognition
+
+**Trigger for Contingency:**
+- If <20% compliance after 3 months → Simplify further or automate extraction
+
+**Contingency Plan:**
+- Semi-automated knowledge extraction (NLP from git commits, task descriptions)
+- Reduce frequency (quarterly not per-task)
+
+**Residual Risk:** MEDIUM (2.0/10) — Behavioral change is hard, but lightweight approach improves odds
+
+**Source:** WORK-032 RISK-4
+
+---
+
+#### RISK-6: Over-Engineering / Scope Creep
+
+**Description:** Building Phase 3-4 capabilities (SPARQL, reasoning, GraphRAG) that Jerry never uses, wasting effort on theoretical features.
+
+**Probability:** MEDIUM (30%)
+**Impact:** MEDIUM (6/10)
+**Score:** 1.8/10 (MODERATE)
+
+**Mitigations:**
+1. **Phase Gates with Go/No-Go Criteria:** Explicit success criteria before Phase 3 (user validation, use case demand)
+2. **YAGNI Discipline:** "You Aren't Gonna Need It"—only build features with proven need
+3. **Quarterly ROI Review:** Measure time saved, duplicate work reduced, knowledge reuse
+4. **Constitutional Gate:** P-032 (Phase Gate Compliance) prevents premature advancement
+5. **User Authority:** Phase 3 requires explicit user approval (P-020)
+
+**Trigger for Contingency:**
+- If KM work exceeds 20% of total dev time in any quarter → Freeze features, focus on utilization
+
+**Contingency Plan:**
+- Maintain Phase 2 capabilities, defer Phase 3 indefinitely
+- Export knowledge graph as RDF for future tools
+
+**Residual Risk:** LOW (1.8/10) — Strong governance prevents over-build
+
+**Source:** WORK-031 RISK-6, WORK-032 RISK-5
+
+---
+
+#### RISK-7: Dependency Abandonment or Breaking Changes
+
+**Description:** NetworkX, RDFLib, or FAISS could introduce breaking changes, security vulnerabilities, or cease maintenance.
+
+**Probability:** LOW (20%)
+**Impact:** HIGH (7/10)
+**Score:** 1.4/10 (LOW-MODERATE)
+
+**Why Low Probability:**
+- NetworkX: 14.9M downloads/week, active development, mature project
+- RDFLib: 14M downloads/week, W3C standards compliance
+- FAISS: Meta-backed, used by LangChain/LlamaIndex, production-critical
+
+**Mitigations:**
+1. **Version Pinning:** Lock versions in `requirements.txt` (avoid auto-upgrades)
+2. **Quarterly Health Checks:** Monitor releases, GitHub activity, security advisories
+3. **Hexagonal Architecture Isolation:** Dependencies in infrastructure layer, domain unaffected
+4. **Adapter Replacement Plan:** Port interface enables swap to alternatives (igraph, graph-tool, Qdrant)
+5. **Stdlib Fallback:** Simple graph operations possible with dict/set (degraded performance)
+
+**Trigger for Contingency:**
+- 6 months without releases OR critical security vulnerability → Evaluate alternatives
+
+**Contingency Plan:**
+- Swap adapter via port interface (domain/application layers unchanged)
+- Budget 1-2 weeks for adapter rewrite
+
+**Residual Risk:** LOW (1.4/10) — Mature libraries, clear fallbacks
+
+**Source:** WORK-032 RISK-2
+
+---
+
+#### RISK-8: Implementation Delays / Complexity Underestimation
+
+**Description:** Implementation takes 2-3x longer than estimated, delaying value delivery and straining resources.
+
+**Probability:** MEDIUM (40%)
+**Impact:** MEDIUM (5/10)
+**Score:** 2.0/10 (MODERATE)
+
+**Mitigations:**
+1. **Phased Rollout with MVP:** Phase 2 delivers tangible value in 8 weeks (not 28 weeks)
+2. **Buffer Time:** Estimates include 20% buffer (e.g., 70 hours → 84 hours realistic)
+3. **Scope Descope:** If Phase 2 exceeds 4 weeks, cut optional features (Turtle, GraphSON)
+4. **Weekly Status Checks:** Monitor progress, adjust scope dynamically
+5. **External Validation:** Effort estimates based on synthesis research (not speculative)
+
+**Trigger for Contingency:**
+- If Phase 2 exceeds 10 weeks (25% overrun) → Pause, reassess architecture
+
+**Contingency Plan:**
+- Deliver basic graph operations first (relationship discovery)
+- Defer semantic search (FAISS) to separate phase
+- User feedback informs priorities
+
+**Residual Risk:** MEDIUM (2.0/10) — Implementation risk inherent in software projects
+
+**Source:** WORK-032 RISK-3
+
+---
+
+#### RISK-9: Premature Phase 4 Migration (Server-Based Infrastructure)
+
+**Description:** Migrating to server-based triple store (Fuseki, Neptune) before necessary, incurring $100-1000/month costs and operational overhead.
+
+**Probability:** LOW (10%)
+**Impact:** HIGH (8/10)
+**Score:** 0.8/10 (LOW)
+
+**Why Low Probability:** Phase 4 has explicit trigger conditions (multi-tenant OR >10M entities OR P95 >500ms OR clustering).
+
+**Mitigations:**
+1. **Explicit Trigger Conditions:** Documented in ASM-001, ASM-002 assumptions
+2. **Quantitative Monitoring:** Entity count alerts at 8M (80% of 10M threshold)
+3. **Phase 4 Evaluation Checklist:** Requires user approval + cost-benefit analysis
+4. **Constitutional Gate:** P-032 prevents premature advancement
+5. **Quarterly Review:** Monitor against triggers (currently: thousands of entities, <50ms latency)
+
+**Trigger for Contingency:**
+- If triggers NOT met but migration proposed → Reject, stay embedded
+
+**Contingency Plan:**
+- Remain on embedded Phase 2-3 architecture indefinitely
+- Only migrate if quantitative triggers crossed
+
+**Residual Risk:** LOW (0.8/10) — Clear gates prevent premature migration
+
+**Source:** WORK-031 RISK-3
+
+---
+
+#### RISK-10: LLM Grounding Verification False Positives
+
+**Description:** MiniCheck grounding verification incorrectly flags factually correct responses as "not supported," causing agent warnings and user confusion.
+
+**Probability:** MEDIUM (40%)
+**Impact:** LOW (3/10)
+**Score:** 1.2/10 (LOW)
+
+**Why Low Impact:** Soft warnings (non-blocking), doesn't break functionality, user can review and override.
+
+**Mitigations:**
+1. **Confidence Threshold Tuning:** Set at 0.7 (adjust based on false positive rate in production)
+2. **Soft Warnings (Non-Blocking):** Emit CloudEvent warning, don't block LLM response
+3. **Defer to Phase 3:** Grounding verification optional in Phase 2 (simpler Jerry URI citations first)
+4. **User Feedback Loop:** Allow users to mark false positives, retrain threshold
+5. **Success Metric:** False positive rate <5% on golden dataset
+
+**Trigger for Contingency:**
+- If false positive rate >10% → Disable verification, reassess model
+
+**Contingency Plan:**
+- Use Jerry URI citations only (no automated verification)
+- Phase 3 optional (can skip grounding verification entirely)
+
+**Residual Risk:** LOW (1.2/10) — Soft warnings, optional feature
+
+**Source:** WORK-031 RISK-5
+
+---
+
+### Risk Heat Map
+
+```
+Impact (1-10)
+    10 │
+     9 │
+     8 │        RISK-2         RISK-1
+     7 │        RISK-4         RISK-7
+     6 │        RISK-3         RISK-6
+     5 │        RISK-8
+     4 │        RISK-5
+     3 │                       RISK-10
+     2 │
+     1 │
+       └────────────────────────────────────
+        10   20   30   40   50   60   70   80
+                  Probability (%)
+
+Risk Zones:
+  RED (Top-Right): CRITICAL - RISK-1, RISK-2
+  YELLOW (Middle): MODERATE - RISK-3, RISK-4, RISK-5, RISK-6, RISK-8
+  GREEN (Bottom-Left): LOW - RISK-7, RISK-9, RISK-10
+```
+
+**Risk Profile:** Most risks in MODERATE zone with effective mitigations. Two CRITICAL risks (corpus growth, supernode) have strong preventive measures.
+
+---
+
+### Risk Mitigation Summary
+
+| Risk ID | Score | Residual Risk | Mitigation Strength | Status |
+|---------|-------|---------------|---------------------|--------|
+| RISK-1 | 4.8 | 2.4 | STRONG | Port/adapter pattern + monitoring |
+| RISK-2 | 5.6 | 1.4 | STRONG | Temporal partitioning + P-031 constitutional requirement |
+| RISK-3 | 3.0 | 3.0 | MEDIUM | Netflix UDA + automated testing |
+| RISK-4 | 3.5 | 3.5 | MEDIUM | P-030 schema governance + migration scripts |
+| RISK-5 | 2.0 | 2.0 | MEDIUM | Lightweight AAR + value demonstration |
+| RISK-6 | 1.8 | 1.8 | STRONG | Phase gates + YAGNI + P-032 |
+| RISK-7 | 1.4 | 1.4 | STRONG | Hexagonal architecture + version pinning |
+| RISK-8 | 2.0 | 2.0 | MEDIUM | Phased rollout + buffer time |
+| RISK-9 | 0.8 | 0.8 | STRONG | Explicit triggers + constitutional gate |
+| RISK-10 | 1.2 | 1.2 | STRONG | Soft warnings + Phase 3 optional |
+
+**Overall Risk:** MODERATE (acceptable with active risk management)
+
+**Key Insight:** Highest risks (RISK-1, RISK-2) have strongest mitigations—port/adapter pattern and constitutional requirements reduce residual risk by 50%+.
+
+---
+
+## 4. Complexity Metrics
+
+### 4.1 Architectural Complexity
+
+**Layers Added to Jerry:**
+
+| Layer | Component Count | Dependency Count | Lines of Code (Estimated) |
+|-------|-----------------|------------------|---------------------------|
+| **Domain (Ports)** | 4 ports | 0 (stdlib only) | ~400 lines |
+| **Infrastructure (Adapters)** | 6 adapters | 3 (NetworkX, RDFLib, FAISS) | ~1,200 lines |
+| **Application (Use Cases)** | 8 commands/queries | 0 (ports only) | ~800 lines |
+| **Interface (CLI/Skills)** | 3 commands | 0 (application only) | ~300 lines |
+
+**Total Additions:** ~2,700 lines of code (Phase 2 complete)
+
+**Complexity Indicators:**
+
+| Metric | Minimal | Phased (Phase 2) | Full | Notes |
+|--------|---------|------------------|------|-------|
+| **Dependencies** | 0 | 3 | 6 | Phased defers pyoxigraph, spaCy, Docling to Phase 3 |
+| **Serialization Formats** | 2 (JSON, TOON) | 3 (+JSON-LD) | 5 (+Turtle, GraphSON) | Netflix UDA pattern |
+| **Validation Layers** | 1 (schema) | 3 (+SHACL, supernode) | 5 (+grounding, OWL) | Defense-in-depth |
+| **Lines of Code** | ~500 | ~2,700 | ~5,000 | Estimated for full implementation |
+| **Test Cases** | ~50 | ~200 | ~400 | Round-trip tests per serializer |
+| **Configuration Files** | 2 | 5 | 10 | JSON-LD contexts, SHACL shapes, OWL ontology |
+
+**Cyclomatic Complexity (McCabe):**
+- Minimal: ~5-10 (linear flow)
+- Phased: ~15-20 (branching for serializers, validation)
+- Full: ~30-40 (decision trees for all features)
+
+**Cognitive Complexity (Sonar):**
+- Minimal: LOW (straightforward graph operations)
+- Phased: MEDIUM (multi-representation requires understanding Netflix UDA)
+- Full: HIGH (SPARQL, reasoning, grounding verification add mental overhead)
+
+**Interpretation:** Phased hits sweet spot—moderate complexity for significant capability gain. Full complexity doubles code and cognitive load.
+
+---
+
+### 4.2 Coupling and Cohesion
+
+**Coupling Analysis (Afferent/Efferent Coupling):**
+
+| Module | Afferent (Incoming) | Efferent (Outgoing) | Instability (I = E/(A+E)) | Abstractness (A) | Distance from Main Sequence |
+|--------|---------------------|---------------------|---------------------------|------------------|------------------------------|
+| **Domain Ports** | 6 (app, infra) | 0 | 0.0 (stable) | 1.0 (abstract) | 0.0 (ideal) |
+| **Infrastructure Adapters** | 4 (app) | 3 (libs) | 0.43 (balanced) | 0.0 (concrete) | 0.43 (acceptable) |
+| **Application Use Cases** | 3 (interface) | 2 (domain, infra) | 0.40 (balanced) | 0.2 (some abstraction) | 0.20 (good) |
+| **Interface CLI/Skills** | 0 (external users) | 2 (app) | 1.0 (unstable, expected) | 0.0 (concrete) | 1.0 (acceptable for UI) |
+
+**Cohesion Analysis (LCOM - Lack of Cohesion of Methods):**
+- **Domain Entities:** LCOM ~0.2 (HIGH cohesion—all methods operate on same data)
+- **Adapters:** LCOM ~0.3 (HIGH cohesion—focused on single port implementation)
+- **Use Cases:** LCOM ~0.4 (MEDIUM cohesion—orchestrate multiple ports, acceptable)
+
+**Interpretation:** Hexagonal architecture maintains low coupling (domain isolated) and high cohesion (focused modules). Well-structured.
+
+---
+
+### 4.3 Maintenance Burden Estimation
+
+**Time Investment per Phase (Hours):**
+
+| Activity | Minimal | Phased (Phase 2) | Full |
+|----------|---------|------------------|------|
+| **Initial Implementation** | 30-50 | 70-100 | 120-180 |
+| **Testing** | 10 | 30 | 50 |
+| **Documentation** | 5 | 15 | 30 |
+| **Quarterly Maintenance** | 2-4 | 5-8 | 10-15 |
+| **Dependency Updates** | 0 | 1-2 | 3-5 |
+| **Schema Migrations (per year)** | 2 | 5 | 10 |
+
+**Annual Maintenance Burden (Hours/Year):**
+- Minimal: ~20 hours (8 hrs quarterly × 4 + 2 migrations × 1 hr)
+- Phased: ~40 hours (quarterly 8 hrs × 4 + 5 migrations × 2 hrs)
+- Full: ~80 hours (quarterly 15 hrs × 4 + 10 migrations × 3 hrs)
+
+**Maintenance as % of Implementation:**
+- Minimal: 40% (20/50)
+- Phased: 40% (40/100)
+- Full: 44% (80/180)
+
+**Interpretation:** Phased and Full have similar maintenance ratios (~40%), but Full has 2x absolute burden (80 vs 40 hours/year).
+
+---
+
+### 4.4 Technology Maturity and Support
+
+| Library | Version | Downloads/Week | Last Release | Active Issues | Stars | Maturity |
+|---------|---------|----------------|--------------|---------------|-------|----------|
+| **NetworkX** | 3.2.1 | 14.9M | 2024-01 | ~200 | 14.3K | MATURE |
+| **RDFLib** | 7.0.0 | 14M | 2023-11 | ~150 | 2.2K | MATURE |
+| **FAISS** | 1.7.4 | 800K+ | 2024-01 | ~100 | 27.8K | MATURE |
+| **pyoxigraph** | Latest | 50K | 2024-12 | ~30 | 700 | GROWING |
+| **spaCy** | 3.7+ | 3M | 2024-01 | ~200 | 28.2K | MATURE |
+
+**Dependency Health Score (Weighted):**
+- NetworkX: 95/100 (excellent)
+- RDFLib: 85/100 (mature, stable)
+- FAISS: 90/100 (Meta-backed, production)
+- pyoxigraph: 70/100 (newer, but active development)
+- spaCy: 95/100 (industry standard)
+
+**Overall Dependency Health:** 87/100 (STRONG)
+
+**Risk Assessment:** Low dependency abandonment risk. All libraries have active communities, production usage, and clear governance.
+
+---
+
+### 4.5 Learning Curve and Onboarding
+
+**Estimated Time to Competency (Hours):**
+
+| Skill | Minimal | Phased | Full | Resources |
+|-------|---------|--------|------|-----------|
+| **Graph Concepts** | 2 | 4 | 8 | NetworkX tutorial, graph theory basics |
+| **RDF/Semantic Web** | 0 | 4 | 12 | W3C RDF Primer, JSON-LD Playground |
+| **SPARQL** | 0 | 0 | 8 | SPARQL tutorial, W3C spec |
+| **Vector Embeddings** | 0 | 2 | 4 | OpenAI embeddings guide, FAISS docs |
+| **Hexagonal Architecture** | 2 | 2 | 2 | Alistair Cockburn article, Jerry codebase |
+| **Netflix UDA Pattern** | 0 | 2 | 4 | Jerry SERIALIZATION_GUIDE.md |
+| **Jerry-Specific Concepts** | 1 | 2 | 4 | CLAUDE.md, Work Tracker docs |
+
+**Total Onboarding Time:**
+- Minimal: **5 hours** (graph concepts + hexagonal + Jerry-specific)
+- Phased: **16 hours** (adds RDF, embeddings, UDA pattern)
+- Full: **42 hours** (adds SPARQL, advanced semantic web)
+
+**Onboarding Success Metrics:**
+- **Target (WORK-031):** <4 hours for contributors (not met by any option)
+- **Realistic (Phased):** <16 hours to implement new entity with all serializers
+- **Acceptable (Full):** <42 hours for full semantic web competency
+
+**Interpretation:** Phased keeps learning curve manageable (2 days of study). Full requires 1 week+ of learning before contribution.
+
+---
+
+### Complexity Summary Table
+
+| Metric | Minimal | Phased (Phase 2) | Full | Winner |
+|--------|---------|------------------|------|--------|
+| **Lines of Code** | ~500 | ~2,700 | ~5,000 | Minimal |
+| **Dependencies** | 0 | 3 | 6 | Minimal |
+| **Cyclomatic Complexity** | 5-10 | 15-20 | 30-40 | Minimal |
+| **Coupling (Domain Instability)** | 0.0 | 0.0 | 0.0 | Tie |
+| **Cohesion (LCOM)** | 0.2 | 0.3 | 0.4 | Minimal |
+| **Annual Maintenance (Hours)** | 20 | 40 | 80 | Minimal |
+| **Onboarding Time (Hours)** | 5 | 16 | 42 | Minimal |
+| **Dependency Health** | N/A | 87/100 | 85/100 | Phased |
+| **Time to Value (Weeks)** | 4-6 | 8 | 16 | Minimal (but limited) |
+
+**Complexity Winner:** Minimal (unsurprisingly—but at cost of capability)
+
+**Balanced Winner:** Phased (3x complexity of Minimal, but 5x+ capability gain)
+
+**Key Insight:** Complexity scales linearly with capability. Phased delivers 80% of Full capability at 54% of complexity (2,700 vs 5,000 LOC).
+
+---
+
+# L2: Strategic Assessment
+
+## 1. Long-Term Implications
+
+### 1.1 Architectural Evolution
+
+**Decision Tree: Where Does Each Option Lead?**
+
+```
+MINIMAL IMPLEMENTATION
+    ├─ Year 1: Basic graph operations working
+    ├─ Year 2: Corpus hits limits (~100 docs), pressure to upgrade
+    ├─ Year 3: CHOICE POINT:
+    │   ├─ Option A: Rip-and-replace with Phased or Full
+    │   │   └─ Cost: Throwaway work, migration effort
+    │   └─ Option B: Stay minimal, accept limitations
+    │       └─ Cost: Missed LLM grounding opportunities, manual cross-referencing
+    └─ Long-term: Technical debt accumulates, competitive disadvantage
+
+PHASED IMPLEMENTATION ← RECOMMENDED
+    ├─ Year 1: Phase 2 complete (graph + RDF + vectors), delivering value
+    ├─ Year 2: Phase 3 evaluation (GraphRAG, SPARQL if use cases emerge)
+    │   ├─ Option A: Proceed to Phase 3 (demand validated)
+    │   │   └─ Benefit: Advanced AI capabilities, SPARQL for integration
+    │   └─ Option B: Stay at Phase 2 (no demand, save effort)
+    │       └─ Benefit: Avoid over-engineering, focus on domain features
+    ├─ Year 3-5: Monitor triggers for Phase 4 (>10M entities, multi-tenant)
+    │   ├─ If triggered: Migrate to production tools (Neo4j, Qdrant)
+    │   └─ If not: Remain embedded, zero operational cost
+    └─ Long-term: Flexible evolution based on actual needs, knowledge as competitive asset
+
+FULL IMPLEMENTATION
+    ├─ Year 1: All features built, high upfront investment
+    ├─ Year 2: Discover SPARQL unused, grounding verification disabled
+    │   └─ Cost: Wasted effort (~40 hours on unused features)
+    ├─ Year 3: Maintenance burden high (80 hours/year)
+    │   ├─ Option A: Continue maintaining unused features
+    │   │   └─ Cost: Ongoing overhead for no benefit
+    │   └─ Option B: Deprecate unused features
+    │       └─ Cost: Refactoring effort, throwaway work
+    └─ Long-term: Over-engineered system, hard to adapt
+```
+
+**Strategic Implication:** Phased minimizes regret—can accelerate (collapse phases) or decelerate (stop at Phase 2) based on actual usage.
+
+---
+
+### 1.2 Knowledge as Competitive Asset
+
+**5-Year Knowledge Accumulation Scenarios:**
+
+| Year | Minimal | Phased | Full |
+|------|---------|--------|------|
+| **Year 1** | 50 docs, manual cross-ref | 200 docs, semantic search | 300 docs, full GraphRAG |
+| **Year 2** | 100 docs, fragmentation | 500 docs, knowledge graph, RAG | 600 docs, SPARQL integration |
+| **Year 3** | 150 docs, "we built this before" queries fail | 1,000 docs, "Lessons Applied" reports, ISO 30401 alignment | 1,000 docs, underutilized features |
+| **Year 4** | 200 docs, plateau (no tools to scale) | 2,000 docs, trigger Phase 4 evaluation (>5K nodes) | 1,500 docs, maintenance burden slows growth |
+| **Year 5** | 250 docs, competitive disadvantage | 3,000+ docs, knowledge as moat, agent quality differentiation | 2,000 docs, technical debt from premature optimization |
+
+**ROI Projections (Cumulative):**
+
+| Metric | Minimal | Phased | Full |
+|--------|---------|--------|------|
+| **Time Saved Finding Info** | 5% (limited search) | 15-20% (semantic search + graph) | 15-20% (same as Phased, unused features) |
+| **Reduced Duplicate Work** | 5% (manual check) | 20-25% ("what exists?" queries) | 20-25% (same as Phased) |
+| **Agent Reasoning Quality** | Baseline (no grounding) | +30-50% (RAG grounding) | +40-60% (GraphRAG, but complex) |
+| **Implementation Cost** | 50 hrs | 150 hrs (across phases) | 200 hrs (upfront) |
+| **Maintenance Cost (5 years)** | 100 hrs | 200 hrs | 400 hrs |
+| **Total Cost (5 years)** | 150 hrs | 350 hrs | 600 hrs |
+| **Value Created (Est.)** | 200 hrs saved | 1,000 hrs saved | 1,000 hrs saved |
+| **Net ROI** | +50 hrs (33% ROI) | +650 hrs (186% ROI) | +400 hrs (67% ROI) |
+
+**Strategic Implication:** Phased has highest ROI (186%) by matching investment to proven value. Full achieves same value at 2x cost.
+
+---
+
+### 1.3 Organizational Learning and Capability
+
+**Capability Development Trajectories:**
+
+**Minimal:**
+- Year 1-2: Basic graph literacy
+- Year 3-5: Stagnation—no incentive to learn advanced concepts
+- Long-term: Team capability plateaus
+
+**Phased:**
+- Year 1: Graph concepts, RDF basics
+- Year 2: Semantic web (JSON-LD), vector embeddings
+- Year 3: SPARQL, GraphRAG (if Phase 3 triggered)
+- Year 4-5: Advanced reasoning, ontology design
+- Long-term: Progressive skill building, industry-relevant expertise
+
+**Full:**
+- Year 1: Steep learning curve (42 hours), cognitive overload
+- Year 2: Forgetting unused features (SPARQL, OWL if not applied)
+- Year 3-5: Maintenance of complex system, diminishing returns
+- Long-term: Risk of "cargo cult" patterns—features used because they exist, not because they solve problems
+
+**Strategic Implication:** Phased builds capabilities incrementally, matching learning to application. Full front-loads complexity, risks knowledge loss if features unused.
+
+---
+
+### 1.4 External Integration and Ecosystem
+
+**Interoperability Scenarios:**
+
+| Integration Use Case | Minimal | Phased | Full |
+|---------------------|---------|--------|------|
+| **Obsidian Plugin (User Layer)** | ❌ No graph export | ✅ RDF export (Phase 2) | ✅ RDF + SPARQL |
+| **External KM Tools (Confluence, Notion)** | ❌ JSON only | ✅ JSON-LD import/export | ✅ Full RDF |
+| **Semantic Web (Schema.org)** | ❌ No standards | ✅ Schema.org mapping (Phase 2) | ✅ 5-star Linked Data |
+| **LLM Frameworks (LangChain, LlamaIndex)** | ❌ No RAG | ✅ FAISS integration (Phase 2) | ✅ GraphRAG (Phase 3) |
+| **Enterprise Search (Elasticsearch)** | ❌ No indexing | ✅ Vector export (Phase 2) | ✅ Multi-format export |
+
+**Ecosystem Positioning:**
+
+**Minimal:** Isolated island—no interoperability, Jerry-specific formats only.
+
+**Phased:** Progressive opening—Phase 2 enables export/import, Phase 3 enables query federation.
+
+**Full:** Fully open—immediate integration with external tools, but complexity may deter adoption.
+
+**Strategic Implication:** Phased balances openness (RDF export) with pragmatism (defer complexity). Full offers max interoperability but at cost of internal complexity.
+
+---
+
+## 2. Scalability Considerations
+
+### 2.1 Corpus Growth Projections
+
+**Knowledge Graph Size Forecasts (Nodes):**
+
+| Year | Conservative | Baseline | Optimistic | Notes |
+|------|--------------|----------|------------|-------|
+| **2026 (End of Year 1)** | 200 | 500 | 1,000 | Phase 2 complete, knowledge capture protocols adopted |
+| **2027** | 500 | 1,500 | 3,000 | AAR/A3 compliance improves, automated extraction |
+| **2028** | 1,000 | 3,000 | 5,000 | Approaching NetworkX limits (10K nodes) |
+| **2029** | 1,500 | 5,000 | 8,000 | Phase 4 trigger evaluation (>5K nodes) |
+| **2030** | 2,000 | 7,000 | 10,000+ | Migration to igraph/graph-tool/Neo4j if needed |
+
+**Tool Capacity vs. Projected Need:**
+
+| Tool | Capacity Limit | Conservative (2030) | Baseline (2030) | Optimistic (2030) | Verdict |
+|------|----------------|---------------------|-----------------|-------------------|---------|
+| **NetworkX** | ~10K nodes | 2,000 (20%) | 7,000 (70%) | 10,000+ (100%) | 2-year runway (baseline), migrate by 2029 (optimistic) |
+| **FAISS (CPU)** | ~1M vectors | 10K (1%) | 35K (3.5%) | 50K (5%) | 5+ year runway |
+| **RDFLib** | ~100K triples | 10K (10%) | 35K (35%) | 50K (50%) | 3-year runway |
+
+**Trigger Points for Migration:**
+
+| Trigger | Conservative | Baseline | Optimistic |
+|---------|--------------|----------|------------|
+| **NetworkX (>5K nodes)** | Never | 2028-2029 | 2027-2028 |
+| **FAISS (>1s search)** | Never | 2030+ | 2029-2030 |
+| **RDFLib (>100K triples)** | Never | 2030+ | 2029 |
+
+**Strategic Implication:** Baseline scenario triggers Phase 4 evaluation in 2028-2029 (2-3 years). Conservative scenario never triggers migration. Optimistic scenario requires migration by 2028.
+
+**Recommendation:** Phased provides 2+ year runway before migration concerns. Monitor quarterly, but don't prematurely optimize.
+
+---
+
+### 2.2 Performance Scaling
+
+**Latency Projections by Corpus Size:**
+
+| Nodes | NetworkX Traversal (P95) | FAISS Search (P95) | RDFLib Export (P95) | Alert Threshold |
+|-------|--------------------------|--------------------|--------------------|-----------------|
+| **100** | <5ms | <50ms | <10ms | BASELINE |
+| **500** | ~10ms | ~100ms | ~20ms | ✅ GREEN |
+| **1,000** | ~15ms | ~150ms | ~40ms | ✅ GREEN |
+| **3,000** | ~30ms | ~300ms | ~100ms | ⚠️ YELLOW (FAISS) |
+| **5,000** | ~50ms | ~500ms | ~200ms | ⚠️ YELLOW (all) |
+| **10,000** | ~100ms | ~1,000ms | ~500ms | 🔴 RED (Phase 4 trigger) |
+
+**Performance Degradation Analysis:**
+
+**NetworkX:**
+- Scales O(E) for traversal where E = edges
+- Supernode mitigation (temporal partitioning) keeps E manageable
+- Predicted degradation: Linear until 10K nodes, then super-linear
+- **Verdict:** 2-year runway before performance concerns (5K nodes)
+
+**FAISS (CPU):**
+- Scales O(N) for brute-force search where N = vectors
+- Index optimization (IVF, PQ) can extend capacity to 1M vectors
+- Predicted degradation: Linear until 100K vectors, then GPU recommended
+- **Verdict:** 5+ year runway (not a concern)
+
+**RDFLib:**
+- Scales O(N*T) where N = entities, T = triples per entity
+- Python-based parsing = slower than Rust (pyoxigraph)
+- Predicted degradation: Super-linear after 50K triples
+- **Verdict:** 3-year runway, swap to pyoxigraph if needed (Phase 3)
+
+**Mitigation Strategies by Performance Tier:**
+
+| Tier | Condition | Mitigation | Cost |
+|------|-----------|------------|------|
+| **Tier 1 (Optimization)** | 3K-5K nodes, <500ms latency | Index tuning, caching, query optimization | 1-2 weeks |
+| **Tier 2 (Library Swap)** | 5K-10K nodes, 500ms-1s latency | NetworkX → igraph, RDFLib → pyoxigraph | 2-4 weeks |
+| **Tier 3 (Production Tools)** | >10K nodes, >1s latency | Neo4j, Qdrant, Fuseki | 4-8 weeks + $100-1000/month |
+
+**Strategic Implication:** Phased provides clear upgrade path. Tier 1 (optimization) sufficient for 2-3 years under baseline scenario.
+
+---
+
+### 2.3 Multi-User and Concurrency
+
+**Current State (Phase 1):**
+- Single-user, file-based storage
+- No concurrency control (git provides versioning)
+- No ACID transactions
+
+**Scalability to Multi-User:**
+
+| Scenario | Minimal | Phased | Full |
+|----------|---------|--------|------|
+| **2-5 Users (Collaborative)** | ⚠️ Git conflicts, manual merges | ✅ Read-mostly workload, occasional conflicts | ✅ Same as Phased |
+| **5-10 Users (Team)** | 🔴 Unworkable (merge hell) | ⚠️ Conflicts increase, consider locking | ✅ SPARQL enables read-only queries |
+| **10+ Users (Organization)** | 🔴 Not viable | 🔴 ACID required (Neo4j) | ✅ Already has SPARQL (read), but no ACID |
+
+**Concurrency Limitations:**
+
+**Minimal & Phased (Phase 2):**
+- **Reads:** Unlimited (file-based, no locking)
+- **Writes:** Single writer (git prevents concurrent commits)
+- **Conflict Resolution:** Manual (git merge)
+
+**Full (Phase 3 with pyoxigraph):**
+- **Reads:** Unlimited (SPARQL queries)
+- **Writes:** Still single writer (embedded pyoxigraph)
+- **Conflict Resolution:** Manual
+
+**Phase 4 (Server-Based):**
+- **Reads:** Unlimited
+- **Writes:** Concurrent with ACID (Neo4j, Fuseki)
+- **Conflict Resolution:** Automatic (database transactions)
+
+**Strategic Implication:** Multi-user scenarios (>5 users) require Phase 4. Current assumption (ASM-001: single-tenant through Phase 3) means Minimal and Phased sufficient.
+
+**Trigger:** If Jerry expands to team/organization use (>5 concurrent users), accelerate Phase 4 evaluation regardless of corpus size.
+
+---
+
+## 3. Implementation Phases Recommendation
+
+### 3.1 Recommended Strategy: Phased Implementation
+
+**Why Phased Wins (Summary):**
+
+1. **Decision Matrix:** 4.6/5 (92%)—highest score
+2. **SWOT:** 8 strengths, effective mitigation of 6 weaknesses/threats
+3. **Risk:** 10 risks identified with strong mitigations, residual risk MODERATE
+4. **ROI:** 186% over 5 years (highest of all options)
+5. **Industry Validation:** Both WORK-031 and WORK-032 independently recommend phased approach
+6. **Sensitivity Analysis:** Wins in all weight scenarios (robust to priority changes)
+
+---
+
+### 3.2 Phase-by-Phase Breakdown
+
+#### **Phase 1: Foundation (✅ COMPLETE)**
+
+**Status:** Already implemented in Jerry.
+
+**Deliverables:**
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker graph model
+
+**No Action Needed:** Build on this foundation.
+
+---
+
+#### **Phase 2: Semantic Layer + KM Foundation (Q1 2026, 8 weeks)**
+
+**Goal:** Core KM capabilities—relationship discovery, semantic search, RDF export.
+
+**Week 1-2: Ports + Protocols**
+
+**Deliverables:**
+- Port definitions (GraphPort, RDFSerializerPort, VectorStorePort, KnowledgePort)
+- Install dependencies (NetworkX 3.2.1, RDFLib 7.0.0, FAISS 1.7.4)
+- JSON-LD context creation (`contexts/worktracker.jsonld`)
+- Supernode validator (100/1000 thresholds)
+- AAR/A3 templates (`.claude/templates/`)
+- Baseline Knowledge Audit
+
+**Success Criteria:**
+- ✅ All ports defined, zero domain dependencies
+- ✅ Supernode validator catches edges ≥100 (warning), ≥1000 (error)
+- ✅ JSON-LD context validates against JSON-LD 1.1 spec
+
+**Effort:** 20-25 hours
+
+---
+
+**Week 3-4: RDF Serialization**
+
+**Deliverables:**
+- RDFLib adapter implementing RDFSerializerPort
+- Turtle serialization for Task/Phase/Plan entities
+- JSON-LD serialization using contexts
+- SHACL validation shapes (`schemas/worktracker-shapes.ttl`)
+- Automated round-trip tests (JSON ↔ TOON ↔ JSON-LD ↔ Turtle)
+
+**Success Criteria:**
+- ✅ All Jerry entities serializable to Turtle and JSON-LD
+- ✅ SHACL shapes validate (0 constraint violations)
+- ✅ Round-trip tests 100% success rate
+
+**Effort:** 15-20 hours
+
+---
+
+**Week 5-6: Graph Layer + Entity Extraction**
+
+**Deliverables:**
+- NetworkX adapter implementing GraphPort
+- Entity extraction from markdown (`src/infrastructure/extraction/markdown_entities.py`)
+- Relationship detection (REFERENCES, PART_OF, USES)
+- Graph builder command (`src/application/commands/build_knowledge_graph.py`)
+- CLI: `jerry knowledge graph --query "find related to X"`
+- Graph visualization export (DOT format)
+
+**Success Criteria:**
+- ✅ Automatically index `docs/` into graph on update
+- ✅ Extract entities: Tasks, Phases, Plans, Concepts, Documents
+- ✅ Provide CLI for knowledge queries
+- ✅ Graph visualization export (Graphviz)
+
+**Effort:** 20-25 hours
+
+---
+
+**Week 7-8: Vector RAG + Integration Testing**
+
+**Deliverables:**
+- FAISS adapter implementing VectorStorePort
+- Document embedding (text-embedding-3-small or local model)
+- Semantic search query (`src/application/queries/semantic_search.py`)
+- CLI: `jerry knowledge search "semantic query text"`
+- Performance benchmarks (property graph <50ms P95, RDF export <100ms P95, vector search <2s)
+- Integration tests (HybridRAG workflow)
+- Contributor documentation (`docs/contributing/SERIALIZATION_GUIDE.md`)
+- Constitutional amendments (P-030, P-031, P-032)
+
+**Success Criteria:**
+- ✅ docs/ indexed with embeddings (all markdown files covered)
+- ✅ Vector search returns relevant results (qualitative assessment)
+- ✅ All performance benchmarks meet targets
+- ✅ Contributor guide reviewed and approved
+
+**Effort:** 15-20 hours
+
+---
+
+**Phase 2 Total:** 70-90 hours (8 weeks at 10 hrs/week)
+
+**Phase 2 Go/No-Go Gate (Week 8):**
+
+Proceed to Phase 3 ONLY if:
+- ✅ Backward compatibility: 100% Phase 1 tests passing
+- ✅ Performance: Property graph <50ms P95, RDF export <100ms P95, vector search <2s
+- ✅ Serialization correctness: 100% round-trip success
+- ✅ Supernode prevention: Alerts working (synthetic test with 10K tasks)
+- ✅ Documentation: Contributor onboarding <4 hours (time-tracked)
+- ✅ User validation: Positive feedback on semantic search and relationship discovery
+
+**If ANY criterion fails:** Pause Phase 3, address issues, re-evaluate.
+
+---
+
+#### **Phase 3: Advanced Capabilities (Q2-Q3 2026, 12 weeks)**
+
+**Conditional:** Proceed ONLY if Phase 2 go/no-go criteria met.
+
+**Month 4-5: GraphRAG + Grounding**
+
+**Deliverables:**
+- Extend Work Tracker entities with embedding properties
+- Graph traversal retrieval (Gremlin patterns via NetworkX)
+- HybridRAG context merger (vector + graph deduplication)
+- Jerry URI citations in LLM responses
+- MiniCheck integration (optional, soft warnings)
+
+**Success Criteria:**
+- ✅ Claude Code agents query Jerry knowledge base (docs/ + Work Tracker)
+- ✅ Responses include Jerry URI citations for all factual claims
+- ✅ Measurable hallucination reduction (baseline vs RAG, user evaluation)
+
+**Effort:** 25-35 hours
+
+---
+
+**Month 5-6: SPARQL + Content Negotiation**
+
+**Deliverables:**
+- pyoxigraph integration for embedded RDF storage
+- SPARQL endpoint (Flask + pyoxigraph)
+- Content negotiation for Jerry URIs (Accept: application/ld+json, text/turtle, text/html)
+- OWL-DL ontology (`ontologies/jerry-ontology.ttl`)
+- Map Jerry vocabulary to Schema.org
+
+**Success Criteria:**
+- ✅ SPARQL endpoint responds to queries (test with `SELECT * WHERE { ?s ?p ?o } LIMIT 10`)
+- ✅ Content negotiation returns correct format based on Accept header
+- ✅ OWL ontology validates (Protégé or OWL validator)
+
+**Effort:** 20-30 hours
+
+---
+
+**Month 6-7: Visualization + Monitoring**
+
+**Deliverables:**
+- Cytoscape.js graph visualization
+- Knowledge architecture health dashboard (entity count, query latency, vertex degree, etc.)
+- CloudEvents integration for monitoring alerts
+- SECI mode tagging for entities
+- Knowledge flow pattern analysis
+
+**Success Criteria:**
+- ✅ Dashboard deployed and accessible
+- ✅ Alerts trigger correctly at thresholds
+- ✅ User reviews dashboard weekly
+
+**Effort:** 15-20 hours
+
+---
+
+**Phase 3 Total:** 60-85 hours (12 weeks at 5-7 hrs/week)
+
+**Phase 3 Go/No-Go Gate (Month 7):**
+
+Proceed to Phase 4 evaluation ONLY if:
+- ✅ Phase 2 success criteria maintained
+- ✅ User validation: Surveys confirm semantic layer value
+- ✅ Use case demand: SPARQL queries or reasoning required for actual use cases (not theoretical)
+- ✅ HybridRAG impact: Measurable hallucination reduction (baseline vs RAG comparison)
+
+**Do NOT proceed if:**
+- ❌ Phase 2 increased query latency >100ms (hot path degraded)
+- ❌ Maintenance overhead slowed development >30% (time tracking)
+- ❌ No external integration use cases emerged (user feedback)
+- ❌ User satisfaction high with Phase 2 capabilities alone (surveys)
+
+---
+
+#### **Phase 4: Scale (Q4 2026+, Triggered)**
+
+**Trigger Conditions (MUST meet at least one):**
+- Multi-tenant SaaS offering required
+- >10M entities in production (currently: thousands)
+- P95 query latency >500ms (currently: <50ms)
+- Clustering/HA required for uptime SLA
+
+**Do NOT proceed unless one trigger met.**
+
+**Evaluation Checklist:**
+```markdown
+## Phase 4 Migration Checklist
+
+Only proceed if answering YES to one or more:
+- [ ] Multi-tenant SaaS offering planned?
+- [ ] > 8M entities in production (80% of 10M threshold)?
+- [ ] P95 query latency > 500ms?
+- [ ] Clustering/HA required for uptime SLA?
+
+If all NO, remain on embedded Phase 2-3 architecture.
+```
+
+**If Triggered, Evaluate:**
+- **Option A:** Apache Jena Fuseki (open-source, self-hosted, full SPARQL 1.1)
+- **Option B:** AWS Neptune (managed, high availability, $100-1000/month)
+- **Option C:** Stay embedded with optimizations (index tuning, caching, query optimization)
+
+**Migration Effort:** 2-4 weeks (schema export, data migration, testing, deployment)
+
+**Cost Analysis Required:** Cloud costs vs performance gains, user approval mandatory
+
+---
+
+### 3.3 Alternative Scenarios
+
+#### **Scenario A: Accelerated Phased (Collapse Phases)**
+
+**When:** Urgent need for GraphRAG (e.g., agent quality issues, competition)
+
+**Approach:** Combine Phase 2 and Phase 3 into single 16-week push.
+
+**Trade-offs:**
+- **Pro:** Faster to full capability (16 weeks vs 28 weeks)
+- **Con:** No Phase 2 go/no-go gate (higher risk)
+- **Con:** Larger upfront investment (130-175 hours)
+
+**Recommendation:** Only if user explicitly requests acceleration and accepts risk.
+
+---
+
+#### **Scenario B: Extended Minimal (Enhanced Minimal)**
+
+**When:** Phase 2 go/no-go criteria fail, but basic graph needed.
+
+**Approach:** Implement Minimal + NetworkX adapter only (no RDF, no vectors).
+
+**Trade-offs:**
+- **Pro:** Faster than Phase 2 (4-6 weeks vs 8 weeks)
+- **Pro:** Lower complexity (no semantic web)
+- **Con:** Misses semantic search, RAG, standards compliance
+
+**Recommendation:** Fallback if Phase 2 proves too complex, but re-evaluate after 6 months.
+
+---
+
+#### **Scenario C: Hybrid Phase 2.5 (Phase 2 + Basic GraphRAG)**
+
+**When:** GraphRAG needed urgently, but SPARQL not required.
+
+**Approach:** Phase 2 + HybridRAG from Phase 3 (skip SPARQL, OWL).
+
+**Trade-offs:**
+- **Pro:** LLM grounding benefits without semantic web complexity
+- **Pro:** 12-week timeline (vs 28 weeks for full Phase 3)
+- **Con:** No SPARQL for external integration (limits interoperability)
+
+**Recommendation:** Pragmatic middle ground if agent quality is top priority.
+
+---
+
+### 3.4 Decision Framework: When to Choose Each Option
+
+| Condition | Recommended Option | Rationale |
+|-----------|-------------------|-----------|
+| **Standard Jerry Use Case** | Phased Implementation | Balances capability, risk, ROI |
+| **Urgent Agent Quality Needs** | Hybrid Phase 2.5 | Gets GraphRAG without SPARQL overhead |
+| **Phase 2 Complexity Too High** | Extended Minimal | Fallback, re-evaluate after 6 months |
+| **Competition Pressure** | Accelerated Phased | Faster to market, accepts higher risk |
+| **Resource Constrained** | Minimal | Lowest investment, but limited value |
+| **External Integration Required** | Full Phased (through Phase 3) | SPARQL + RDF standards enable interoperability |
+
+---
+
+### 3.5 Success Metrics and Governance
+
+**Quantitative Metrics (Measured Quarterly):**
+
+| Metric | Phase 2 Target (Q2 2026) | Phase 3 Target (Q4 2026) | Phase 4 Trigger |
+|--------|--------------------------|--------------------------|-----------------|
+| **Knowledge Graph Size** | 500+ nodes | 1,000+ nodes | >8M nodes (80% of 10M) |
+| **Query Performance (P95)** | <50ms (property graph) | <50ms (maintained) | >500ms (degraded) |
+| **Vector Search (P95)** | <2s | <2s | >5s (degraded) |
+| **Adoption (AAR/A3)** | 50% work items | 70% work items | N/A |
+| **Coverage (docs/ indexed)** | 80% | 90% | N/A |
+
+**Qualitative Metrics (User/Agent Feedback):**
+
+| Metric | Phase 2 | Phase 3 | Measurement |
+|--------|---------|---------|-------------|
+| **Agent Reasoning Improvement** | Measurable via RAG | Measurable via GraphRAG | Baseline vs RAG comparison, user evaluation |
+| **Faster Discovery** | User reports | User reports | Surveys: "How often do you find related work faster?" |
+| **Knowledge Reuse** | "Lessons Applied" reports | SECI internalization tracking | Query logs: "concepts applied to new problems" |
+| **Reduced Duplicate Work** | 15-25% | 20-30% | Time tracking: "what exists?" queries prevent redundant effort |
+
+**ROI Targets:**
+
+| Metric | Phase 2 (Q2 2026) | Phase 3 (Q4 2026) | Measurement |
+|--------|-------------------|-------------------|-------------|
+| **Time Saved Finding Info** | 10-20% | 15-25% | Time tracking baseline vs post-KM |
+| **Reduced Duplicate Work** | 15-25% | 20-30% | "What exists?" query logs |
+| **Improved Decision Quality** | Qualitative | Qualitative | Better-informed choices (user feedback) |
+
+**Quarterly Assessment (Jan/Apr/Jul/Oct):**
+
+1. Review knowledge graph growth vs. tool capacity
+2. Check dependency health (releases, vulnerabilities, GitHub activity)
+3. Measure adoption metrics (AAR completion, knowledge queries)
+4. Assess ROI (time saved vs. maintenance burden)
+5. **Decide:** Continue, upgrade tools, or roll back
+
+**Off-Ramps:**
+- If adoption <20% by Q2 2026 → Simplify protocols or defer Phase 3
+- If maintenance burden >20% of dev time → Consider managed services
+- If performance issues arise → Trigger Phase 4 upgrades early
+- If constitutional violations detected → Immediate remediation
+
+---
+
+## Final Recommendation
+
+**IMPLEMENT PHASED STRATEGY (Phase 1 → 2 → 3 → 4 with gates)**
+
+### Rationale Summary
+
+1. **Highest Decision Matrix Score:** 4.6/5 (92%)—wins on 4 of 5 criteria
+2. **Best ROI:** 186% over 5 years (vs 33% Minimal, 67% Full)
+3. **Lowest Risk:** Clear go/no-go gates, reversible decisions, strong mitigations
+4. **Industry Validation:** Both WORK-031 and WORK-032 independently converged on this approach
+5. **Robust to Weight Changes:** Wins in all sensitivity scenarios (speed, safety, mission)
+6. **Strategic Flexibility:** Can accelerate (collapse phases) or decelerate (stop at Phase 2) based on actual usage
+
+### Implementation Timeline
+
+- **Q1 2026 (Week 1-8):** Phase 2 (foundation + RDF + graph + vectors)
+- **Q2-Q3 2026 (Week 9-28):** Phase 3 (GraphRAG + SPARQL + monitoring) — conditional on Phase 2 success
+- **Q4 2026+:** Phase 4 evaluation (only if triggers met—multi-tenant OR >10M entities OR >500ms latency OR HA required)
+
+### Success Probability
+
+**Phase 2:** HIGH (85%)—well-defined deliverables, proven libraries, clear success criteria
+
+**Phase 3:** MEDIUM (65%)—contingent on Phase 2 success and user demand validation
+
+**Phase 4:** LOW (20% that triggers are met by 2026)—current trajectory suggests 2028-2029 for baseline scenario
+
+### Next Steps
+
+1. **User Approval:** Review this analysis, approve Phased strategy (or request modifications)
+2. **Create PLAN File:** `docs/plans/PLAN-WORK-033-unified-km-implementation.md`
+3. **Begin Phase 2 Week 1-2:** Port definitions + JSON-LD contexts + AAR templates + supernode validator
+4. **Weekly Status Updates:** Monitor progress, adjust scope if needed
+5. **Week 8 Go/No-Go:** Evaluate Phase 2 success criteria, decide on Phase 3
+
+---
+
+**Document Status:** PROPOSED
+**File:** `/home/user/jerry/docs/analysis/work-033-e-003-design-trade-offs.md`
+**Date:** 2026-01-09
+**Agent:** ps-analyst v2.0.0
+**Word Count:** ~13,800 words
+**Analysis Method:** Decision Matrix + SWOT + Risk Register + Complexity Metrics + Strategic Assessment
+
+**Citations:**
+- Unified Design: `docs/design/work-033-e-002-unified-design.md`
+- Integration Analysis: `docs/research/work-033-e-001-integration-analysis.md`
+- ADR-031: `docs/decisions/ADR-031-knowledge-architecture.md`
+- ADR-032: `docs/decisions/ADR-032-km-integration.md`
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): All claims cited to input documents
+- P-002 (File Persistence): Analysis persisted to markdown file
+- P-004 (Reasoning Transparency): Decision rationale documented at multiple levels (L0, L1, L2)

--- a/docs/archive/projects-archive/analysis/work-034-e-004-tradeoff-analysis.md
+++ b/docs/archive/projects-archive/analysis/work-034-e-004-tradeoff-analysis.md
@@ -1,0 +1,1070 @@
+# WORK-034 Trade-off Analysis: Work Tracker + Knowledge Management Architecture
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **PS ID** | work-034 |
+| **Entry ID** | e-004 |
+| **Date** | 2026-01-09 |
+| **Author** | ps-analyst v2.0.0 |
+| **Input Documents** | work-034-e-003-unified-design.md (87KB), work-034-e-002-domain-synthesis.md (54KB), work-034-e-001-domain-analysis.md (93KB) |
+| **Output Target** | 30-50KB |
+| **Status** | COMPLETE |
+
+---
+
+## Executive Summary
+
+This trade-off analysis evaluates the key architectural and implementation decisions proposed in WORK-034 for integrating Work Tracker and Knowledge Management (KM) bounded contexts within the Jerry Framework. The analysis examines fifteen major decision points across architecture, technology, and implementation dimensions.
+
+**Key Findings:**
+
+1. **Hexagonal Architecture** is strongly recommended over layered architecture (8.2/10 weighted score). The 30-40% additional initial complexity is offset by 50-70% faster adapter swapping and 60% easier testing. The zero-dependency domain layer aligns with Jerry's constrained execution environment.
+
+2. **Work Tracker First** implementation strategy is the clear winner (8.4/10 vs. 5.6/10 for KM First, 6.2/10 for Parallel). The 4x faster issue discovery and 10x smaller fix costs justify the 8-week delayed KM delivery.
+
+3. **NetworkX** is recommended for graph storage (8.5/10), outperforming Neo4j (6.4/10) and DGraph (5.8/10) for Jerry's scale. The zero-dependency benefit and sufficient performance (<10ms at 5,500 nodes) make it ideal for Phase 2-3.
+
+4. **FAISS with IndexFlatL2** is recommended for semantic search (8.1/10), providing exact search without training overhead at Jerry's expected scale (<10K vectors).
+
+5. **Hybrid CQRS** is recommended over pure CRUD (7.8/10 vs. 6.2/10), with full CQRS for complex domains and simplified patterns for simple operations.
+
+**Primary Recommendation:** Proceed with the four-phase implementation plan as specified in e-003, with Work Tracker as the proving ground for KM infrastructure. The risk-adjusted ROI analysis projects 180-220% return over 24 months.
+
+---
+
+## 1. Introduction
+
+### 1.1 Analysis Scope
+
+This document provides comprehensive trade-off analysis for WORK-034 architectural decisions. Each decision is evaluated using:
+
+- **Quantitative metrics**: Performance, complexity, cost
+- **Qualitative factors**: Maintainability, testability, team familiarity
+- **Risk analysis**: Probability, impact, mitigation cost
+- **Sensitivity analysis**: Behavior under changed assumptions
+
+### 1.2 Evaluation Framework
+
+All decisions use a weighted scoring system:
+
+| Weight | Factor | Description |
+|--------|--------|-------------|
+| 25% | Performance | Runtime efficiency, latency, throughput |
+| 20% | Maintainability | Code organization, change isolation |
+| 20% | Testability | Test coverage feasibility, isolation |
+| 15% | Complexity | Initial implementation effort |
+| 10% | Dependencies | External library requirements |
+| 10% | Risk | Probability x impact of failure |
+
+Scores range from 1 (poor) to 10 (excellent).
+
+### 1.3 Document References
+
+| Document | Key Contributions to Analysis |
+|----------|------------------------------|
+| e-003 (Unified Design) | Architecture specifications, port definitions, use cases |
+| e-002 (Domain Synthesis) | Unified entity model, cross-domain relationships |
+| e-001 (Domain Analysis) | Bounded context definitions, event catalogs, BDD scenarios |
+
+---
+
+## 2. Architecture Trade-offs
+
+### 2.1 Hexagonal Architecture vs. Layered Architecture
+
+#### 2.1.1 Comparison Matrix
+
+| Criterion | Hexagonal | Layered | Delta |
+|-----------|-----------|---------|-------|
+| **Initial Complexity** | High | Medium | +30-40% |
+| **Adapter Swapping** | Trivial | Significant | -50-70% effort |
+| **Testability** | Excellent | Good | +40% coverage ease |
+| **Domain Isolation** | Complete | Partial | +100% isolation |
+| **Learning Curve** | 2-3 weeks | 1 week | +1-2 weeks |
+| **Dependency Inversion** | Enforced | Optional | N/A |
+| **Port Definition Overhead** | 15-20% LOC | 0% | +15-20% LOC |
+
+#### 2.1.2 Hexagonal Architecture Analysis
+
+**Pros:**
+- Complete domain isolation (domain/ imports only stdlib)
+- Testable in isolation via port mocking
+- Adapter hot-swapping without domain changes
+- Aligns with DDD bounded context patterns
+- Future-proof for technology migrations
+
+**Cons:**
+- Higher initial implementation cost (~30%)
+- More interfaces to maintain
+- Team learning curve for port/adapter pattern
+- Potential over-engineering for simple features
+
+**Quantified Impact:**
+
+| Metric | Hexagonal | Layered |
+|--------|-----------|---------|
+| Domain test coverage achievable | 95%+ | 70-80% |
+| Time to swap SQLite for Postgres | 2 hours | 2-3 days |
+| Lines of interface code | ~800 LOC | ~200 LOC |
+| Time to add new adapter | 4-8 hours | 2-4 days |
+
+#### 2.1.3 Layered Architecture Analysis
+
+**Pros:**
+- Simpler initial implementation
+- Familiar to most developers
+- Less boilerplate code
+- Faster time to first feature
+
+**Cons:**
+- Domain coupled to infrastructure details
+- Testing requires database/external mocks
+- Technology changes ripple through layers
+- Harder to maintain bounded context boundaries
+
+#### 2.1.4 Recommendation
+
+| Factor | Score (Hex) | Score (Layer) | Weight | Weighted (Hex) | Weighted (Layer) |
+|--------|-------------|---------------|--------|----------------|------------------|
+| Performance | 8 | 8 | 25% | 2.00 | 2.00 |
+| Maintainability | 9 | 6 | 20% | 1.80 | 1.20 |
+| Testability | 10 | 6 | 20% | 2.00 | 1.20 |
+| Complexity | 6 | 8 | 15% | 0.90 | 1.20 |
+| Dependencies | 9 | 7 | 10% | 0.90 | 0.70 |
+| Risk | 8 | 7 | 10% | 0.80 | 0.70 |
+| **Total** | | | | **8.40** | **7.00** |
+
+**Decision: Hexagonal Architecture**
+
+Rationale: The 20% weighted score advantage compounds over the project lifetime. Jerry's requirement for zero-dependency domain layer makes Hexagonal Architecture essential. The initial complexity cost is a one-time investment; maintainability and testability benefits are ongoing.
+
+---
+
+### 2.2 Work Tracker First vs. KM First vs. Parallel Development
+
+#### 2.2.1 Option Analysis
+
+**Option A: Work Tracker First (Proposed)**
+
+| Phase | Duration | Focus | KM Benefit |
+|-------|----------|-------|------------|
+| 1 | 8 weeks | WT entities, repos, CQRS | Validates patterns |
+| 2 | 8 weeks | Shared infrastructure | NetworkX, FAISS proven at small scale |
+| 3 | 8 weeks | KM core | Uses validated infrastructure |
+| 4 | 8 weeks | Integration | Cross-domain features |
+
+**Option B: KM First**
+
+| Phase | Duration | Focus | Risk |
+|-------|----------|-------|------|
+| 1 | 8 weeks | KM entities | No validation before scale |
+| 2 | 8 weeks | KM infrastructure | Discover issues at 5K nodes |
+| 3 | 8 weeks | WT core | Delayed operational benefits |
+| 4 | 8 weeks | Integration | Late WT availability |
+
+**Option C: Parallel Development**
+
+| Phase | Duration | WT Track | KM Track | Risk |
+|-------|----------|----------|----------|------|
+| 1-2 | 16 weeks | WT full | KM full | Duplicated infrastructure |
+| 3-4 | 16 weeks | Integration | Integration | Divergent patterns |
+
+#### 2.2.2 Risk Comparison
+
+| Risk | WT First | KM First | Parallel |
+|------|----------|----------|----------|
+| **Performance issues at scale** | Discover at 500 nodes | Discover at 5K nodes | Discover at both |
+| **Infrastructure bugs** | 10x smaller fix cost | 100x fix cost | 50x fix cost |
+| **Schema evolution problems** | Practice on simpler schema | Learn on complex schema | Learn twice |
+| **User adoption issues** | Learn from WT completion hooks | Learn late | Two adoption curves |
+| **Resource utilization** | Focused team | Focused team | Split team |
+
+**Quantified Risk Impact:**
+
+| Metric | WT First | KM First | Parallel |
+|--------|----------|----------|----------|
+| Time to discover infrastructure issues | 2 weeks | 8 weeks | 4 weeks |
+| Cost to fix (LOC changed) | ~200 | ~2,000 | ~1,000 |
+| Users impacted by bugs | 1 (developer) | Many (agents) | Split |
+| Rollback complexity | Simple | Complex | Moderate |
+| Team context switching | None | None | High |
+
+#### 2.2.3 Timeline Comparison
+
+```
+Option A: Work Tracker First
+Week:  0    8   16   24   32
+       |----|----|----|----|
+       WT   Infrastructure  KM   Integration
+                           ^^^^
+                           KM delivery at week 24
+
+Option B: KM First
+Week:  0    8   16   24   32
+       |----|----|----|----|
+       KM   Infrastructure  WT   Integration
+       ^^^^
+       KM delivery at week 16 (8 weeks earlier)
+       Risk: untested infrastructure
+
+Option C: Parallel
+Week:  0       16      32
+       |-------|-------|
+       WT+KM   Integration
+       ^^^^^^^^^^^^
+       Both at week 16 (8 weeks earlier)
+       Risk: duplicated work, divergence
+```
+
+#### 2.2.4 Recommendation
+
+| Factor | WT First | KM First | Parallel | Weight |
+|--------|----------|----------|----------|--------|
+| Performance | 9 | 5 | 7 | 25% |
+| Maintainability | 9 | 6 | 5 | 20% |
+| Testability | 9 | 7 | 6 | 20% |
+| Complexity | 8 | 8 | 5 | 15% |
+| Dependencies | 8 | 8 | 6 | 10% |
+| Risk | 9 | 4 | 5 | 10% |
+| **Weighted Total** | **8.65** | **6.05** | **5.70** |
+
+**Decision: Work Tracker First**
+
+Rationale: The 8-week delayed KM delivery is justified by:
+- 4x faster issue discovery
+- 10x smaller fix costs
+- Proven infrastructure before KM scale
+- Focused team execution
+
+The delayed KM delivery has minimal business impact since Work Tracker provides immediate value.
+
+---
+
+### 2.3 CQRS vs. CRUD
+
+#### 2.3.1 Pattern Comparison
+
+| Aspect | CQRS | CRUD | Hybrid |
+|--------|------|------|--------|
+| **Command/Query Separation** | Complete | None | Selective |
+| **Event Generation** | All writes emit events | None | Commands only |
+| **Read Model Optimization** | Independent | Shared | Selective |
+| **Implementation Complexity** | High | Low | Medium |
+| **Audit Trail** | Built-in via events | Requires addition | Partial |
+| **Temporal Queries** | Native (event sourcing) | Requires versioning | Partial |
+
+#### 2.3.2 Complexity Cost Analysis
+
+| Component | CQRS LOC | CRUD LOC | Delta |
+|-----------|----------|----------|-------|
+| Command classes | 200 | 0 | +200 |
+| Command handlers | 400 | 0 | +400 |
+| Query classes | 150 | 0 | +150 |
+| Query handlers | 300 | 0 | +300 |
+| Event classes | 250 | 0 | +250 |
+| Repository (CRUD) | 200 | 200 | 0 |
+| Service layer | 0 | 400 | -400 |
+| **Total** | **1,500** | **600** | **+900 (+150%)** |
+
+#### 2.3.3 Benefit Quantification
+
+| Benefit | CQRS Value | CRUD Value |
+|---------|------------|------------|
+| Event replay for debugging | Full history | None |
+| Audit compliance | Automatic | Manual implementation |
+| Read/write scaling independence | Yes | No |
+| Cross-domain event handling | Native | Requires pub/sub addition |
+| Testing command isolation | Excellent | Coupled |
+
+#### 2.3.4 When CQRS Overhead is Justified
+
+| Scenario | CQRS Justified | Rationale |
+|----------|----------------|-----------|
+| Work Tracker core | Yes | Events drive KM integration |
+| KM knowledge capture | Yes | Audit trail essential |
+| Simple list queries | No | Overkill |
+| Status updates | Yes | Event sourcing value |
+| Tag management | Hybrid | Simple but needs events |
+
+#### 2.3.5 Recommendation
+
+| Factor | CQRS | CRUD | Hybrid |
+|--------|------|------|--------|
+| Performance | 7 | 8 | 8 |
+| Maintainability | 9 | 6 | 8 |
+| Testability | 9 | 6 | 8 |
+| Complexity | 5 | 9 | 7 |
+| Dependencies | 8 | 9 | 8 |
+| Risk | 7 | 8 | 8 |
+| **Weighted Total** | **7.45** | **7.25** | **7.80** |
+
+**Decision: Hybrid CQRS**
+
+Rationale: Full CQRS for:
+- Task state transitions (events required for KM)
+- Knowledge capture (audit trail)
+- Cross-domain operations
+
+Simplified patterns for:
+- Simple reads (direct repository queries)
+- Tag/note additions (minimal event value)
+
+---
+
+### 2.4 Event Sourcing vs. State-based Persistence
+
+#### 2.4.1 Comparison Matrix
+
+| Criterion | Event Sourcing | State-based | Hybrid |
+|-----------|---------------|-------------|--------|
+| **Storage Growth** | Linear with events | Constant | Moderate |
+| **Query Complexity** | Requires projections | Simple | Mixed |
+| **Audit Trail** | Complete, immutable | Requires triggers | Partial |
+| **Replay Capability** | Full history | None | Snapshots + events |
+| **Temporal Queries** | Native | Complex | Partial |
+| **Implementation Effort** | High | Low | Medium |
+
+#### 2.4.2 Storage Requirements Analysis
+
+Assumptions:
+- 500 Work Tracker entities Year 1
+- 5,000 KM entities Year 1
+- Average 10 events per entity lifecycle
+- Average event size: 500 bytes
+- Average state size: 2KB
+
+| Approach | Year 1 | Year 2 | Year 3 |
+|----------|--------|--------|--------|
+| **Event Sourcing** | 27.5 MB | 82.5 MB | 275 MB |
+| **State-based** | 11 MB | 33 MB | 110 MB |
+| **Hybrid (state + audit events)** | 16.5 MB | 49.5 MB | 165 MB |
+
+#### 2.4.3 Query Performance Impact
+
+| Query Type | Event Sourcing | State-based |
+|------------|----------------|-------------|
+| Current state | Requires replay or snapshot | O(1) |
+| Historical state at time T | O(n) events | Not supported |
+| Audit trail | Built-in | Requires separate table |
+| Cross-entity queries | Projection required | Direct join |
+
+#### 2.4.4 Hybrid Approach Details
+
+The hybrid approach combines:
+1. **State storage**: Current entity state in SQLite
+2. **Event log**: All domain events persisted
+3. **Snapshots**: Periodic state snapshots for fast replay
+
+Benefits:
+- Simple current-state queries
+- Full audit trail
+- Replay for debugging
+- Moderate storage overhead
+
+#### 2.4.5 Recommendation
+
+| Factor | Event Sourcing | State-based | Hybrid |
+|--------|----------------|-------------|--------|
+| Performance | 6 | 9 | 8 |
+| Maintainability | 8 | 7 | 8 |
+| Testability | 9 | 7 | 8 |
+| Complexity | 5 | 9 | 7 |
+| Dependencies | 7 | 9 | 8 |
+| Risk | 6 | 8 | 8 |
+| **Weighted Total** | **6.65** | **8.05** | **7.80** |
+
+**Decision: Hybrid (State + Events)**
+
+Rationale: Jerry requires event-driven KM integration (events essential) but also needs simple state queries (Claude Code agents need fast reads). The hybrid approach provides both with 50% less storage than pure event sourcing.
+
+---
+
+## 3. Technology Trade-offs
+
+### 3.1 Graph Database: NetworkX vs. Neo4j vs. DGraph
+
+#### 3.1.1 Technical Comparison
+
+| Feature | NetworkX | Neo4j | DGraph |
+|---------|----------|-------|--------|
+| **Type** | In-memory library | Graph database | Distributed graph |
+| **Language** | Python | Java | Go |
+| **Query Language** | Python API | Cypher | GraphQL+- |
+| **Scaling** | Single process | Cluster | Distributed |
+| **Dependencies** | pip install | Server process | Server process |
+| **License** | BSD | Community/Enterprise | Apache 2.0 |
+
+#### 3.1.2 Performance Benchmarks
+
+Estimated for Jerry's projected scale:
+
+| Operation | NetworkX | Neo4j | DGraph |
+|-----------|----------|-------|--------|
+| **Add vertex (1K nodes)** | <1ms | 5ms | 10ms |
+| **Add edge (5K edges)** | <1ms | 3ms | 8ms |
+| **2-hop traversal (5K nodes)** | <10ms | <5ms | <5ms |
+| **Path finding** | <50ms | <10ms | <10ms |
+| **Startup time** | <100ms | 5-10s | 10-30s |
+| **Memory (5.5K nodes)** | ~15MB | ~200MB | ~500MB |
+
+#### 3.1.3 Dependency Analysis
+
+| Aspect | NetworkX | Neo4j | DGraph |
+|--------|----------|-------|--------|
+| **Installation** | pip install networkx | Docker or native install | Docker required |
+| **Runtime dependency** | None (pure Python) | JVM + Neo4j process | gRPC + DGraph process |
+| **Claude Code compatibility** | Excellent | Requires external setup | Requires external setup |
+| **Offline operation** | Full | Full (after setup) | Full (after setup) |
+| **Deployment complexity** | None | Medium | High |
+
+#### 3.1.4 Scale Limits
+
+| Scale Point | NetworkX | Neo4j | DGraph |
+|-------------|----------|-------|--------|
+| **Comfortable** | <50K nodes | <1M nodes | <10M nodes |
+| **Max practical** | <500K nodes | <10M nodes | <100M nodes |
+| **Jerry Year 1** | 5.5K nodes | Overkill | Overkill |
+| **Jerry Year 3** | 50K nodes | Still overkill | Still overkill |
+
+#### 3.1.5 Migration Path
+
+NetworkX to igraph (if needed):
+- Same Python API style
+- 10x performance improvement
+- Zero additional dependencies
+- Effort: 1-2 days
+
+NetworkX to Neo4j (if needed):
+- Cypher query rewrite
+- Server infrastructure setup
+- Adapter implementation
+- Effort: 2-3 weeks
+
+#### 3.1.6 Recommendation
+
+| Factor | NetworkX | Neo4j | DGraph | Weight |
+|--------|----------|-------|--------|--------|
+| Performance | 8 | 9 | 9 | 25% |
+| Maintainability | 8 | 7 | 6 | 20% |
+| Testability | 9 | 7 | 6 | 20% |
+| Complexity | 9 | 6 | 5 | 15% |
+| Dependencies | 10 | 5 | 4 | 10% |
+| Risk | 8 | 7 | 6 | 10% |
+| **Weighted Total** | **8.50** | **7.05** | **6.35** |
+
+**Decision: NetworkX**
+
+Rationale: NetworkX provides:
+- Zero deployment overhead
+- Sufficient performance for 5-50K nodes
+- Python-native integration
+- Clear migration path to igraph if needed
+
+Neo4j/DGraph introduce unnecessary complexity for Jerry's scale.
+
+---
+
+### 3.2 Vector Search: FAISS vs. Pinecone vs. ChromaDB
+
+#### 3.2.1 Technical Comparison
+
+| Feature | FAISS | Pinecone | ChromaDB |
+|---------|-------|----------|----------|
+| **Type** | Library | Managed service | Library/Service |
+| **Deployment** | Local | Cloud only | Local or cloud |
+| **Index Types** | Flat, IVF, HNSW | Managed | HNSW |
+| **Filtering** | Post-filter | Native | Native |
+| **Cost** | Free | Per-operation | Free (OSS) |
+| **Dependencies** | numpy, faiss-cpu | API client | chromadb |
+
+#### 3.2.2 Performance at Jerry Scale
+
+| Metric | FAISS (Flat) | FAISS (IVF) | Pinecone | ChromaDB |
+|--------|--------------|-------------|----------|----------|
+| **Index build (5K vectors)** | <1s | 2-5s | N/A (managed) | <2s |
+| **Search latency (k=10)** | <50ms | <10ms | 50-100ms (network) | <30ms |
+| **Memory (5K x 1536)** | ~12MB | ~15MB | N/A | ~20MB |
+| **Update latency** | O(1) | O(1) | ~100ms | O(1) |
+
+#### 3.2.3 Cost Analysis (Year 1)
+
+| Provider | Setup | Monthly | Annual |
+|----------|-------|---------|--------|
+| **FAISS** | $0 | $0 | $0 |
+| **Pinecone Starter** | $0 | $0 | $0 (limited) |
+| **Pinecone Standard** | $0 | $70+ | $840+ |
+| **ChromaDB** | $0 | $0 | $0 |
+
+#### 3.2.4 Embedding Requirements
+
+All options support Jerry's embedding requirements:
+- Dimension: 1536 (text-embedding-3-small)
+- Vectors: 5,500 Year 1, 50,000 Year 3
+- Updates: ~100/day
+
+#### 3.2.5 Recommendation
+
+| Factor | FAISS | Pinecone | ChromaDB | Weight |
+|--------|-------|----------|----------|--------|
+| Performance | 9 | 8 | 8 | 25% |
+| Maintainability | 7 | 9 | 8 | 20% |
+| Testability | 9 | 6 | 8 | 20% |
+| Complexity | 8 | 9 | 8 | 15% |
+| Dependencies | 8 | 5 | 7 | 10% |
+| Risk | 8 | 6 | 7 | 10% |
+| **Weighted Total** | **8.10** | **7.25** | **7.70** |
+
+**Decision: FAISS with IndexFlatL2**
+
+Rationale: FAISS provides:
+- Zero network latency (local execution)
+- Exact search at Jerry's scale (no approximation needed)
+- Zero recurring cost
+- Claude Code offline compatibility
+
+IndexFlatL2 is sufficient for <10K vectors. Migration to IndexIVFFlat if scaling needed.
+
+---
+
+### 3.3 RDF Serialization: RDFLib vs. Apache Jena
+
+#### 3.3.1 Technical Comparison
+
+| Feature | RDFLib | Apache Jena |
+|---------|--------|-------------|
+| **Language** | Python | Java |
+| **Installation** | pip install rdflib | Maven/Gradle |
+| **SPARQL Support** | Built-in | Built-in |
+| **Format Support** | Turtle, JSON-LD, N3, RDF/XML | All standard formats |
+| **SHACL Validation** | Via pyshacl | Built-in |
+| **Performance** | Good | Excellent |
+
+#### 3.3.2 Integration Assessment
+
+| Aspect | RDFLib | Apache Jena |
+|--------|--------|-------------|
+| **Python integration** | Native | JNI/subprocess |
+| **Jerry codebase fit** | Excellent | Poor |
+| **Testing** | Standard pytest | Complex setup |
+| **Deployment** | None | JVM required |
+
+#### 3.3.3 Recommendation
+
+| Factor | RDFLib | Apache Jena | Weight |
+|--------|--------|-------------|--------|
+| Performance | 7 | 9 | 25% |
+| Maintainability | 9 | 5 | 20% |
+| Testability | 9 | 5 | 20% |
+| Complexity | 9 | 4 | 15% |
+| Dependencies | 8 | 3 | 10% |
+| Risk | 8 | 5 | 10% |
+| **Weighted Total** | **8.30** | **5.35** |
+
+**Decision: RDFLib**
+
+Rationale: Python-native integration outweighs Jena's performance advantage. Jerry's RDF operations are export-focused, not query-intensive.
+
+---
+
+### 3.4 Persistence: SQLite vs. PostgreSQL vs. DuckDB
+
+#### 3.4.1 Technical Comparison
+
+| Feature | SQLite | PostgreSQL | DuckDB |
+|---------|--------|------------|--------|
+| **Type** | Embedded | Server | Embedded |
+| **Concurrency** | Single writer | Multi-writer | Multi-reader |
+| **Installation** | Built-in Python | Server required | pip install |
+| **ACID** | Full | Full | Full |
+| **JSON Support** | Limited | JSONB | Native |
+| **Analytics** | Limited | Good | Excellent |
+
+#### 3.4.2 Concurrency Analysis
+
+Jerry's concurrency requirements:
+- Single Claude Code instance per session
+- No concurrent writes expected
+- Read-heavy workload
+
+| Scenario | SQLite | PostgreSQL | DuckDB |
+|----------|--------|------------|--------|
+| **Single user** | Excellent | Overkill | Good |
+| **10 concurrent reads** | Good | Excellent | Excellent |
+| **10 concurrent writes** | Poor | Excellent | Poor |
+| **Jerry actual use** | Perfect fit | Overkill | Good |
+
+#### 3.4.3 Deployment Complexity
+
+| Aspect | SQLite | PostgreSQL | DuckDB |
+|--------|--------|------------|--------|
+| **Setup** | None | Server install | None |
+| **Configuration** | None | Complex | Minimal |
+| **Backup** | File copy | pg_dump | File copy |
+| **Claude Code integration** | Trivial | Requires credentials | Trivial |
+
+#### 3.4.4 Recommendation
+
+| Factor | SQLite | PostgreSQL | DuckDB | Weight |
+|--------|--------|------------|--------|--------|
+| Performance | 8 | 9 | 9 | 25% |
+| Maintainability | 9 | 6 | 8 | 20% |
+| Testability | 9 | 6 | 8 | 20% |
+| Complexity | 10 | 5 | 9 | 15% |
+| Dependencies | 10 | 4 | 8 | 10% |
+| Risk | 9 | 7 | 7 | 10% |
+| **Weighted Total** | **9.00** | **6.35** | **8.25** |
+
+**Decision: SQLite**
+
+Rationale: SQLite provides:
+- Zero deployment overhead
+- Built into Python stdlib
+- Sufficient for single-writer workload
+- Simple backup (file copy)
+
+PostgreSQL is overkill for Jerry's requirements.
+
+---
+
+## 4. Implementation Trade-offs
+
+### 4.1 AAR Integration Options
+
+#### 4.1.1 Option Comparison
+
+| Option | Description | UX Impact | Capture Rate |
+|--------|-------------|-----------|--------------|
+| **Mandatory Prompt** | Always prompt on task completion | Friction | 100% (forced) |
+| **Optional Prompt** | Ask if user wants to capture | Medium | 30-50% |
+| **Threshold-based** | Prompt if effort > threshold | Low | 60-80% |
+| **Deferred Queue** | Batch prompts at session end | Very low | 40-60% |
+
+#### 4.1.2 User Experience Analysis
+
+| Scenario | Mandatory | Optional | Threshold | Deferred |
+|----------|-----------|----------|-----------|----------|
+| **Quick task (5 min)** | Annoying | OK | Skip | OK |
+| **Complex task (2+ hrs)** | Valuable | Risk miss | Capture | Risk forget |
+| **Flow state** | Disruptive | OK | OK | Preserves flow |
+| **Session ending** | N/A | N/A | N/A | Natural pause |
+
+#### 4.1.3 Adoption Risk Analysis
+
+Historical data from similar systems:
+- Mandatory prompts: High abandonment (40-60% skip/dismiss)
+- Optional prompts: Low capture (20-30%)
+- Threshold-based: Good balance (60-80% meaningful capture)
+- Deferred: Context loss degrades quality
+
+#### 4.1.4 Recommendation
+
+**Decision: Threshold-based with Optional Defer**
+
+Configuration:
+- Prompt if `effort_hours > 2` (from e-001 specification)
+- Allow "capture later" deferral
+- Batch deferred items at session end
+
+Rationale: Balances capture rate with user experience. Respects flow state while ensuring valuable work generates lessons.
+
+---
+
+### 4.2 Pattern Discovery Strategies
+
+#### 4.2.1 Strategy Comparison
+
+| Strategy | Description | Accuracy | Overhead |
+|----------|-------------|----------|----------|
+| **Manual Only** | User explicitly captures patterns | High | High user effort |
+| **Assisted Discovery** | Suggest based on similarity | Medium-High | Low |
+| **Automated Detection** | System identifies patterns | Low-Medium | None |
+
+#### 4.2.2 False Positive Analysis
+
+| Strategy | False Positive Rate | User Trust Impact |
+|----------|---------------------|-------------------|
+| **Manual Only** | 0% (user controlled) | Neutral |
+| **Assisted (threshold 0.8)** | 5-10% | Minor irritation |
+| **Assisted (threshold 0.6)** | 20-30% | Significant distrust |
+| **Automated** | 30-50% | "Noise machine" |
+
+#### 4.2.3 Recommendation
+
+**Decision: Assisted Discovery with High Threshold**
+
+Configuration:
+- Similarity threshold: 0.8 (conservative)
+- Minimum occurrences: 3 (from e-001)
+- User confirmation required for all patterns
+
+Rationale: Assisted discovery reduces user effort while maintaining quality through high thresholds and mandatory confirmation.
+
+---
+
+### 4.3 Graph Integration Depth
+
+#### 4.3.1 Option Comparison
+
+| Depth | Description | Consistency | Performance |
+|-------|-------------|-------------|-------------|
+| **Deep Integration** | All entities in graph, graph is source of truth | Strong | Lower |
+| **Parallel Stores** | SQLite primary, graph mirror | Eventual | Higher |
+| **Loose Coupling** | Graph only for relationships | Weak | Highest |
+
+#### 4.3.2 Consistency Analysis
+
+| Scenario | Deep | Parallel | Loose |
+|----------|------|----------|-------|
+| **Entity creation** | Atomic | Async sync | N/A |
+| **Relationship creation** | Atomic | Atomic | Atomic |
+| **Query consistency** | Always | Eventual | N/A for entities |
+| **Failure recovery** | Complex | Reconciliation | Simple |
+
+#### 4.3.3 Recommendation
+
+**Decision: Parallel Stores with Async Sync**
+
+Architecture:
+- SQLite as source of truth for entities
+- NetworkX for relationship queries
+- Async sync with reconciliation
+- Graph rebuild capability
+
+Rationale: Performance-critical reads from SQLite, relationship traversal from graph. Eventual consistency acceptable for Jerry's use case.
+
+---
+
+## 5. Risk-Benefit Analysis
+
+### 5.1 Risk Register
+
+| Risk ID | Description | Probability | Impact | Expected Value |
+|---------|-------------|-------------|--------|----------------|
+| R-001 | Performance degradation at scale | Medium (40%) | High ($20K) | $8,000 |
+| R-002 | Supernode formation | High (60%) | Medium ($10K) | $6,000 |
+| R-003 | User AAR adoption low | High (70%) | Medium ($8K) | $5,600 |
+| R-004 | Event store scaling issues | Low (20%) | High ($15K) | $3,000 |
+| R-005 | Schema evolution breaks | Medium (35%) | High ($12K) | $4,200 |
+| R-006 | Graph query timeout | Medium (30%) | Low ($5K) | $1,500 |
+| R-007 | Vector index drift | Low (25%) | Medium ($8K) | $2,000 |
+| **Total Expected Risk Cost** | | | | **$30,300** |
+
+### 5.2 Mitigation Strategies
+
+| Risk | Mitigation | Cost | Residual Risk |
+|------|------------|------|---------------|
+| R-001 | Validate at WT scale first | $2,000 | $2,000 |
+| R-002 | Edge count validator, alert at 100 | $500 | $1,500 |
+| R-003 | Threshold-based prompts, defer option | $1,000 | $2,000 |
+| R-004 | Event partitioning design | $1,500 | $500 |
+| R-005 | Migration practice on WT | $1,000 | $1,000 |
+| R-006 | Max depth limit (3), caching | $500 | $500 |
+| R-007 | Re-index on content change | $800 | $500 |
+| **Total Mitigation Cost** | | **$7,300** | **$8,000** |
+
+### 5.3 Net Risk Assessment
+
+| Metric | Without Mitigation | With Mitigation | Improvement |
+|--------|-------------------|-----------------|-------------|
+| Expected risk cost | $30,300 | $8,000 | 74% reduction |
+| Mitigation investment | $0 | $7,300 | - |
+| Net benefit | $0 | $15,000 | Positive ROI |
+
+### 5.4 Benefit Quantification
+
+| Benefit | Year 1 | Year 2 | Year 3 |
+|---------|--------|--------|--------|
+| **Time saved finding knowledge** | 100 hrs | 300 hrs | 600 hrs |
+| **Reduced context rot impact** | 50 hrs | 150 hrs | 300 hrs |
+| **Pattern reuse value** | 20 hrs | 100 hrs | 250 hrs |
+| **Total hours saved** | 170 hrs | 550 hrs | 1,150 hrs |
+| **Value @ $100/hr** | $17,000 | $55,000 | $115,000 |
+
+### 5.5 ROI Calculation
+
+| Metric | Value |
+|--------|-------|
+| **Implementation cost** | ~$80,000 (32 weeks @ $2,500/week) |
+| **Mitigation cost** | $7,300 |
+| **Total investment** | $87,300 |
+| **Year 1 benefit** | $17,000 |
+| **Year 2 benefit** | $55,000 |
+| **Year 3 benefit** | $115,000 |
+| **3-year total benefit** | $187,000 |
+| **3-year ROI** | 114% |
+| **Payback period** | ~20 months |
+
+---
+
+## 6. Decision Matrix
+
+### 6.1 Criteria Weights
+
+| Criteria | Weight | Rationale |
+|----------|--------|-----------|
+| Performance | 25% | Critical for Claude Code responsiveness |
+| Maintainability | 20% | Long-term codebase health |
+| Testability | 20% | Quality assurance essential |
+| Complexity | 15% | Initial delivery risk |
+| Dependencies | 10% | Claude Code environment constraints |
+| Risk | 10% | Project success probability |
+
+### 6.2 Comprehensive Decision Matrix
+
+| Decision | Option A | Option B | Option C | Recommended | Confidence |
+|----------|----------|----------|----------|-------------|------------|
+| **Architecture** | Hexagonal (8.4) | Layered (7.0) | - | Hexagonal | High |
+| **Sequence** | WT First (8.7) | KM First (6.1) | Parallel (5.7) | WT First | High |
+| **Pattern** | CQRS (7.5) | CRUD (7.3) | Hybrid (7.8) | Hybrid CQRS | Medium |
+| **Persistence Model** | Event Sourcing (6.7) | State-based (8.1) | Hybrid (7.8) | Hybrid | High |
+| **Graph DB** | NetworkX (8.5) | Neo4j (7.1) | DGraph (6.4) | NetworkX | High |
+| **Vector Search** | FAISS (8.1) | Pinecone (7.3) | ChromaDB (7.7) | FAISS | High |
+| **RDF Library** | RDFLib (8.3) | Apache Jena (5.4) | - | RDFLib | High |
+| **Database** | SQLite (9.0) | PostgreSQL (6.4) | DuckDB (8.3) | SQLite | High |
+| **AAR Strategy** | Mandatory | Optional | Threshold | Threshold | Medium |
+| **Pattern Discovery** | Manual | Assisted | Automated | Assisted | Medium |
+| **Graph Integration** | Deep | Parallel | Loose | Parallel | Medium |
+
+### 6.3 Decision Dependencies
+
+```
+Architecture (Hexagonal)
+    └── Enables: CQRS, Port-based integration
+        └── Enables: Technology swapping
+
+Sequence (WT First)
+    └── Validates: Graph, Vector, Event infrastructure
+        └── Reduces: KM implementation risk
+
+Technology Stack (NetworkX + FAISS + SQLite)
+    └── Requires: Zero external dependencies
+        └── Matches: Claude Code constraints
+
+Integration (Parallel stores + Async sync)
+    └── Balances: Performance + Consistency
+        └── Acceptable: For Jerry's use case
+```
+
+---
+
+## 7. Sensitivity Analysis
+
+### 7.1 Scale Increase (10x)
+
+**Scenario:** Year 3 grows to 500K nodes instead of 50K
+
+| Component | Current Recommendation | At 10x Scale | Action Required |
+|-----------|----------------------|--------------|-----------------|
+| NetworkX | Sufficient | Insufficient | Migrate to igraph or Neo4j |
+| FAISS (Flat) | Sufficient | Insufficient | Migrate to IndexIVFFlat |
+| SQLite | Sufficient | Borderline | Consider PostgreSQL |
+| Event Store | Sufficient | Insufficient | Add partitioning |
+
+**Mitigation:** Design with migration paths. NetworkX adapter implements IGraphStore; swap to Neo4j adapter if needed.
+
+### 7.2 Low User Adoption
+
+**Scenario:** AAR capture rate < 20%
+
+| Impact | Severity | Response |
+|--------|----------|----------|
+| KM value diminished | High | Reduce prompts, improve UX |
+| Pattern discovery fails | High | Lower occurrence threshold |
+| ROI reduced | Medium | Focus on automated capture |
+
+**Mitigation:** Monitor capture rate weekly. Pivot to automated extraction if adoption remains low after 4 weeks.
+
+### 7.3 Performance Requirements Tighten
+
+**Scenario:** P95 latency requirement drops from 100ms to 10ms
+
+| Component | Current P95 | Required | Gap |
+|-----------|-------------|----------|-----|
+| Graph traversal | 50ms | 10ms | 40ms |
+| Vector search | 50ms | 10ms | 40ms |
+| State lookup | 5ms | 10ms | None |
+
+**Mitigation:**
+- Add caching layer (Redis optional)
+- Pre-compute common traversals
+- Limit max_depth to 2
+
+### 7.4 New Technology Emergence
+
+**Scenario:** Better graph/vector technology becomes available
+
+| Technology | Current Choice | Migration Path |
+|------------|----------------|----------------|
+| Graph | NetworkX | Port-based; any IGraphStore impl |
+| Vector | FAISS | Port-based; any ISemanticIndex impl |
+| Database | SQLite | Port-based; any IEventStore impl |
+
+**Mitigation:** Hexagonal architecture ensures all external dependencies are isolated behind ports. Migration cost ~1-2 weeks per component.
+
+---
+
+## 8. Recommendations Summary
+
+| Decision | Recommended Option | Confidence | Key Rationale |
+|----------|-------------------|------------|---------------|
+| Architecture | Hexagonal | High | Zero-dependency domain, testability |
+| Implementation Sequence | Work Tracker First | High | 4x faster issue discovery, 10x smaller fixes |
+| Command/Query Pattern | Hybrid CQRS | Medium | Events for integration, simplicity for reads |
+| Persistence Model | Hybrid (State + Events) | High | Query performance + audit trail |
+| Graph Database | NetworkX | High | Zero dependencies, sufficient scale |
+| Vector Search | FAISS (IndexFlatL2) | High | Exact search, no training overhead |
+| RDF Library | RDFLib | High | Python-native integration |
+| Database | SQLite | High | Zero deployment, sufficient concurrency |
+| AAR Strategy | Threshold-based | Medium | Balance capture rate vs. UX |
+| Pattern Discovery | Assisted with confirmation | Medium | Reduce effort, maintain quality |
+| Graph Integration | Parallel with async sync | Medium | Performance + acceptable consistency |
+
+---
+
+## 9. Open Questions
+
+### 9.1 Questions Requiring Resolution Before ADR
+
+1. **Embedding Model Choice**: Should Jerry use text-embedding-3-small (1536d) or text-embedding-3-large (3072d)? Trade-off: quality vs. storage/latency.
+
+2. **Event Retention Policy**: How long should events be retained? Forever (audit) vs. N days (storage)?
+
+3. **Graph Persistence Strategy**: Should NetworkX graph be persisted on every change or periodically? Trade-off: durability vs. performance.
+
+4. **Cross-Domain Transaction Handling**: When Task completion triggers Lesson capture, what happens if Lesson save fails? Retry? Compensate?
+
+5. **Embedding Generation Location**: Generate embeddings locally (sentence-transformers) or via API (OpenAI)? Trade-off: latency vs. quality.
+
+6. **SHACL Validation Timing**: Validate on write (slower) or on export (deferred errors)?
+
+7. **Graph Rebuild Strategy**: If graph becomes inconsistent, how is it rebuilt from SQLite sources?
+
+8. **AAR Skip Tracking**: Should skipped AAR prompts be logged for later follow-up?
+
+9. **Pattern Confidence Decay**: Should pattern confidence decrease if not used for N months?
+
+10. **Multi-Session Graph Access**: If multiple Claude Code sessions access the same project, how is graph consistency maintained?
+
+### 9.2 Assumptions Requiring Validation
+
+| Assumption | Validation Method | Risk if Wrong |
+|------------|-------------------|---------------|
+| Claude Code allows ~15MB RAM for graph | Benchmark test | Performance degradation |
+| Users will complete AAR 60%+ of time | Usage metrics | KM value diminished |
+| 5,500 nodes Year 1 is realistic | Historical data | Scale planning wrong |
+| NetworkX <10ms at 5K nodes | Performance test | Need alternative |
+| FAISS works offline in Claude Code | Integration test | Need alternative |
+
+---
+
+## 10. Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | `docs/analysis/work-034-e-004-tradeoff-analysis.md` |
+| **Created** | 2026-01-09 |
+| **Author** | ps-analyst v2.0.0 |
+| **Word Count** | ~7,500 words |
+| **Tables** | 65+ |
+| **Status** | COMPLETE |
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): All claims quantified with sources where available
+- P-002 (File Persistence): Analysis persisted to markdown file
+- P-004 (Reasoning Transparency): Trade-off rationale documented throughout
+- P-010 (Task Tracking): Document supports WORK-034 Step 4
+
+**Next Steps:**
+1. Review trade-off analysis with stakeholders
+2. Resolve open questions (Section 9)
+3. Create ADR (Architecture Decision Record) from recommendations
+4. Update implementation plan based on analysis
+
+---
+
+## Appendix A: Scoring Methodology
+
+### A.1 Score Definitions
+
+| Score | Definition | Examples |
+|-------|------------|----------|
+| 1-2 | Poor, significant issues | Critical blockers, major gaps |
+| 3-4 | Below average | Notable weaknesses |
+| 5-6 | Average | Acceptable with limitations |
+| 7-8 | Good | Meets requirements well |
+| 9-10 | Excellent | Exceeds requirements |
+
+### A.2 Weight Justification
+
+| Factor | Weight | Justification |
+|--------|--------|---------------|
+| Performance (25%) | Highest | Claude Code agents need responsive UX |
+| Maintainability (20%) | High | Jerry is long-term investment |
+| Testability (20%) | High | Quality essential for framework code |
+| Complexity (15%) | Medium | Initial delivery matters |
+| Dependencies (10%) | Lower | Constraint but not blocking |
+| Risk (10%) | Lower | Mitigatable in most cases |
+
+### A.3 Data Sources
+
+| Data Type | Source | Confidence |
+|-----------|--------|------------|
+| Performance benchmarks | Library documentation, internal tests | Medium-High |
+| Scale limits | Industry experience, documentation | Medium |
+| Cost estimates | Team velocity, historical data | Medium |
+| Risk probabilities | Expert judgment | Low-Medium |
+| Adoption rates | Industry averages | Low |
+
+---
+
+## Appendix B: Alternative Scenarios
+
+### B.1 Scenario: Strict Real-time Requirements
+
+If future requirements demand <10ms P95 for all operations:
+
+**Changes Required:**
+- Replace NetworkX with Neo4j or memgraph
+- Add Redis caching layer
+- Pre-compute graph traversals
+- Consider event streaming (Kafka) for async
+
+**Estimated Rework:** 4-6 weeks
+
+### B.2 Scenario: Multi-tenant Deployment
+
+If Jerry becomes multi-tenant (multiple users, isolated data):
+
+**Changes Required:**
+- Replace SQLite with PostgreSQL
+- Add tenant isolation to all queries
+- Consider Neo4j for graph (better multi-tenancy)
+- Separate vector indexes per tenant
+
+**Estimated Rework:** 8-12 weeks
+
+### B.3 Scenario: Enterprise Compliance
+
+If enterprise compliance (SOC2, GDPR) required:
+
+**Changes Required:**
+- Add encryption at rest (SQLCipher)
+- Implement data retention policies
+- Add PII detection and masking
+- Audit log enhancement
+
+**Estimated Rework:** 4-8 weeks
+
+---
+
+## Appendix C: Decision Changelog
+
+| Date | Decision | Previous | New | Rationale |
+|------|----------|----------|-----|-----------|
+| 2026-01-09 | Initial analysis | N/A | All recommendations | First version |
+
+---
+
+*End of Trade-off Analysis Document*

--- a/docs/archive/projects-archive/decisions/ADR-031-knowledge-architecture.md
+++ b/docs/archive/projects-archive/decisions/ADR-031-knowledge-architecture.md
@@ -1,0 +1,955 @@
+# ADR-031: Jerry Knowledge Architecture
+
+## Status
+PROPOSED
+
+## Date
+2026-01-08
+
+## Context
+
+### The Problem Space
+
+Jerry is a framework for behavior and workflow guardrails that helps solve problems while accruing a body of knowledge, wisdom, and experience. Currently, Jerry operates at **Phase 1** with:
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker graph model for operational state
+
+However, Jerry faces several architectural challenges:
+
+1. **Context Rot in LLM Agents**: LLM performance degrades as context windows fill, even within technical token limits. Jerry needs persistent knowledge storage beyond ephemeral context.
+
+2. **Knowledge Fragmentation**: Jerry accumulates knowledge across Work Tracker entities (tasks, phases, plans) AND documentation (`docs/` hierarchy), but these exist as isolated silos without semantic connections.
+
+3. **LLM Hallucination**: Claude Code agents operating within Jerry lack grounding mechanisms, leading to factually incorrect responses. Production systems show baseline hallucination rates that impact user trust.
+
+4. **Interoperability Limitations**: Jerry's current property graph uses implicit schemas and Jerry-specific formats, limiting integration with external systems and semantic web standards.
+
+5. **Architectural Evolution**: Jerry needs a knowledge architecture roadmap that scales from current single-user embedded deployment to potential multi-tenant, high-volume scenarios without requiring complete rewrites.
+
+### The Strategic Context
+
+Knowledge architecture is no longer infrastructure—it's **strategic differentiation**. Recent industry evidence shows:
+
+- **GraphRAG achieves 90% hallucination reduction** (FalkorDB case study)
+- **63% faster issue resolution** (LinkedIn: 40hrs → 15hrs with knowledge graph grounding)
+- **49% → 86% accuracy improvement** (Amazon Finance with GraphRAG)
+- **300-320% ROI** from knowledge graph investments in production systems
+
+Additionally, the Semantic Web has undergone a **pragmatic turn in 2024-2025**:
+- JSON-LD reached 70% web adoption (vs 3% RDFa, 46% Microdata)
+- Modern embedded tooling available (Oxigraph in Rust/Python, not legacy Java)
+- 45M+ websites use Schema.org for structured data
+- LLM grounding via knowledge graphs has emerged as the "killer app" for semantic technologies
+
+### Jerry's Current Position
+
+Jerry is at **4-star Linked Open Data status** (Tim Berners-Lee's 5-star model):
+- ★★★★ **Achieved**: HTTP URIs to denote things (Jerry URI scheme SPEC-001)
+- ★★★★★ **Target**: Link data to other data to provide context
+
+The path to 5 stars requires semantic layer capabilities that Jerry currently lacks.
+
+## Decision Drivers
+
+The following factors influenced this architectural decision, in priority order:
+
+### Critical Drivers (Must-Have)
+
+1. **LLM Grounding Effectiveness**: Measurable reduction in hallucinations, improved agent accuracy
+2. **Backward Compatibility**: Phase 1 property graph foundation must remain intact
+3. **Performance Requirements**: Query latency P95 < 50ms for operational queries
+4. **Zero-Dependency Core**: Domain layer maintains Python stdlib-only constraint
+5. **Incremental Implementation**: Each phase must deliver independent value
+
+### Important Drivers (Should-Have)
+
+6. **Standards Compliance**: W3C RDF, SPARQL, JSON-LD for interoperability
+7. **Implementation Complexity**: Balance between capability and maintainability
+8. **Cost Management**: Prefer embedded over server-based through Phase 3
+9. **Supernode Prevention**: Avoid catastrophic performance degradation from high-degree vertices
+10. **Schema Evolution**: Support for versioning and migrations
+
+### Beneficial Drivers (Nice-to-Have)
+
+11. **Future Extensibility**: Enable advanced capabilities (reasoning, SPARQL) without rewrites
+12. **Ecosystem Integration**: Compatibility with Schema.org (45M+ websites)
+13. **Visualization**: Graph visualization for debugging and exploration
+
+## Considered Options
+
+### Option 1: Property Graph Only (Gremlin/NetworkX)
+
+**Description:** Extend current Phase 1 property graph with Gremlin queries, maintain file-based JSON/TOON storage, no semantic web capabilities.
+
+**Strengths:**
+- Simplest option—builds on existing foundation
+- Best performance: O(1) edge traversals, in-memory operations
+- Zero infrastructure costs (embedded)
+- Low maintenance complexity
+
+**Weaknesses:**
+- No standards compliance—Jerry-specific formats only
+- No semantic interoperability with external systems
+- Implicit schema—risk of drift over time
+- Cannot achieve 5-star Linked Open Data status
+- Misses LLM grounding improvements from GraphRAG
+
+**Score:** 18/25 (72%)
+- Performance: 5/5
+- Maintainability: 4/5
+- Scalability: 3/5
+- Cost: 5/5
+- Standards: 1/5
+
+**Verdict:** Strong second place, but strategically limiting.
+
+---
+
+### Option 2: RDF/Semantic Web Only (pyoxigraph)
+
+**Description:** Replace property graph with pure RDF triple store, SPARQL for all queries, OWL ontology for domain model, full semantic web stack.
+
+**Strengths:**
+- Full W3C standards compliance (RDF, SPARQL, OWL)
+- Maximum interoperability
+- Formal reasoning capabilities (OWL-DL)
+- Native RDF* support (edge properties without reification)
+
+**Weaknesses:**
+- Poorest performance: SPARQL 50-500ms vs Gremlin 5-10ms
+- Highest complexity: semantic web learning curve, ontology maintenance
+- Requires throwing away Phase 1 property graph work
+- Limited Python ecosystem (RDFLib slower than Java-based Jena)
+- Breaks backward compatibility
+
+**Score:** 16/25 (64%)
+- Performance: 2/5
+- Maintainability: 2/5
+- Scalability: 4/5
+- Cost: 3/5
+- Standards: 5/5
+
+**Verdict:** Standards-pure but pragmatically weak.
+
+---
+
+### Option 3: Hybrid Property + RDF (RECOMMENDED)
+
+**Description:** Property graph as primary operational storage with RDF serialization as export/integration layer. Implements Netflix UDA "Model Once, Represent Everywhere" pattern.
+
+**Architecture:**
+```
+Domain Model (Property Graph)
+    ├─ Primary Storage: File-based JSON/TOON
+    ├─ Operational Queries: Gremlin traversal (hot path)
+    └─ Serialization Adapters (cold path):
+        ├─ JSON-LD (web integration)
+        ├─ Turtle (human-readable RDF)
+        ├─ GraphSON (TinkerPop export)
+        └─ RDF* (edge properties without reification)
+```
+
+**Strengths:**
+- **Best of both worlds**: Fast property graph operations + standards-compliant RDF export
+- **Unanimous cross-document support**: 5/5 research documents independently recommend this pattern
+- **Netflix UDA validation**: Production-proven pattern at scale
+- **Backward compatible**: Phase 1 foundation remains unchanged
+- **Incremental risk**: JSON-LD optional, high reversibility in Phase 2
+- **Highest decision matrix score**: 22/25 (88%)
+
+**Weaknesses:**
+- More complex than property graph alone (multiple serializers)
+- Synchronization burden (property graph ↔ RDF consistency)
+- Learning curve for semantic web technologies
+- Dependency expansion (pyoxigraph, embedding models)
+
+**Score:** 22/25 (88%)
+- Performance: 5/5 (property graph primary)
+- Maintainability: 3/5 (adapter layer overhead)
+- Scalability: 4/5 (embedded → server path)
+- Cost: 5/5 (embedded through Phase 3)
+- Standards: 5/5 (RDF export)
+
+**Verdict:** Clear winner—pragmatic hybrid approach.
+
+---
+
+### Option 4: Vector DB Only
+
+**Description:** Embed all Jerry knowledge (Work Tracker + docs/) as vectors, use cosine similarity for retrieval, no graph structure.
+
+**Strengths:**
+- Fast semantic search (vector similarity)
+- Scales horizontally (Pinecone, Weaviate)
+- Simple conceptual model (embeddings + distance)
+
+**Weaknesses:**
+- **Cannot answer relational queries**: "What blocks this task?" requires graph traversal
+- No standards compliance (proprietary vector formats)
+- Loses Work Tracker graph structure (tasks, phases, edges)
+- Embedding API costs or local model overhead
+- 300-token chunk limits break context
+
+**Score:** 16/25 (64%)
+- Performance: 4/5
+- Maintainability: 3/5
+- Scalability: 4/5
+- Cost: 3/5
+- Standards: 2/5
+
+**Verdict:** Good for semantic search, insufficient for Jerry's relational needs.
+
+---
+
+### Option 5: HybridRAG (Vector + Graph)
+
+**Description:** Combine vector retrieval (docs/ indexing) with graph traversal (Work Tracker), merge results for LLM grounding.
+
+**Strengths:**
+- **Best LLM grounding**: 90% hallucination reduction (FalkorDB)
+- Semantic similarity + relational reasoning
+- Addresses Jerry's core mission (knowledge accumulation + problem solving)
+
+**Weaknesses:**
+- **Highest complexity**: Property graph + RDF + vector embeddings + context merger
+- Most maintenance burden (multiple systems to coordinate)
+- Embedding pipeline management (indexing, updates, dimensions)
+
+**Score:** 18/25 (72%)
+- Performance: 4/5
+- Maintainability: 2/5
+- Scalability: 4/5
+- Cost: 4/5
+- Standards: 4/5
+
+**Verdict:** Strategic but complex—best deployed as **enhancement layer on top of Option 3** rather than standalone.
+
+## Decision
+
+We will adopt the **Hybrid Property + RDF Architecture (Option 3)** with the following implementation strategy:
+
+### Core Architecture
+
+1. **Primary Storage:** Property graph with file-based JSON/TOON persistence (existing Phase 1)
+2. **Operational Queries:** Gremlin traversal for hot-path performance (< 50ms P95)
+3. **Semantic Layer:** RDF serialization adapters for cold-path interoperability
+4. **Representation Formats:** JSON, TOON, JSON-LD, Turtle, GraphSON (Netflix UDA pattern)
+5. **Embedded Databases:** pyoxigraph for RDF storage, zero infrastructure costs through Phase 3
+6. **Graph Enhancement (Phase 3):** HybridRAG layer combining vector retrieval (docs/) with graph traversal (Work Tracker)
+
+### Four-Phase Implementation Roadmap
+
+| Phase | Focus | Timeline | Capabilities |
+|-------|-------|----------|--------------|
+| **Phase 1: Foundation** | Property graph abstractions, file storage | ✅ COMPLETE | Vertex/Edge/VertexProperty, JSON/TOON, Jerry URIs |
+| **Phase 2: Semantic Layer** | RDF serialization, JSON-LD, vector RAG | 🎯 Q1 2026 | pyoxigraph, JSON-LD contexts, SHACL, vector search |
+| **Phase 3: Advanced Capabilities** | SPARQL endpoint, OWL ontology, GraphRAG | 🔮 Q2-Q3 2026 | Content negotiation, reasoning, grounding verification |
+| **Phase 4: Scale (Optional)** | Server-based deployment, cloud migration | 🔮 Q4 2026+ | Neptune/Fuseki evaluation, clustering, > 10M entities |
+
+### Technology Stack
+
+**Phase 2 (Immediate):**
+- **RDF Storage:** pyoxigraph (pure Rust, embedded, zero Java)
+- **RDF Serialization:** Turtle, JSON-LD, RDF* (via pyoxigraph)
+- **Validation:** SHACL shapes for constraint validation
+- **Vector Search:** text-embedding-3-small + FAISS/ChromaDB (embedded)
+- **Supernode Prevention:** Edge count monitoring with 100/1000 warning/error thresholds
+
+**Phase 3 (Future):**
+- **SPARQL Endpoint:** Flask + pyoxigraph with HTTP content negotiation
+- **Ontology:** OWL-DL (decidable reasoning) via jerry-ontology.ttl
+- **Grounding:** MiniCheck for verification (GPT-4 accuracy at 400x lower cost)
+- **Visualization:** Cytoscape.js for graph exploration
+
+**Phase 4 (If Needed):**
+- **Trigger Conditions:** Multi-tenant access OR > 10M entities OR clustering/HA required
+- **Options:** Apache Jena Fuseki (open-source), AWS Neptune (managed), stay embedded (baseline)
+
+## Rationale
+
+### Evidence from Research
+
+This decision is supported by **unanimous consensus across 5 independent research documents**:
+
+1. **Pattern Support:** PAT-001 (Hybrid Property Graph + RDF) and PAT-002 (Four-Phase Maturity Model) received unanimous support (5/5 documents)
+2. **Decision Matrix:** Hybrid architecture scored 22/25 (88%)—highest of all options evaluated
+3. **Production Validation:** Netflix UDA pattern deployed at scale, 4/5 documents cite this as architectural ideal
+4. **Standards Adoption:** JSON-LD at 70% web adoption, 45M+ Schema.org websites, W3C RDF 1.2 with modern features (RDF*)
+
+### Evidence from Case Studies
+
+5. **FalkorDB:** 90% hallucination reduction with GraphRAG
+6. **LinkedIn:** 63% faster ticket resolution (40hrs → 15hrs) with knowledge graph grounding
+7. **Amazon Finance:** 49% → 86% accuracy improvement with GraphRAG
+8. **ROI Validation:** 300-320% return on investment from knowledge graph initiatives
+
+### Evidence from Jerry's Context
+
+9. **Backward Compatible:** Jerry's existing Phase 1 property graph foundation remains intact—no throwaway work
+10. **Jerry URI Scheme:** Already RDF-compatible (SPEC-001), minimal changes needed for semantic web integration
+11. **Zero-Dependency Core:** Semantic capabilities live in infrastructure layer (pyoxigraph), domain layer stays pure Python stdlib
+12. **Constitutional Alignment:** Supports P-001 (Truth and Accuracy) via grounding verification, P-002 (File Persistence) via multiple serialization formats
+
+### Why Not Property Graph Only?
+
+- Misses 90% hallucination reduction from GraphRAG
+- Cannot achieve 5-star Linked Open Data status
+- No standards-based interoperability
+- Strategically limiting—Jerry's knowledge architecture becomes competitive differentiator
+
+### Why Not RDF Only?
+
+- 10x slower query performance (50-500ms SPARQL vs 5-10ms Gremlin)
+- Breaks backward compatibility—throws away Phase 1 work
+- Highest learning curve—semantic web stack unfamiliar
+- Premature optimization for scale Jerry may never need
+
+### Why Not Vector DB Only?
+
+- Cannot answer relational queries ("What blocks this task?")
+- Loses Work Tracker graph structure (tasks → phases → plans)
+- No standards compliance (proprietary vector formats)
+
+### Why Hybrid Wins
+
+**Performance:** Hot path uses fast property graph (5-10ms), cold path uses RDF export (no performance impact on operations)
+
+**Standards:** RDF export provides W3C compliance without end-to-end RDF overhead
+
+**Risk:** Incremental phases with clear go/no-go gates—can stop at Phase 2 if advanced features not needed
+
+**Flexibility:** Netflix UDA "Model Once, Represent Everywhere"—single domain model, multiple representations via adapters
+
+**Validation:** Unanimous cross-document support + production case studies + Jerry's existing foundation
+
+## Consequences
+
+### Positive Consequences
+
+1. **Strategic Differentiation via LLM Grounding**
+   - 90% hallucination reduction for Claude Code agents (FalkorDB case study)
+   - 63% faster issue resolution (LinkedIn case study)
+   - Jerry citations via URI scheme enable transparent sourcing
+   - Agents can ground responses in accumulated Jerry knowledge
+
+2. **Standards Compliance Without Performance Cost**
+   - 5-star Linked Open Data status (Tim Berners-Lee model)
+   - W3C RDF, SPARQL, JSON-LD interoperability
+   - Integration with Schema.org ecosystem (45M+ websites)
+   - Property graph hot path maintains < 50ms P95 latency
+
+3. **Incremental Risk Management**
+   - Each phase delivers independent value
+   - High reversibility in Phase 2 (JSON-LD optional extension)
+   - Can stop at Phase 2 if advanced capabilities not needed
+   - Clear go/no-go gates prevent premature optimization
+
+4. **Zero-Dependency Core Preserved**
+   - Semantic capabilities in infrastructure layer (pyoxigraph)
+   - Domain layer remains pure Python stdlib
+   - Embedded databases through Phase 3 ($0 infrastructure)
+   - Server-based only if > 10M entities (Phase 4 triggers)
+
+5. **Production-Validated Pattern**
+   - Netflix UDA deployed at scale (4/5 documents cite)
+   - GraphRAG production case studies (FalkorDB, LinkedIn, Amazon)
+   - JSON-LD 70% web adoption (not experimental technology)
+   - Modern tooling (Oxigraph in Rust/Python, not legacy Java)
+
+6. **Knowledge as Durable Asset**
+   - Accumulated knowledge persists across sessions
+   - Graph structure captures relationships (blocks, depends-on, created-by)
+   - Multiple serialization formats prevent vendor lock-in
+   - Formal validation (SHACL) prevents schema drift
+
+### Negative Consequences
+
+1. **Architectural Complexity Increase**
+   - **Issue:** Multiple representation formats (JSON, TOON, JSON-LD, Turtle, GraphSON) require synchronization
+   - **Impact:** More code surface area, more potential bugs, testing matrix explosion
+   - **Mitigation:** Netflix UDA pattern (serializers as pure functions, no business logic), automated round-trip tests, defer optional serializers to Phase 3
+
+2. **Learning Curve for Semantic Web**
+   - **Issue:** SPARQL, SHACL, OWL, RDF concepts unfamiliar to most developers
+   - **Impact:** Steeper onboarding for contributors, slower initial development velocity
+   - **Mitigation:** Document in `docs/contributing/SERIALIZATION_GUIDE.md`, Phase 2 focuses on JSON-LD (most accessible semantic format), defer SPARQL/OWL to Phase 3
+
+3. **Dependency Expansion**
+   - **Issue:** pyoxigraph (RDF storage), embedding models (vector RAG), potentially MiniCheck (grounding)
+   - **Impact:** Goes against Jerry's zero-dependency principle (though dependencies in infrastructure layer, not domain)
+   - **Mitigation:** All dependencies optional (infrastructure layer only), embedded deployment avoids server dependencies, Phase 2 evaluates pyoxigraph sufficiency before deeper investment
+
+4. **Multi-Layer Validation Overhead**
+   - **Issue:** Schema validation + SHACL constraints + supernode detection + grounding verification = latency accumulation
+   - **Impact:** Save operations slower, more complex error handling
+   - **Mitigation:** Asynchronous validation (non-blocking), performance budgets (P95 < 50ms for hot path), grounding verification optional (Phase 3)
+
+5. **Synchronization Between Property Graph and RDF**
+   - **Issue:** Changes to domain model require updates across multiple serializers
+   - **Impact:** Risk of format divergence, inconsistent representations
+   - **Mitigation:** Netflix UDA pattern (single source of truth = domain model), automated round-trip tests catch divergence, schema versioning (P-030 constitutional requirement)
+
+6. **Risk of Premature Optimization**
+   - **Issue:** Building Phase 3-4 capabilities (SPARQL, reasoning, server-based) Jerry may never need
+   - **Impact:** Time invested in semantic infrastructure vs domain features, over-engineering
+   - **Mitigation:** Phase gates with explicit go/no-go criteria, Phase 3 requires user validation of Phase 2 value, Phase 4 requires quantitative triggers (> 10M entities, multi-tenant, clustering)
+
+### Neutral Consequences (Context-Dependent)
+
+1. **Schema Evolution Requires Governance**
+   - Positive: Explicit schema versioning prevents drift
+   - Negative: Migration scripts add overhead
+   - Constitutional requirement P-030 enforces this
+
+2. **Embedded vs Server-Based Choice Deferred**
+   - Positive: No premature infrastructure costs
+   - Negative: Phase 4 migration effort if triggers crossed
+   - Assumption ASM-001 documents this explicitly
+
+3. **Vector Embeddings Add Storage Overhead**
+   - Positive: Enables semantic search for docs/
+   - Negative: Embedding generation latency, storage 2-3x growth
+   - Can use embedded ChromaDB/FAISS (no cloud costs)
+
+## Risks
+
+### Risk 1: Supernode Performance Degradation (Actor Vertex) — CRITICAL
+
+**Description:** Actor vertex (representing Claude) could accumulate thousands of edges as it creates tasks, leading to catastrophic O(n) traversal performance where n = edge count.
+
+**Probability:** HIGH (synthesis document rates Actor as HIGH supernode risk)
+
+**Impact:** HIGH (performance degradation affects all agents, queries slow from 5-10ms to 500ms+)
+
+**Risk Score:** 9/9 (Critical)
+
+**Mitigations:**
+1. **Preventive Monitoring:** Edge count validator with 100 (warn) / 1000 (error) thresholds
+2. **Temporal Partitioning:** Use time-based edge labels (`CREATED_BY_2026_01` not generic `CREATED_BY`)
+3. **Hierarchical Decomposition:** Create intermediate Actor nodes (`Actor:Claude:Session:2026-01-08`)
+4. **Constitutional Enforcement:** P-031 (Supernode Prevention) requires mitigation strategy for HIGH-risk vertices
+5. **Quantitative Validation:** Test with 10,000 synthetic tasks to verify mitigation effectiveness
+
+**Residual Risk:** LOW (if mitigations implemented in Phase 2 Week 1-2)
+
+---
+
+### Risk 2: Complexity Overhead Slowing Development Velocity — MODERATE
+
+**Description:** Multi-representation architecture creates maintenance burden (property graph + JSON + TOON + JSON-LD + Turtle + GraphSON), slowing feature development.
+
+**Probability:** MEDIUM (5 serializers confirmed in Phase 2)
+
+**Impact:** MEDIUM (slower velocity, but not catastrophic; estimated 20-30% overhead)
+
+**Risk Score:** 4/9 (Moderate)
+
+**Mitigations:**
+1. **Netflix UDA Pattern Enforcement:** Single domain model, serializers as pure functions (no business logic)
+2. **Automated Testing:** Parametrized round-trip tests for all serializers, catch divergence early
+3. **Defer Optional Serializers:** Phase 2 focuses on JSON + TOON + JSON-LD (essential), defer Turtle + GraphSON to Phase 3
+4. **Contributor Documentation:** `docs/contributing/SERIALIZATION_GUIDE.md` with clear examples
+
+**Success Metric:** Time-to-implement new entity type < 2 hours including all serializers
+
+**Residual Risk:** MEDIUM (complexity inherent to multi-representation architecture)
+
+---
+
+### Risk 3: Premature Phase 4 Migration (Server-Based Infrastructure) — LOW-MODERATE
+
+**Description:** Migrating to server-based triple store (Fuseki, Neptune) before necessary, incurring infrastructure costs ($100-1000/month) and operational overhead.
+
+**Probability:** LOW (Phase 4 clearly marked "if scale demands")
+
+**Impact:** HIGH (monthly costs + migration effort measured in weeks + operational complexity)
+
+**Risk Score:** 3/9 (Low-Moderate)
+
+**Mitigations:**
+1. **Explicit Trigger Conditions:** Multi-tenant access OR > 10M entities OR clustering/HA required (documented in ASM-001, ASM-002)
+2. **Quantitative Monitoring:** Entity count alerts at 8M (80% of 10M threshold), query latency alerts if P95 > 500ms
+3. **Phase 4 Evaluation Checklist:** Requires user approval + cost-benefit analysis before migration
+4. **Constitutional Gate:** P-032 (Phase Gate Compliance) prevents premature advancement
+
+**Residual Risk:** LOW (clear gates + monitoring prevent premature migration)
+
+---
+
+### Risk 4: Schema Evolution Breaking Graph Traversals — MODERATE-HIGH
+
+**Description:** Changes to graph schema (vertex types, edge labels, property names) break existing Gremlin queries and agent traversal logic.
+
+**Probability:** MEDIUM (Jerry is evolving system, schema changes inevitable)
+
+**Impact:** HIGH (breaks agent functionality, requires code updates across system)
+
+**Risk Score:** 6/9 (Moderate-High)
+
+**Mitigations:**
+1. **Schema Versioning:** Semantic versioning (v2.0.0), compatibility validation, major version changes signal breaking changes
+2. **Forward Migration Scripts:** Every schema change includes migration script (e.g., `migrations/001_add_blocking_reason.py`)
+3. **Rollback Migration Scripts:** Every schema change includes rollback script for reversibility
+4. **Schema Changelog:** `docs/specifications/SCHEMA_CHANGELOG.md` documents all changes (constitutional requirement P-030)
+5. **Integration Tests:** Traversal test suite runs against schema versions, catches breaking changes before deployment
+
+**Residual Risk:** MEDIUM (can't eliminate schema evolution, but can manage it systematically)
+
+---
+
+### Risk 5: LLM Grounding Verification False Positives — LOW
+
+**Description:** MiniCheck grounding verification incorrectly flags factually correct responses as "not supported," causing agent warnings and user confusion.
+
+**Probability:** MEDIUM (grounding models have error rates; MiniCheck GPT-4-level accuracy but not perfect)
+
+**Impact:** LOW (soft warnings logged, doesn't block functionality; user can review and override)
+
+**Risk Score:** 2/9 (Low)
+
+**Mitigations:**
+1. **Confidence Threshold Tuning:** Set threshold at 0.7 (tune based on false positive rate in production)
+2. **Soft Warnings (Non-Blocking):** Emit CloudEvent warning, don't block LLM response
+3. **Defer to Phase 3:** Grounding verification optional in Phase 2 (simpler Jerry URI citations first), add verification in Phase 3 when models mature
+4. **User Feedback Loop:** Allow users to mark false positives, retrain threshold based on feedback
+
+**Success Metric:** False positive rate < 5% on golden dataset
+
+**Residual Risk:** LOW (soft warnings, not hard failures; optional feature)
+
+---
+
+### Risk Summary Table
+
+| Risk ID | Description | Probability | Impact | Score | Residual Risk |
+|---------|-------------|-------------|--------|-------|---------------|
+| **RISK-1** | Supernode degradation (Actor vertex) | HIGH | HIGH | 9/9 | LOW (strong mitigations) |
+| **RISK-2** | Complexity slowing development | MEDIUM | MEDIUM | 4/9 | MEDIUM (inherent tradeoff) |
+| **RISK-3** | Premature Phase 4 migration | LOW | HIGH | 3/9 | LOW (clear gates) |
+| **RISK-4** | Schema evolution breaking traversals | MEDIUM | HIGH | 6/9 | MEDIUM (systematic management) |
+| **RISK-5** | Grounding verification false positives | MEDIUM | LOW | 2/9 | LOW (soft warnings) |
+
+**Overall Risk Profile:** MODERATE (most high-impact risks have strong mitigations; residual risks acceptable)
+
+## Implementation Plan
+
+### Phase 2: Semantic Layer (Q1 2026) — 8 Weeks
+
+#### Week 1-2: Foundation
+
+**Deliverables:**
+- Create JSON-LD context: `contexts/worktracker.jsonld`
+  - Map Jerry entities to Schema.org (Task → schema:Action, Actor:Human → schema:Person, Actor:Claude → schema:SoftwareApplication)
+  - Define custom Jerry vocabulary (`jerry:blockingReason`, `jerry:Phase`, etc.)
+  - Reference: Schema.org 803 types, 1,461 properties
+
+- Implement supernode validator (RISK-1 mitigation):
+  ```python
+  class SupernodeValidator:
+      WARN_THRESHOLD = 100
+      ERROR_THRESHOLD = 1000
+
+      def validate_vertex_degree(self, vertex_id, edge_label, edge_count):
+          if edge_count >= ERROR_THRESHOLD:
+              raise SupernodeError(f"Supernode detected: {vertex_id}")
+          elif edge_count >= WARN_THRESHOLD:
+              log.warning(f"Approaching supernode: {vertex_id} ({edge_count} edges)")
+  ```
+
+- Add edge count monitoring to repository save operations
+- Document Netflix UDA pattern in `docs/design/MULTI_REPRESENTATION_PATTERN.md`
+
+**Success Criteria:**
+- JSON-LD context validates against JSON-LD 1.1 spec
+- Supernode validator catches edges >= 100 (warning) and >= 1000 (error)
+- Pattern documentation reviewed and approved
+
+---
+
+#### Week 3-4: RDF Serialization
+
+**Deliverables:**
+- Install pyoxigraph: `pip install pyoxigraph`
+- Create RDF serialization adapter: `src/infrastructure/persistence/rdf_adapter.py`
+  - Implement Turtle serialization for Task/Phase/Plan entities
+  - Implement JSON-LD serialization using contexts/worktracker.jsonld
+  - Implement RDF* for edge properties (no reification overhead)
+
+- Create SHACL validation shapes: `schemas/worktracker-shapes.ttl`
+  - Task shape: title (required), status (enum), blocking_reason (optional)
+  - Phase shape: name (required), description (optional)
+  - Plan shape: goal (required), context (optional)
+
+- Automated round-trip tests (RISK-2 mitigation):
+  ```python
+  @pytest.mark.parametrize("serializer", [
+      JsonSerializer, ToonSerializer, JsonLdSerializer, RdfTurtleSerializer
+  ])
+  def test_round_trip(serializer):
+      task = Task(title="Test", status="IN_PROGRESS")
+      serialized = serializer.serialize(task)
+      deserialized = serializer.deserialize(serialized)
+      assert task == deserialized
+  ```
+
+**Success Criteria:**
+- All Jerry entities serializable to Turtle and JSON-LD
+- SHACL shapes validate against entities (0 constraint violations)
+- Round-trip tests pass at 100% success rate
+
+---
+
+#### Week 5-6: Vector RAG (Foundation for HybridRAG)
+
+**Deliverables:**
+- Index `docs/` with text-embedding-3-small (OpenAI API or local model)
+- Store embeddings in TOON format alongside documents:
+  ```toon
+  {
+    file: "docs/experience/LES-001-hybrid-prevents-lockin.md"
+    embedding: [0.023, -0.142, 0.089, ...]  # 1536 dimensions
+    chunk_boundaries: [0, 500, 1000, 1500]
+    metadata: {indexed_at: 2026-01-08T10:30:00Z}
+  }
+  ```
+
+- Implement cosine similarity search:
+  ```python
+  def retrieve_docs(query: str, top_k: int = 5) -> List[Document]:
+      query_embedding = embed(query)
+      results = []
+      for doc in all_docs:
+          similarity = cosine_similarity(query_embedding, doc.embedding)
+          results.append((doc, similarity))
+      return sorted(results, key=lambda x: x[1], reverse=True)[:top_k]
+  ```
+
+- Test with Claude Code agent queries: "What tasks block TASK-042?" → retrieve relevant docs + traverse BLOCKS edges
+
+**Success Criteria:**
+- docs/ indexed with embeddings (all markdown files covered)
+- Vector search returns relevant results (qualitative assessment by user)
+- Integration test passes: query returns both docs/ content and Work Tracker relationships
+
+---
+
+#### Week 7-8: Integration & Testing
+
+**Deliverables:**
+- Performance benchmarks:
+  - Property graph query latency (baseline): Target P95 < 10ms
+  - RDF export latency (non-blocking): Target P95 < 100ms
+  - Vector search latency: Target P95 < 50ms
+
+- Schema evolution integration tests (RISK-4 mitigation):
+  ```python
+  def test_schema_migration_backward_compatibility():
+      # Create entity with v1 schema
+      task_v1 = Task(title="Test", status="TODO")
+      task_v1.save()
+
+      # Apply migration to v2 (adds blocking_reason field)
+      apply_migration("001_add_blocking_reason")
+
+      # Verify v1 entity still loadable
+      loaded_task = Task.load(task_v1.id)
+      assert loaded_task.title == "Test"
+      assert loaded_task.blocking_reason is None  # Default value
+  ```
+
+- Contributor documentation: `docs/contributing/SERIALIZATION_GUIDE.md`
+  - How to add new entity types
+  - Netflix UDA pattern explanation
+  - Serializer implementation checklist
+
+- Constitutional amendments: Add P-030 (Schema Evolution Governance), P-031 (Supernode Prevention), P-032 (Phase Gate Compliance) to `docs/governance/JERRY_CONSTITUTION.md`
+
+**Success Criteria:**
+- All performance benchmarks meet targets (P95 < 50ms hot path)
+- Schema migration tests pass (100% backward compatibility)
+- Contributor guide reviewed and approved by user
+- Constitutional amendments integrated
+
+---
+
+### Phase 3: Advanced Capabilities (Q2-Q3 2026) — 12 Weeks
+
+**Conditional on Phase 2 Success:** Proceed ONLY if Phase 2 go/no-go criteria met (see Success Criteria section below).
+
+#### Month 4-5: GraphRAG & Grounding
+
+**Deliverables:**
+- Extend Work Tracker entities with embedding properties
+- Implement graph traversal retrieval (Gremlin):
+  ```python
+  def retrieve_blocking_tasks(task_id: str) -> List[Task]:
+      return g.V(task_id).out('BLOCKS').toList()
+  ```
+
+- Create HybridRAG context merger:
+  ```python
+  def hybrid_retrieve(query: str) -> GroundingContext:
+      # Parallel retrieval
+      vector_results = retrieve_docs(query, top_k=5)  # docs/ semantic search
+      graph_results = retrieve_related_entities(query)  # Work Tracker traversal
+
+      # Deduplicate and rank
+      merged = deduplicate(vector_results + graph_results)
+      return GroundingContext(sources=merged, citations=[...])
+  ```
+
+- Add Jerry URI citations to LLM responses:
+  ```
+  Response: "TASK-042 is blocked by TASK-038 due to missing dependency."
+  Citations:
+  - jer:jer:work-tracker:task:TASK-042
+  - jer:jer:work-tracker:task:TASK-038
+  - jer:jer:work-tracker:edge:BLOCKS:abc123
+  ```
+
+- Integrate MiniCheck model (optional):
+  - Evaluate model on golden dataset (false positive rate < 5%)
+  - Add verification step to RAG pipeline (non-blocking, soft warnings)
+  - Log verification results as CloudEvents
+
+**Success Criteria:**
+- Claude Code agents can query Jerry knowledge base (both docs/ and Work Tracker)
+- Responses include Jerry URI citations for all factual claims
+- Measurable hallucination reduction (baseline vs RAG, user evaluation)
+
+---
+
+#### Month 5-6: SPARQL & Content Negotiation
+
+**Deliverables:**
+- SPARQL endpoint (Flask + pyoxigraph):
+  ```python
+  @app.route('/sparql', methods=['POST'])
+  def sparql_query():
+      query = request.form.get('query')
+      results = oxigraph_store.query(query)
+      return jsonify(results), 200
+  ```
+
+- Content negotiation for Jerry URIs (PAT-010):
+  ```python
+  @app.route('/jer/work-tracker/task/<task_id>')
+  def resolve_task_uri(task_id: str):
+      accept = request.headers.get('Accept', 'application/json')
+
+      if 'application/ld+json' in accept:
+          return jsonify(task_as_jsonld), 200
+      elif 'text/turtle' in accept:
+          return task_as_turtle, 200, {'Content-Type': 'text/turtle'}
+      elif 'text/html' in accept:
+          return render_template('task.html', task=task), 200
+      else:
+          return jsonify(task_as_json), 200
+  ```
+
+- OWL-DL ontology (decidable reasoning): `ontologies/jerry-ontology.ttl`
+  - Define Jerry vocabulary classes (jerry:Task, jerry:Phase, jerry:Plan)
+  - Define property restrictions (jerry:blockingReason domain jerry:Task)
+  - Map to Schema.org (jerry:Task rdfs:subClassOf schema:Action)
+
+**Success Criteria:**
+- SPARQL endpoint responds to queries (test with `SELECT * WHERE { ?s ?p ?o } LIMIT 10`)
+- Content negotiation returns correct format based on Accept header
+- OWL ontology validates (Protégé or OWL validator)
+
+---
+
+#### Month 6-7: Visualization & Monitoring
+
+**Deliverables:**
+- Cytoscape.js graph visualization
+- Knowledge architecture health dashboard:
+  | Metric | Alert Threshold | Current Value |
+  |--------|----------------|---------------|
+  | Entity count | 8M (80% of Phase 4 trigger) | 1,234 |
+  | Query latency P95 | > 500ms | 12ms |
+  | Max vertex degree | > 80 (80% of warning) | 23 (Actor:Claude) |
+  | Serialization round-trip time | > 100ms | 45ms |
+  | Grounding false positive rate | > 5% | 2.3% |
+
+- CloudEvents integration for monitoring alerts
+
+**Success Criteria:**
+- Dashboard deployed and accessible
+- Alerts trigger correctly at thresholds
+- User reviews dashboard weekly
+
+---
+
+### Phase 4: Scale (Optional — Q4 2026+)
+
+**Trigger Conditions (MUST meet at least one):**
+- Multi-tenant SaaS offering required
+- > 10M entities in production (currently: thousands)
+- P95 query latency > 500ms (currently: < 50ms)
+- Clustering/HA required for uptime SLA
+
+**Do NOT proceed to Phase 4 unless one trigger condition met.**
+
+**Evaluation Checklist:**
+```markdown
+## Phase 4 Migration Checklist
+
+Only proceed if answering YES to one or more:
+- [ ] Multi-tenant SaaS offering planned?
+- [ ] > 8M entities in production?
+- [ ] P95 query latency > 500ms?
+- [ ] Clustering/HA required for uptime SLA?
+
+If all NO, remain on embedded Phase 2-3 architecture.
+```
+
+**If Triggered, Evaluate:**
+- **Option A:** Apache Jena Fuseki (open-source, self-hosted, full SPARQL 1.1)
+- **Option B:** AWS Neptune (managed, high availability, $100-1000/month)
+- **Option C:** Stay embedded with optimizations (index tuning, caching, query optimization)
+
+**Migration Effort:** Estimated 2-4 weeks (schema export, data migration, testing, deployment)
+
+**Cost Analysis Required:** Cloud costs vs performance gains, user approval mandatory
+
+---
+
+## Success Criteria
+
+### Phase 2 Go/No-Go Gates (Week 8)
+
+Proceed to Phase 3 ONLY if all criteria met:
+
+| Criterion | Metric | Target | Measurement |
+|-----------|--------|--------|-------------|
+| **Backward Compatibility** | % of existing tests passing | 100% | pytest suite (all Phase 1 tests) |
+| **Performance (Hot Path)** | Query latency P95 | < 50ms | Benchmark suite (property graph queries) |
+| **Performance (Cold Path)** | RDF export latency P95 | < 100ms | Benchmark suite (Turtle, JSON-LD) |
+| **Serialization Correctness** | Round-trip success rate | 100% | Parametrized tests (all serializers) |
+| **Supernode Prevention** | Edge count monitoring | Alerts working | Synthetic test (10,000 tasks) |
+| **Documentation** | Contributor onboarding time | < 4 hours | User time tracking |
+
+**If any criterion fails:** Pause Phase 3, address issues, re-evaluate.
+
+---
+
+### Phase 3 Go/No-Go Gates (Month 7)
+
+Proceed to Phase 4 evaluation ONLY if:
+
+| Criterion | Evidence Required |
+|-----------|------------------|
+| ✅ **Phase 2 Success** | All Phase 2 criteria met |
+| ✅ **User Validation** | User feedback confirms semantic layer value (surveys, usage metrics) |
+| ✅ **Use Case Demand** | SPARQL queries or reasoning required for actual use cases (not theoretical) |
+| ✅ **HybridRAG Impact** | Measurable hallucination reduction (baseline vs RAG comparison, user evaluation) |
+
+**Do NOT proceed to Phase 3 if:**
+- ❌ Phase 2 increases query latency > 100ms (hot path degraded)
+- ❌ Maintenance overhead slows development velocity > 30% (time tracking)
+- ❌ No external integration use cases emerge (user feedback)
+- ❌ User satisfaction high with Phase 2 capabilities alone (surveys)
+
+---
+
+### Phase 4 Trigger Conditions (Ongoing Monitoring)
+
+Phase 4 migration triggered ONLY if:
+- Multi-tenant access required (user requests)
+- > 10M entities (dashboard alerts at 8M)
+- P95 query latency > 500ms (dashboard monitoring)
+- Clustering/HA required (user SLA requirements)
+
+**Monitor quarterly** via Work Tracker.
+
+## Related Decisions
+
+- **SPEC-001: Jerry URI Scheme** — Existing Jerry URI scheme is RDF-compatible, Phase 2 builds on this foundation
+- **ADR-XXX: Work Tracker Graph Model** (future) — Will document Phase 1 property graph design
+- **ADR-XXX: Constitutional Principles for Knowledge Architecture** (future) — Will formalize P-030, P-031, P-032
+- **ASM-001: Jerry Will Remain Single-Tenant Through Phase 3** (future) — Documents assumption that embedded deployment sufficient
+- **ASM-002: Property Graph Performance Sufficient for Jerry Scale** (future) — Documents assumption that < 10M entities
+
+## References
+
+### Primary Sources
+
+- **docs/synthesis/work-031-e-006-synthesis.md** — Cross-document synthesis of 5 research reports (1,142 lines)
+  - Braun & Clarke thematic analysis
+  - 10 architectural patterns (PAT-001 through PAT-010)
+  - L0/L1/L2 multi-level synthesis (ELI5, technical, strategic)
+
+- **docs/analysis/work-031-e-007-trade-off-analysis.md** — ATAM-inspired quality attribute trade-off analysis (821 lines)
+  - SWOT analysis (6 strengths, 6 weaknesses, 6 opportunities, 6 threats)
+  - Quality attribute trade-offs (4 ATAM scenarios)
+  - Decision matrix (5 options scored on 5 criteria)
+  - Risk analysis (top 5 risks with mitigation strategies)
+
+### Research Evidence (via Synthesis)
+
+**Pattern Support:**
+- PAT-001: Hybrid Property Graph + RDF Architecture — **Unanimous support (5/5 documents)**
+- PAT-002: Four-Phase Knowledge Architecture Maturity Model — **Unanimous support (5/5 documents)**
+- PAT-003: Netflix UDA "Model Once, Represent Everywhere" — **Strong support (4/5 documents)**
+
+**Case Studies:**
+- **FalkorDB:** 90% hallucination reduction with GraphRAG
+- **LinkedIn:** 63% faster ticket resolution (40hrs → 15hrs) with knowledge graph grounding
+- **Amazon Finance:** 49% → 86% accuracy improvement with GraphRAG
+- **Netflix UDA:** Production-proven pattern at scale (Unified Data Architecture)
+
+**Standards:**
+- **W3C RDF 1.2:** RDF* for edge properties without reification
+- **W3C SPARQL 1.2:** Improved query performance
+- **W3C JSON-LD 1.1:** 70% web adoption (Web Data Commons 2024)
+- **Schema.org:** 45M+ websites, 803 types, 1,461 properties
+- **Tim Berners-Lee 5-Star Linked Open Data:** Jerry at 4 stars, targeting 5 stars
+
+**Technologies:**
+- **pyoxigraph:** Embedded RDF store in Rust/Python, zero Java dependencies
+- **Gremlin/TinkerPop:** Property graph query language, Apache standard
+- **MiniCheck:** Grounding verification (GPT-4 accuracy at 400x lower cost, 770M parameters)
+- **FAISS/ChromaDB:** Embedded vector databases for semantic search
+
+### Research Methods
+
+- **Braun & Clarke Thematic Analysis:** 6-phase qualitative method for pattern extraction (synthesis document)
+- **ATAM (Architecture Tradeoff Analysis Method):** Quality attribute scenario analysis, Carnegie Mellon SEI (analysis document)
+- **SWOT Analysis:** Strategic planning framework for identifying strengths, weaknesses, opportunities, threats (analysis document)
+- **Decision Matrix:** Multi-criteria decision analysis with weighted scoring (analysis document)
+- **Risk Matrix:** Probability × Impact scoring with mitigation strategies (analysis document)
+
+### Industry Prior Art
+
+- **Netflix UDA (Unified Data Architecture):** "Conceptual RDF, Flexible Physical" pattern
+- **Microsoft Research GraphRAG:** Knowledge graph-based retrieval for LLM grounding
+- **FalkorDB GraphRAG:** Production deployment case study
+- **Neo4j Graph Modeling:** Supernode problem and mitigation strategies
+- **DataStax Graph Best Practices:** Property graph modeling at scale
+
+### Jerry Documentation
+
+- **CLAUDE.md:** Jerry framework root context, architecture overview
+- **docs/governance/JERRY_CONSTITUTION.md:** Constitutional principles for agent governance
+- **docs/knowledge/:** Accumulated knowledge hierarchy
+- **docs/experience/:** Lessons learned (LES items)
+- **docs/wisdom/:** Distilled wisdom (WIS items)
+
+---
+
+## Changelog
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-08 | ps-architect agent (v2.0.0) | Initial ADR created from synthesis work-031-e-006 and analysis work-031-e-007 |
+
+---
+
+*Decision Record Method: Michael Nygard ADR Format*
+*Decision: Hybrid Property + RDF Architecture (22/25, 88%)*
+*Top Risk: Supernode degradation (9/9 Critical, strong mitigations)*
+*Agent: ps-architect (v2.0.0)*
+*Constitution Compliance: P-001 (all claims cited), P-002 (decision persisted to file)*

--- a/docs/archive/projects-archive/decisions/ADR-032-km-integration.md
+++ b/docs/archive/projects-archive/decisions/ADR-032-km-integration.md
@@ -1,0 +1,548 @@
+# ADR-032: Jerry Knowledge Management Integration
+
+## Status
+
+**PROPOSED** (Awaiting ps-validator approval)
+
+## Date
+
+2026-01-09
+
+## Context
+
+### Problem Statement
+
+Jerry is a framework for behavior and workflow guardrails designed to accrue knowledge, wisdom, and experience while solving problems. As the knowledge corpus grows, we face **context rot**—degraded LLM performance despite remaining within token limits—and practical challenges in knowledge discovery and reuse.
+
+**Current State:**
+- Filesystem-only knowledge storage (markdown in `docs/` hierarchy)
+- Manual cross-referencing required
+- No relationship discovery or semantic search
+- Limited ability to answer "what relates to X?" queries
+- Knowledge fragmentation as corpus exceeds ~100 documents
+- Agent reasoning constrained by keyword-based retrieval
+
+**Research Foundation:**
+A comprehensive Knowledge Management research synthesis (358KB across 5 documents, 71+ citations) identified that modern KM requires three complementary capabilities:
+1. **Filesystem** - Human-readable, version-controlled source of truth
+2. **Graph Layer** - Relationship discovery and traversal
+3. **AI Layer** - Semantic search and retrieval-augmented generation (RAG)
+
+**Why Now:**
+- Jerry's mission explicitly includes knowledge accumulation
+- Current corpus approaching limits of manual management
+- Agent capabilities limited without semantic retrieval
+- Industry trends validate graph + vector + filesystem architecture
+- Lightweight Python libraries available that align with hexagonal architecture
+
+### Decision Drivers
+
+The following factors shaped this decision (weighted by importance):
+
+| Driver | Weight | Rationale |
+|--------|--------|-----------|
+| **Architectural Fit** | 15% | Must align with hexagonal architecture, zero-dependency domain |
+| **Capability** | 20% | Enable relationship discovery, semantic search, RAG foundation |
+| **Cost (Implementation)** | 10% | Time/effort to implement and maintain |
+| **Cost (Operational)** | 10% | Runtime resources, licensing, service management |
+| **Local-First** | 12% | Maintain filesystem as source of truth, no required cloud |
+| **Time to Value** | 10% | Speed to working MVP and tangible benefits |
+| **Scalability** | 8% | Handle growth from 100s to 1000s of documents |
+| **Future-Proofing** | 8% | Migration paths if needs change |
+| **Learning Curve** | 7% | Developer/user adoption friction |
+
+**Additional Constraints:**
+- Must preserve constitutional principle P-002 (File Persistence)
+- Must not violate P-003 (No Recursive Subagents—ReAct uses tools, not nested agents)
+- Must support local deployment (privacy, cost, ownership)
+- Should enable progressive ISO 30401 standard alignment
+
+## Considered Options
+
+### Option 1: Minimal KM (Filesystem Only)
+
+**Description:** Maintain current state—markdown files in `docs/`, git versioning, no KM tooling.
+
+**Strengths:**
+- Zero dependencies (pure stdlib)
+- Simple mental model
+- Portable, future-proof format (markdown)
+- Already working
+
+**Weaknesses:**
+- No relationship discovery
+- No semantic search
+- Manual cross-referencing
+- Scales poorly beyond ~100 documents
+- Knowledge fragmentation inevitable
+
+**Scores:**
+- Decision Matrix: 7.0/10
+- SWOT: 5.3/10
+- Quality Attributes: 4.30/7
+
+**Verdict:** Inadequate for Jerry's knowledge-centric mission. Already experiencing limitations.
+
+---
+
+### Option 2: Lightweight KM (NetworkX + FAISS + RDFLib) ← RECOMMENDED
+
+**Description:** Add graph operations (NetworkX), vector search (FAISS), semantic web (RDFLib) to infrastructure layer while maintaining filesystem as source of truth.
+
+**Strengths:**
+- Pure Python libraries (no external services)
+- Minimal dependencies (3 packages, all pre-installable)
+- Hexagonal architecture fit (infrastructure adapters via ports)
+- Proven at scale (14M+ downloads/week each)
+- Enables semantic search, relationship discovery, RAG
+- Standards-based interoperability (RDF, SPARQL)
+- Swappable implementations (NetworkX → igraph → graph-tool)
+- Zero operational cost (no services, no licensing)
+
+**Weaknesses:**
+- Introduces external dependencies (infrastructure layer only)
+- Learning curve (graph concepts, RDF, embeddings)
+- Performance limits (NetworkX <10K nodes, FAISS CPU-bound)
+- Memory overhead (in-memory graphs and vectors)
+
+**Scores:**
+- Decision Matrix: **8.5/10** (highest)
+- SWOT: **8.2/10** (highest)
+- Quality Attributes: **4.37/7** (highest)
+
+**Verdict:** Best balance of capability, cost, and architectural fit.
+
+---
+
+### Option 3: Full KM (Neo4j + Qdrant + pyoxigraph)
+
+**Description:** Production-grade tools with native graph database (Neo4j), distributed vector store (Qdrant), advanced RDF processing (pyoxigraph). Requires external services.
+
+**Strengths:**
+- Production-ready scalability (billions of vectors, millions of nodes)
+- ACID transactions, advanced features (Cypher, graph algorithms)
+- Enterprise-proven (Neo4j: 75% Fortune 500 adoption)
+- Performance optimized (Rust cores)
+
+**Weaknesses:**
+- Requires external services (databases, deployment complexity)
+- Operational burden (monitoring, backups, DevOps)
+- Resource intensive (RAM, CPU, disk)
+- Cost (Neo4j Enterprise licensing)
+- Overkill for current corpus (<500 docs)
+- Longer implementation timeline
+- Doesn't fit hexagonal architecture cleanly
+
+**Scores:**
+- Decision Matrix: 6.5/10
+- SWOT: 6.8/10
+- Quality Attributes: 3.67/7
+
+**Verdict:** Premature optimization. Capabilities exceed current needs.
+
+---
+
+### Option 4: Enterprise KM (ISO 30401 + Commercial Platforms)
+
+**Description:** Complete ISO 30401 implementation with commercial KM platforms (Bloomfire, Guru, Confluence Enterprise), formal governance, dedicated roles.
+
+**Strengths:**
+- ISO 30401 certification possible
+- Comprehensive features (wikis, forums, analytics)
+- Vendor support and SLAs
+- Enterprise-scale proven
+
+**Weaknesses:**
+- Extremely expensive ($10K-$100K+ annually)
+- Massive overkill for 1-10 users
+- Cloud-dependent (contradicts local-first)
+- Vendor lock-in
+- Implementation timeline: months to years
+- Heavy cultural change required
+
+**Scores:**
+- Decision Matrix: 5.1/10
+- SWOT: 4.5/10
+- Quality Attributes: 3.14/7
+
+**Verdict:** Completely misaligned with Jerry's philosophy and scale.
+
+## Decision
+
+**We will adopt Lightweight KM (NetworkX + FAISS + RDFLib) with phased implementation starting Q1 2026.**
+
+### Rationale
+
+1. **Highest Scores Across All Evaluation Methods:**
+   - Decision Matrix: 8.5/10 (15% higher than next best)
+   - SWOT Analysis: 8.2/10
+   - Quality Attributes: 4.37/7 (balances functionality with maintainability)
+
+2. **Perfect Architectural Alignment:**
+   - Infrastructure layer adapters (domain remains dependency-free)
+   - Port/adapter pattern enables future swapping
+   - Local-first preserved (filesystem remains source of truth)
+   - Hexagonal architecture integrity maintained
+
+3. **Addresses Current Pain Points:**
+   - Enables relationship discovery ("what relates to X?")
+   - Supports semantic search (beyond keyword grep)
+   - Provides standards-based export (RDF/SPARQL for interoperability)
+   - Foundation for RAG implementation (agent knowledge retrieval)
+
+4. **Risk Profile Acceptable:**
+   - All 5 major risks have effective mitigations
+   - Port/adapter pattern de-risks dependency and growth concerns
+   - Phased rollout limits implementation risk
+   - No operational burden (no services to manage)
+
+5. **Industry Validation:**
+   - Synthesis of 358KB research across 71+ citations recommends this exact stack
+   - NetworkX: 14.9M downloads/week, active development
+   - RDFLib: 14M downloads/week, RDF standard compliance
+   - FAISS: Meta-backed, production-proven, used by LangChain/LlamaIndex
+
+6. **Clear Migration Paths:**
+   - If corpus exceeds capacity → swap to igraph/graph-tool/Qdrant via ports
+   - If need ACID/collaboration → add Neo4j via same port interface
+   - Progressive enhancement, not rip-and-replace
+
+7. **Cost-Effective:**
+   - Zero licensing costs (all open-source)
+   - Zero operational costs (no services)
+   - Implementation: 70-100 hours over 3 phases (manageable)
+   - ROI: 10-20% time saved finding information (industry average)
+
+### Confidence Level
+
+**85% (HIGH)**
+
+Based on:
+- Convergent evidence across multiple evaluation methods
+- Clear superiority in weighted decision matrix
+- Strong alignment with Jerry's architectural principles
+- Industry validation from comprehensive research synthesis
+- Effective risk mitigations identified
+
+## Consequences
+
+### Positive
+
+**Immediate Benefits:**
+- ✅ Relationship discovery: Answer "what relates to X?" queries
+- ✅ Semantic search: Find conceptually similar documents
+- ✅ Standards interoperability: Export knowledge graph as RDF/Turtle
+- ✅ Foundation for RAG: Retrieval-augmented agent reasoning
+- ✅ Graph visualization: NetworkX → Graphviz for knowledge maps
+
+**Medium-Term Benefits:**
+- ✅ Reduced duplicate work: 15-25% (via "what already exists?" queries)
+- ✅ Faster information discovery: 10-20% time saved (industry average)
+- ✅ Improved agent reasoning: Grounded in knowledge retrieval vs. pure generation
+- ✅ Knowledge reuse tracking: Measure concept application to new problems
+- ✅ ISO 30401 alignment path: Progressive standard compliance
+
+**Long-Term Benefits:**
+- ✅ Competitive advantage: Knowledge graph as differentiator
+- ✅ Community engagement: Graph visualizations for collaboration
+- ✅ Migration readiness: Ports enable production tool adoption if needed
+- ✅ Accumulated wisdom: Structured knowledge compounds over time
+
+### Negative
+
+**Compromises Accepted:**
+- ❌ Introduces external dependencies (infrastructure layer—acceptable per architecture)
+- ❌ Performance limits (NetworkX <10K nodes, FAISS CPU-only—acceptable for 1-2 year horizon)
+- ❌ Learning curve (graph concepts, RDF, embeddings—mitigated via phased adoption)
+- ❌ Memory overhead (in-memory structures—acceptable for expected corpus size)
+- ❌ Manual graph construction initially (automated extraction deferred to Phase 2)
+
+**Technical Debt:**
+- Must monitor library health (releases, vulnerabilities)
+- Must track knowledge graph size vs. tool capacity
+- Must maintain adapter code (vs. stdlib-only simplicity)
+- FAISS dimension management adds complexity
+
+**Philosophical Trade-offs:**
+- Relaxes "zero-dependency core" aspiration for infrastructure layer
+- Accepts that modern KM requires selective external libraries
+- Prioritizes capability over purity
+
+### Risks
+
+**Risk #1: Knowledge Corpus Growth Exceeds Tool Capacity**
+- **Severity:** HIGH (P=60%, I=8, Score=4.8/10)
+- **Mitigation:** Port/adapter pattern enables swap to igraph/graph-tool/Qdrant
+- **Trigger:** Graph >5K nodes OR FAISS search >2 seconds
+- **Contingency:** Quarterly size monitoring, predefined migration paths
+
+**Risk #2: Dependency Abandonment or Breaking Changes**
+- **Severity:** MEDIUM (P=20%, I=7, Score=1.4/10)
+- **Mitigation:** Pin versions, quarterly health checks, hexagonal architecture isolates impact
+- **Trigger:** 6 months without releases OR critical security vulnerability
+- **Contingency:** Adapter replacement via port interface, stdlib fallback where possible
+
+**Risk #3: Implementation Complexity Delays Value Delivery**
+- **Severity:** MEDIUM (P=40%, I=5, Score=2.0/10)
+- **Mitigation:** Phased rollout with MVP in 1 month (Phase 2 = tangible value)
+- **Trigger:** If Phase 2 exceeds 4 weeks, descope or reassess
+- **Contingency:** Deliver basic graph operations first, defer advanced features
+
+**Risk #4: User Adoption Failure (Protocols)**
+- **Severity:** MEDIUM (P=50%, I=4, Score=2.0/10)
+- **Mitigation:** Lightweight AAR (3 questions, <5 min), show value via "Lessons Applied" reports
+- **Trigger:** If <20% compliance after 3 months, simplify or automate
+- **Contingency:** Quarterly retrospective instead of per-task AAR
+
+**Risk #5: Over-Engineering / Scope Creep**
+- **Severity:** MEDIUM (P=30%, I=6, Score=1.8/10)
+- **Mitigation:** Strict phase gates, YAGNI discipline, quarterly ROI review
+- **Trigger:** If KM work exceeds 20% of total dev time in any quarter
+- **Contingency:** Freeze feature development, focus on utilization
+
+## Implementation Plan
+
+### Phase 1: Foundation (Q1 2026, Weeks 1-4)
+
+**Goal:** Working graph operations and semantic search.
+
+**Deliverables:**
+```python
+# Port definitions (domain layer, zero dependencies)
+src/domain/ports/graph_port.py          # Graph operations interface
+src/domain/ports/knowledge_port.py      # Semantic/RDF operations interface
+src/domain/ports/vector_store_port.py   # Vector search interface
+
+# Adapters (infrastructure layer)
+src/infrastructure/graph/networkx_adapter.py      # NetworkX implementation
+src/infrastructure/knowledge/rdflib_adapter.py    # RDFLib implementation
+src/infrastructure/embeddings/faiss_adapter.py    # FAISS implementation
+
+# Dependencies
+pip install networkx==3.2.1 rdflib==7.0.0 faiss-cpu==1.7.4
+```
+
+**Success Criteria:**
+- [x] Can add nodes and edges to graph
+- [x] Can query "What docs reference concept X?"
+- [x] Can export knowledge graph to RDF/Turtle format
+- [x] Can add document embeddings to FAISS
+- [x] Can search "Find top 5 docs similar to query"
+
+**Effort Estimate:** 20-30 hours (1-2 weeks part-time)
+
+**Risk:** Low (libraries well-documented, clear interfaces)
+
+---
+
+### Phase 2: Integration (Q2 2026, Weeks 5-10)
+
+**Goal:** Automated knowledge graph construction from `docs/`.
+
+**Deliverables:**
+```python
+# Entity extraction
+src/infrastructure/extraction/markdown_entities.py
+
+# Graph builder
+src/application/commands/build_knowledge_graph.py
+
+# Query interface
+src/application/queries/find_related_docs.py
+src/application/queries/semantic_search.py
+
+# CLI integration
+jerry knowledge graph --query "find related to X"
+jerry knowledge search "semantic query text"
+```
+
+**Success Criteria:**
+- [x] Automatically index `docs/` into graph on update
+- [x] Extract entities: Tasks, Phases, Plans, Concepts, Documents
+- [x] Extract relationships: REFERENCES, PART_OF, USES, IMPLEMENTS
+- [x] Provide CLI for knowledge queries
+- [x] Graph visualization export (DOT format for Graphviz)
+
+**Effort Estimate:** 30-40 hours (2-3 weeks part-time)
+
+**Risk:** Medium (entity extraction heuristics may need tuning)
+
+---
+
+### Phase 3: AI Integration (Q3 2026, Weeks 11-16)
+
+**Goal:** RAG over knowledge base for agent reasoning.
+
+**Deliverables:**
+```python
+# RAG implementation
+src/interface/rag/simple_rag.py
+
+# Agent integration
+skills/knowledge-search/SKILL.md
+
+# Use cases
+src/application/queries/knowledge_query.py  # "What do we know about X?"
+```
+
+**Success Criteria:**
+- [x] Agents can query: "What do we know about topic X?"
+- [x] Retrieval includes top K relevant docs + source citations
+- [x] Generation grounded in retrieved knowledge
+- [x] Source attribution always provided (constitutional compliance)
+- [x] Agents demonstrate measurable reasoning improvement
+
+**Effort Estimate:** 20-30 hours (1-2 weeks part-time)
+
+**Risk:** Low (RAG pattern well-established, FAISS + LLM API)
+
+---
+
+### Phase 4: Optimization (Q4 2026+, Triggered)
+
+**Goal:** Performance tuning and advanced features (only if needed).
+
+**Potential Upgrades:**
+- NetworkX → igraph (if graph >5K nodes)
+- FAISS CPU → FAISS GPU (if search >1 second)
+- Simple RAG → GraphRAG (if multi-hop reasoning needed)
+- Add Docling for PDF processing (if document formats expand)
+- Consider Neo4j Community Edition (if ACID transactions needed)
+
+**Trigger-Based:** Only implement if performance issues arise or specific needs emerge.
+
+**Governance:** Quarterly review against success metrics.
+
+---
+
+### Success Metrics
+
+**Quantitative (Measured Quarterly):**
+- Knowledge graph size: Target 500+ nodes by Q2 2026, 1000+ by Q4 2026
+- Query performance: <500ms for graph queries, <2s for semantic search
+- Adoption: 50% of work items with associated knowledge by Q2 2026
+- Coverage: 80% of `docs/` indexed in graph by Q3 2026
+
+**Qualitative (User/Agent Feedback):**
+- Agents demonstrate improved reasoning via knowledge retrieval
+- Users report faster discovery of related work
+- Knowledge reuse measurable (concepts applied to new problems)
+- "Lessons Applied" reports show learning circulation (SECI spiral)
+
+**ROI Targets:**
+- Time saved finding information: 10-20% (baseline via time-tracking)
+- Reduced duplicate work: 15-25% (via "what exists?" query logs)
+- Improved decision quality: Qualitative (better-informed choices)
+
+---
+
+### Governance and Review
+
+**Quarterly Assessment (Jan/Apr/Jul/Oct):**
+1. Review knowledge graph growth vs. tool capacity
+2. Check dependency health (releases, vulnerabilities, GitHub activity)
+3. Measure adoption metrics (AAR completion, knowledge queries)
+4. Assess ROI (time saved vs. maintenance burden)
+5. Decide: Continue, upgrade tools, or roll back
+
+**Off-Ramps:**
+- If adoption <20% by Q2 2026 → Simplify protocols or defer Phase 3
+- If maintenance burden >20% of dev time → Consider managed services
+- If performance issues arise → Trigger Phase 4 upgrades early
+- If constitutional violations detected → Immediate remediation
+
+**Alignment Checks:**
+- P-002 (File Persistence): Filesystem remains source of truth ✅
+- P-003 (No Recursive Subagents): ReAct uses tools, not nested agents ✅
+- P-020 (User Authority): Recommendations, not mandates ✅
+- P-022 (No Deception): Always cite sources, expose uncertainty ✅
+
+---
+
+### Rollback Plan
+
+**If Lightweight KM fails to deliver value:**
+
+**Rollback Trigger:** After 6 months, if:
+- Adoption <20% AND
+- ROI not measurable AND
+- Maintenance burden high
+
+**Rollback Steps:**
+1. Freeze feature development
+2. Preserve filesystem knowledge (already source of truth)
+3. Archive graph/vector data (exportable as RDF)
+4. Remove infrastructure adapters
+5. Revert to Enhanced Minimal KM (pure Python graph fallback)
+
+**Data Preservation:**
+- Filesystem unaffected (remained source of truth throughout)
+- RDF export available for future tools
+- Knowledge not lost, just retrieval mechanisms changed
+
+**Cost of Rollback:** Low (hexagonal architecture isolates impact)
+
+## References
+
+### Primary Research Documents
+
+1. **KM Domain Synthesis** (`docs/synthesis/work-032-e-006-km-synthesis.md`)
+   - 37KB, 7 major thematic patterns identified
+   - Synthesis of 358KB research across 5 documents, 71+ citations
+   - Braun & Clarke thematic analysis methodology
+   - Key finding: Modern KM = Filesystem + Graph + AI
+
+2. **Trade-off Analysis** (`docs/analysis/work-032-e-007-trade-off-analysis.md`)
+   - 29KB, SWOT + Decision Matrix + Quality Attributes + Risk Analysis
+   - 4 options evaluated against 9 weighted criteria
+   - Lightweight KM recommended (8.5/10 score, 85% confidence)
+   - 5 major risks identified with mitigations
+
+### Research Sources (via Synthesis)
+
+3. **KM Fundamentals** (e-001): SECI model, Cynefin, ISO 30401, thought leaders
+4. **KM Protocols** (e-002): AAR, A3, Knowledge Audit, APQC framework
+5. **KM Products** (e-003): Neo4j, Obsidian, RAG products, market trends
+6. **Python SDKs** (e-004): NetworkX, RDFLib, FAISS, spaCy, Docling analysis
+7. **KM Frameworks** (e-005): SECI, Cynefin, TRIZ, Design Thinking, ReAct, RAG, GraphRAG
+
+### Industry Standards
+
+8. **ISO 30401:2018** - Knowledge Management Systems (progressive alignment target)
+9. **RDF/SPARQL** - W3C Semantic Web standards (via RDFLib)
+10. **Hexagonal Architecture** - Alistair Cockburn (ports/adapters pattern)
+
+### Technical Documentation
+
+11. **NetworkX Documentation** - https://networkx.org/ (v3.2.1)
+12. **RDFLib Documentation** - https://rdflib.readthedocs.io/ (v7.0.0)
+13. **FAISS Documentation** - https://faiss.ai/ (v1.7.4)
+
+### Jerry Governance
+
+14. **Jerry Constitution** (`docs/governance/JERRY_CONSTITUTION.md`) - Principles P-002, P-003, P-020, P-022
+15. **Coding Standards** (`.claude/rules/coding-standards.md`) - Hexagonal architecture enforcement
+
+---
+
+## Approval Chain
+
+| Role | Name | Status | Date |
+|------|------|--------|------|
+| **Author** | ps-architect v2.0.0 | ✅ Complete | 2026-01-09 |
+| **Reviewer** | ps-validator | ⏳ Pending | - |
+| **Approver** | User | ⏳ Pending | - |
+
+**Next Steps:**
+1. ps-validator review for correctness, completeness, adherence to ADR format
+2. User approval or feedback
+3. If approved: Create implementation PLAN file and begin Phase 1
+4. If rejected: Document rationale, consider alternatives
+
+---
+
+**ADR Status:** PROPOSED
+**File:** `/home/user/jerry/docs/decisions/ADR-032-km-integration.md`
+**Last Updated:** 2026-01-09
+**Supersedes:** None
+**Superseded By:** None (active)

--- a/docs/archive/projects-archive/decisions/ADR-033-unified-km-architecture.md
+++ b/docs/archive/projects-archive/decisions/ADR-033-unified-km-architecture.md
@@ -1,0 +1,1124 @@
+# ADR-033: Unified Knowledge Management Architecture
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Status** | PROPOSED |
+| **Date** | 2026-01-09 |
+| **Deciders** | ps-architect v2.0.0, User (pending approval) |
+| **Technical Story** | WORK-033 (Unified KM Architecture Decision) |
+| **Supersedes** | None (unifies ADR-031 + ADR-032) |
+| **Related ADRs** | ADR-031 (Knowledge Architecture), ADR-032 (KM Integration) |
+
+---
+
+## Executive Summary
+
+Jerry is a framework for behavior and workflow guardrails designed to accrue knowledge, wisdom, and experience while solving problems. Two major architectural decisions have been proposed to enhance Jerry's knowledge management capabilities:
+
+- **ADR-031 (WORK-031)**: Defines a Hybrid Property Graph + RDF Architecture for semantic web integration, with a four-phase maturity roadmap, achieving a decision matrix score of 22/25 (88%).
+- **ADR-032 (WORK-032)**: Recommends a Lightweight KM Stack using NetworkX, FAISS, and RDFLib for practical implementation, scoring 8.5/10 (85%) on the decision matrix.
+
+This ADR unifies both decisions into a single, comprehensive architectural specification. Integration analysis reveals **95% compatibility** between the two decisions, with zero conflicts. Both independently converged on identical architectural patterns: hybrid property graph + RDF + vectors, four-phase maturity model, and Netflix UDA "Model Once, Represent Everywhere" philosophy.
+
+The unified design adopts a **Phased Implementation Strategy**, which scored 4.6/5 (92%) in decision matrix analysis, outperforming both Minimal (3.2/5, 64%) and Full (2.6/5, 52%) implementation alternatives. This approach delivers core KM capabilities in 8 weeks (Phase 2) while preserving flexibility to add advanced features (GraphRAG, SPARQL) in subsequent phases only if value is demonstrated.
+
+**Key Outcome**: Jerry gains relationship discovery, semantic search, RDF export, and RAG foundation with a projected 186% ROI over 5 years, achieved through a risk-managed phased approach that aligns with Jerry's hexagonal architecture and constitutional principles.
+
+---
+
+## Context and Problem Statement
+
+### The Knowledge Management Challenge
+
+Jerry's core mission is to **accrue knowledge while solving problems**. Currently, Jerry operates at Phase 1 with:
+
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON formats)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker graph model for operational state
+
+However, as the knowledge corpus grows, Jerry faces critical challenges:
+
+1. **Context Rot**: LLM performance degrades as context windows fill, even within technical token limits. Jerry needs persistent knowledge storage beyond ephemeral context.
+
+2. **Knowledge Fragmentation**: Knowledge accumulates across Work Tracker entities (tasks, phases, plans) AND documentation (`docs/` hierarchy), but these exist as isolated silos without semantic connections.
+
+3. **Discovery Limitations**: No ability to answer "what relates to X?" queries. Manual cross-referencing required, which scales poorly beyond ~100 documents.
+
+4. **LLM Hallucination**: Claude Code agents operating within Jerry lack grounding mechanisms, leading to factually incorrect responses without source attribution.
+
+5. **Interoperability Gaps**: Jerry's current property graph uses implicit schemas and Jerry-specific formats, limiting integration with external systems and semantic web standards.
+
+### Prior Work Leading to This Decision
+
+**WORK-031 (ADR-031: Knowledge Architecture)** provided the **technical foundation**:
+- Comprehensive research synthesis (358KB across 5 documents, 71+ citations)
+- Hybrid Property Graph + RDF architecture recommendation
+- Four-phase maturity roadmap (Foundation → Semantic → Advanced → Scale)
+- Technology stack: pyoxigraph, JSON-LD contexts, SHACL validation
+- Focus: Semantic web standards, 5-star Linked Open Data, LLM grounding
+
+**WORK-032 (ADR-032: KM Integration)** provided the **practical implementation plan**:
+- Lightweight stack analysis (NetworkX, FAISS, RDFLib)
+- Port/adapter pattern for hexagonal architecture compliance
+- AAR/A3 protocols for knowledge capture
+- Focus: Python libraries, zero operational cost, pragmatic rollout
+
+**WORK-033 Integration Analysis** discovered:
+- 95% compatibility between both decisions
+- Zero architectural conflicts
+- Natural 5-layer integration model
+- Unified 8-week Phase 2 roadmap
+
+### Constraints and Requirements
+
+This architecture must honor:
+
+| Constraint | Source | Requirement |
+|------------|--------|-------------|
+| **P-002 (File Persistence)** | Jerry Constitution | Filesystem remains source of truth |
+| **P-003 (No Recursive Subagents)** | Jerry Constitution | ReAct uses tools, not nested agents |
+| **Zero-Dependency Domain** | Hexagonal Architecture | Domain layer uses Python stdlib only |
+| **Backward Compatibility** | Phase 1 Foundation | Existing property graph foundation unchanged |
+| **Local-First** | Privacy/Cost | No required cloud services through Phase 3 |
+
+---
+
+## Decision Drivers
+
+The following factors influenced this architectural decision, ranked by priority:
+
+### Critical Drivers (Must-Have)
+
+| # | Driver | Weight | Rationale |
+|---|--------|--------|-----------|
+| 1 | **LLM Grounding Effectiveness** | 20% | Measurable reduction in hallucinations, improved agent accuracy. Industry evidence shows 90% reduction (FalkorDB), 63% faster resolution (LinkedIn). |
+| 2 | **Backward Compatibility** | 15% | Phase 1 property graph foundation must remain intact. No throwaway work. |
+| 3 | **Performance Requirements** | 15% | Query latency P95 < 50ms for hot path, < 2s for semantic search. |
+| 4 | **Zero-Dependency Core** | 10% | Domain layer maintains Python stdlib-only constraint. |
+| 5 | **Incremental Implementation** | 10% | Each phase must deliver independent value with clear go/no-go gates. |
+
+### Important Drivers (Should-Have)
+
+| # | Driver | Weight | Rationale |
+|---|--------|--------|-----------|
+| 6 | **Standards Compliance** | 8% | W3C RDF, SPARQL, JSON-LD for interoperability, 5-star Linked Open Data. |
+| 7 | **Architectural Fit** | 8% | Must align with hexagonal architecture ports/adapters pattern. |
+| 8 | **Cost Management** | 7% | Prefer embedded over server-based through Phase 3. Zero operational cost. |
+| 9 | **Supernode Prevention** | 4% | Avoid catastrophic performance degradation from high-degree vertices. |
+| 10 | **Schema Evolution** | 3% | Support for versioning and migrations per P-030. |
+
+---
+
+## Considered Options
+
+### Option 1: Minimal Implementation
+
+**Description**: Build only essential capabilities (ports, basic adapters, simple graph operations). No semantic search, no RDF, no RAG.
+
+**Timeline**: 4-6 weeks | **Effort**: 30-50 hours
+
+**Pros**:
+- Fastest to implement
+- Lowest complexity (500 LOC, 0 dependencies)
+- Easiest to maintain (20 hours/year)
+
+**Cons**:
+- Limited capability (no semantic search, no RAG)
+- Cannot answer "what relates to X?" with confidence
+- Misses transformative features that justify KM investment
+- Low alignment with Jerry's knowledge-centric mission
+- Time to value slow (limited features = limited benefits)
+
+**Decision Matrix Score**: 3.2/5 (64%)
+
+---
+
+### Option 2: Phased Implementation (CHOSEN)
+
+**Description**: Incremental rollout across 4 phases with explicit go/no-go gates. Phase 2 delivers core KM capabilities (8 weeks); Phase 3 adds advanced features (12 weeks, conditional); Phase 4 scales only if triggers met.
+
+**Timeline**: 8-28 weeks (depending on gates) | **Effort**: 70-150 hours across phases
+
+**Pros**:
+- **Highest ROI**: 186% over 5 years (vs 33% Minimal, 67% Full)
+- **Lowest risk**: Clear stop points, reversible decisions, strong mitigations
+- **Early value**: Phase 2 (week 8) delivers relationship discovery + semantic search
+- **Industry validated**: Both ADR-031 and ADR-032 independently recommend this approach
+- **Robust**: Wins in all sensitivity analysis scenarios (speed, safety, mission)
+- **Flexible**: Can accelerate (collapse phases) or decelerate (stop at Phase 2)
+
+**Cons**:
+- Longer timeline to "full" capability (28 weeks vs 16 weeks for Full)
+- Must wait for advanced features (SPARQL, grounding verification)
+- Requires discipline to maintain phase gates
+
+**Decision Matrix Score**: 4.6/5 (92%)
+
+---
+
+### Option 3: Full Implementation
+
+**Description**: Build everything upfront in single 12-16 week push. All features: RDF + graph + vectors + SPARQL + GraphRAG + grounding verification.
+
+**Timeline**: 12-16 weeks | **Effort**: 120-180 hours upfront
+
+**Pros**:
+- Fastest to "complete" feature set
+- All features available immediately
+- No phase gate overhead
+
+**Cons**:
+- **Highest risk**: No checkpoints, all-or-nothing investment
+- **Time to value delayed**: Must build everything before seeing benefits (Week 16 vs Week 8)
+- **Worst maintainability**: Most code surface area upfront (5,000 LOC)
+- **Premature optimization**: SPARQL/GraphRAG might never be used
+- **Lower ROI**: 67% (same value as Phased at 2x cost)
+
+**Decision Matrix Score**: 2.6/5 (52%)
+
+---
+
+## Decision Outcome
+
+### Chosen Option: Phased Implementation
+
+**The Phased Implementation strategy is selected** because it achieves the optimal balance of capability, risk, and value delivery:
+
+1. **Decision Matrix Winner**: 4.6/5 (92%)—leads Minimal by 44%, Full by 77%
+2. **Wins 4 of 5 Criteria**: Time to Value (5/5), Risk (5/5), Alignment (5/5), Maintainability (4/5)
+3. **Robust to Weight Changes**: Wins in all sensitivity scenarios tested
+4. **Industry Validation**: Both WORK-031 and WORK-032 independently converged on this approach
+5. **Highest ROI**: 186% over 5 years
+
+### Positive Consequences
+
+**Immediate Benefits (Phase 2, Week 8)**:
+- Relationship discovery: Answer "what relates to X?" via graph traversal
+- Semantic search: Find conceptually similar documents via vector similarity
+- Standards compliance: Export knowledge graph as RDF/Turtle/JSON-LD
+- Foundation for RAG: Retrieval-augmented agent reasoning
+- Graph visualization: NetworkX to Graphviz for knowledge maps
+
+**Medium-Term Benefits (Phase 3, Month 7)**:
+- GraphRAG: Combined vector + graph retrieval for LLM grounding
+- Jerry URI citations: Transparent sourcing in agent responses
+- SPARQL endpoint: Federated queries for external integration
+- 90% hallucination reduction potential (FalkorDB case study)
+
+**Long-Term Benefits (Year 1-5)**:
+- Knowledge as competitive moat: 300-320% ROI from knowledge graph investments
+- Accumulated wisdom: Structured knowledge compounds over time
+- Migration readiness: Ports enable production tool adoption if needed
+- ISO 30401 alignment path: Progressive standard compliance
+
+### Negative Consequences
+
+**Accepted Trade-offs**:
+
+| Trade-off | Impact | Mitigation |
+|-----------|--------|------------|
+| **Dependency expansion** | Introduces NetworkX, RDFLib, FAISS to infrastructure layer | Hexagonal architecture isolates impact; adapters swappable |
+| **Learning curve** | Graph concepts, RDF, embeddings require study | Documentation, phased adoption, <16 hours onboarding target |
+| **Architectural complexity** | Multiple serialization formats (JSON, TOON, JSON-LD, Turtle) | Netflix UDA pattern, automated round-trip tests |
+| **Performance limits** | NetworkX <10K nodes, FAISS CPU-bound | Sufficient for 2-year runway; migration paths defined |
+| **Longer timeline to full capability** | 28 weeks vs 16 weeks (Full option) | Early value at Week 8 compensates; flexibility preserved |
+
+---
+
+## Technical Architecture
+
+### Domain Model
+
+The unified design introduces a **KnowledgeItem** aggregate root as the central entity for knowledge management:
+
+```mermaid
+classDiagram
+    class EntityBase {
+        <<abstract>>
+        +JerryId id
+        +JerryUri uri
+        +datetime created_at
+        +str created_by
+        +datetime modified_at
+        +str modified_by
+        +str version
+        +str content_hash
+    }
+
+    class Vertex {
+        <<abstract>>
+        +VertexId id
+        +str label
+        +Dict properties
+        +set_property(key, value)
+        +get_property(key, default)
+    }
+
+    class KnowledgeItem {
+        +KnowledgeItemId id
+        +JerryUri uri
+        +str title
+        +KnowledgeType km_type
+        +KnowledgeStatus status
+        +Pattern|Lesson|Assumption content
+        +str context
+        +List~str~ tags
+        +List~KnowledgeItemId~ related_items
+        +List~str~ evidence_refs
+        +validate()
+        +deprecate(reason)
+        +add_evidence(uri)
+        +relate_to(other)
+    }
+
+    class KnowledgeType {
+        <<enumeration>>
+        PATTERN
+        LESSON
+        ASSUMPTION
+    }
+
+    class KnowledgeStatus {
+        <<enumeration>>
+        DRAFT
+        VALIDATED
+        DEPRECATED
+    }
+
+    class Pattern {
+        <<value object>>
+        +str context
+        +str problem
+        +str solution
+        +str consequences
+        +to_markdown() str
+    }
+
+    class Lesson {
+        <<value object>>
+        +str what_happened
+        +str what_learned
+        +str prevention
+        +to_markdown() str
+    }
+
+    class Assumption {
+        <<value object>>
+        +str statement
+        +str impact_if_wrong
+        +str validation_path
+        +to_markdown() str
+    }
+
+    class KnowledgeItemId {
+        <<value object>>
+        +str value
+        +generate(type, seq) KnowledgeItemId
+        +km_type KnowledgeType
+    }
+
+    EntityBase <|-- Vertex
+    Vertex <|-- KnowledgeItem
+    KnowledgeItem --> KnowledgeType
+    KnowledgeItem --> KnowledgeStatus
+    KnowledgeItem --> Pattern : "content (if PAT)"
+    KnowledgeItem --> Lesson : "content (if LES)"
+    KnowledgeItem --> Assumption : "content (if ASM)"
+    KnowledgeItem --> KnowledgeItemId
+```
+
+**Knowledge Item Types**:
+
+| Type | Prefix | Purpose | Example |
+|------|--------|---------|---------|
+| **Pattern** | PAT | Reusable solution to recurring problem | "Hybrid architecture prevents vendor lock-in" |
+| **Lesson** | LES | Experience from past work | "SHACL validation caught schema drift early" |
+| **Assumption** | ASM | Belief requiring validation | "Jerry will remain single-tenant through 2026" |
+
+### Ports (Interfaces)
+
+The domain layer defines four primary ports (zero external dependencies):
+
+#### IKnowledgeRepository (Persistence Port)
+
+```python
+class IKnowledgeRepository(ABC):
+    """Port for knowledge item persistence operations."""
+
+    @abstractmethod
+    def save(self, item: KnowledgeItem) -> None:
+        """Persist knowledge item to filesystem (source of truth)."""
+
+    @abstractmethod
+    def find_by_id(self, id: KnowledgeItemId) -> Optional[KnowledgeItem]:
+        """Retrieve knowledge item by ID."""
+
+    @abstractmethod
+    def find_by_type(self, km_type: KnowledgeType,
+                     status: Optional[KnowledgeStatus] = None) -> List[KnowledgeItem]:
+        """Find all items of a specific type."""
+
+    @abstractmethod
+    def find_related(self, item_id: KnowledgeItemId,
+                     max_depth: int = 2) -> List[KnowledgeItem]:
+        """Find knowledge items related via graph traversal."""
+```
+
+#### ISemanticIndex (Vector Search Port)
+
+```python
+class ISemanticIndex(ABC):
+    """Port for semantic search operations."""
+
+    @abstractmethod
+    def index(self, item: KnowledgeItem) -> None:
+        """Add knowledge item to semantic index (generate embeddings)."""
+
+    @abstractmethod
+    def search(self, query: str, top_k: int = 5,
+               filters: dict = None) -> List[Tuple[KnowledgeItemId, float]]:
+        """Semantic search returning (item_id, similarity_score) tuples."""
+
+    @abstractmethod
+    def reindex(self, items: List[KnowledgeItem]) -> None:
+        """Rebuild index from scratch."""
+```
+
+#### IGraphStore (Graph Operations Port)
+
+```python
+class IGraphStore(ABC):
+    """Port for graph operations on knowledge items."""
+
+    @abstractmethod
+    def add_vertex(self, item: KnowledgeItem) -> None:
+        """Add knowledge item as graph vertex."""
+
+    @abstractmethod
+    def add_edge(self, from_id: KnowledgeItemId, to_id: KnowledgeItemId,
+                 label: str, properties: Dict[str, Any] = None) -> Edge:
+        """Create relationship between knowledge items."""
+
+    @abstractmethod
+    def traverse(self, start_id: KnowledgeItemId, edge_label: str,
+                 max_depth: int = 2) -> List[KnowledgeItemId]:
+        """Graph traversal from starting vertex."""
+
+    @abstractmethod
+    def export_rdf(self, format: str = "turtle") -> str:
+        """Export knowledge graph as RDF (Turtle, JSON-LD, N-Triples)."""
+```
+
+#### IRDFSerializer (Serialization Port)
+
+```python
+class IRDFSerializer(ABC):
+    """Port for RDF serialization operations."""
+
+    @abstractmethod
+    def to_turtle(self, item: KnowledgeItem) -> str:
+        """Serialize to Turtle format."""
+
+    @abstractmethod
+    def to_jsonld(self, item: KnowledgeItem, context_url: str) -> dict:
+        """Serialize to JSON-LD with context."""
+
+    @abstractmethod
+    def validate_shacl(self, item: KnowledgeItem) -> ValidationResult:
+        """Validate against SHACL shapes."""
+```
+
+### Adapters (Infrastructure)
+
+Infrastructure layer provides concrete implementations:
+
+| Port | Adapter | Library | Phase | Purpose |
+|------|---------|---------|-------|---------|
+| IKnowledgeRepository | FileSystemAdapter | Python stdlib | 2 | Markdown persistence in `docs/knowledge/` |
+| IGraphStore | NetworkXAdapter | NetworkX 3.2.1 | 2 | Property graph operations |
+| ISemanticIndex | FAISSAdapter | FAISS 1.7.4 | 2 | Vector similarity search |
+| IRDFSerializer | RDFLibAdapter | RDFLib 7.0.0 | 2 | RDF serialization (Turtle, JSON-LD) |
+| IGraphStore | PyoxigraphAdapter | pyoxigraph | 3 | SPARQL endpoint, embedded triple store |
+
+**Adapter Architecture**:
+
+```mermaid
+graph TB
+    subgraph "Domain Layer (Zero Dependencies)"
+        PORT_REPO[IKnowledgeRepository]
+        PORT_INDEX[ISemanticIndex]
+        PORT_GRAPH[IGraphStore]
+        PORT_RDF[IRDFSerializer]
+    end
+
+    subgraph "Infrastructure Layer (Adapters)"
+        ADAPTER_FS[FileSystemAdapter<br/>Markdown in docs/knowledge/]
+        ADAPTER_NX[NetworkXAdapter<br/>Property graph operations]
+        ADAPTER_FAISS[FAISSAdapter<br/>Vector similarity search]
+        ADAPTER_RDF[RDFLibAdapter<br/>RDF serialization]
+        ADAPTER_PYOX[PyoxigraphAdapter<br/>SPARQL endpoint - Phase 3]
+    end
+
+    subgraph "Storage Layer"
+        FS[Filesystem<br/>docs/knowledge/*.md<br/>SOURCE OF TRUTH]
+        GRAPH_MEM[In-Memory Graph<br/>NetworkX]
+        VECTOR_INDEX[FAISS Index<br/>.jerry/indexes/]
+        RDF_EXPORT[RDF Files<br/>knowledge-graph.ttl]
+    end
+
+    PORT_REPO -.implements.-> ADAPTER_FS
+    PORT_INDEX -.implements.-> ADAPTER_FAISS
+    PORT_GRAPH -.implements.-> ADAPTER_NX
+    PORT_RDF -.implements.-> ADAPTER_RDF
+    PORT_GRAPH -.implements.-> ADAPTER_PYOX
+
+    ADAPTER_FS --> FS
+    ADAPTER_NX --> GRAPH_MEM
+    ADAPTER_FAISS --> VECTOR_INDEX
+    ADAPTER_RDF --> RDF_EXPORT
+```
+
+### Use Cases (CQRS)
+
+**Commands (Write Operations)**:
+
+| Command | Handler | Description |
+|---------|---------|-------------|
+| `CaptureKnowledgeCommand` | `CaptureKnowledgeHandler` | Create new knowledge item (PAT, LES, ASM) |
+| `ValidateKnowledgeCommand` | `ValidateKnowledgeHandler` | Transition from DRAFT to VALIDATED |
+| `DeprecateKnowledgeCommand` | `DeprecateKnowledgeHandler` | Mark knowledge as no longer applicable |
+| `RelateKnowledgeCommand` | `RelateKnowledgeHandler` | Create relationship between items |
+
+**Queries (Read Operations)**:
+
+| Query | Handler | Description |
+|-------|---------|-------------|
+| `SearchKnowledgeQuery` | `SearchKnowledgeHandler` | Semantic search via FAISS |
+| `GetRelatedKnowledgeQuery` | `GetRelatedKnowledgeHandler` | Graph traversal for related items |
+| `TraverseKnowledgeGraphQuery` | `TraverseKnowledgeGraphHandler` | Execute graph traversal patterns |
+| `ExportKnowledgeGraphQuery` | `ExportKnowledgeGraphHandler` | Export as RDF (Turtle, JSON-LD) |
+
+### Domain Events (CloudEvents 1.0)
+
+All events follow CloudEvents 1.0 specification:
+
+| Event | Type URI | Trigger |
+|-------|----------|---------|
+| `KnowledgeItemCreated` | `jer:jer:knowledge:facts/KnowledgeItemCreated` | New item captured |
+| `KnowledgeItemValidated` | `jer:jer:knowledge:facts/KnowledgeItemValidated` | DRAFT → VALIDATED transition |
+| `KnowledgeItemDeprecated` | `jer:jer:knowledge:facts/KnowledgeItemDeprecated` | Item marked deprecated |
+| `KnowledgeRelationCreated` | `jer:jer:knowledge:facts/KnowledgeRelationCreated` | New relationship created |
+
+**Event Schema**:
+```json
+{
+  "specversion": "1.0",
+  "type": "jer:jer:knowledge:facts/KnowledgeItemCreated",
+  "source": "jer:jer:knowledge:system",
+  "subject": "jer:jer:knowledge:pat:pat-001",
+  "time": "2026-01-09T10:30:00Z",
+  "data": {
+    "item_id": "PAT-001",
+    "km_type": "PATTERN",
+    "title": "Hybrid Architecture",
+    "created_by": "user:architect"
+  }
+}
+```
+
+### Technology Stack
+
+| Component | Library | Version | Purpose | Phase |
+|-----------|---------|---------|---------|-------|
+| **Graph Operations** | NetworkX | 3.2.1 | Property graph traversal, in-memory operations | 2 |
+| **Vector Search** | FAISS | 1.7.4 | Semantic similarity search, CPU-based | 2 |
+| **RDF Serialization** | RDFLib | 7.0.0 | Turtle, JSON-LD export, SHACL validation | 2 |
+| **RDF Triple Store** | pyoxigraph | Latest | SPARQL endpoint, embedded storage | 3 |
+| **Document Processing** | Docling | Latest | PDF/DOCX extraction (optional) | 3 |
+| **Entity Extraction** | spaCy | 3.7+ | NLP for entity extraction (optional) | 3 |
+
+**Dependency Installation**:
+```bash
+# Phase 2 (Required)
+pip install networkx==3.2.1 rdflib==7.0.0 faiss-cpu==1.7.4
+
+# Phase 3 (Optional)
+pip install pyoxigraph docling
+pip install spacy && python -m spacy download en_core_web_sm
+```
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundation (COMPLETE)
+
+**Status**: Already implemented in Jerry.
+
+**Deliverables**:
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON formats)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker graph model
+- CloudEvents integration
+
+### Phase 2: Semantic Layer + KM Foundation (8 weeks)
+
+**Timeline**: Q1 2026 | **Effort**: 70-100 hours
+
+#### Week 1-2: Foundation and Protocols
+
+**WORK-031 Contributions**:
+- [ ] Create JSON-LD context (`contexts/worktracker.jsonld`)
+- [ ] Implement supernode validator (100/1000 thresholds)
+- [ ] Document Netflix UDA pattern (`docs/design/MULTI_REPRESENTATION_PATTERN.md`)
+
+**WORK-032 Contributions**:
+- [ ] Create AAR template (`.claude/templates/aar-template.md`)
+- [ ] Create A3 template (`.claude/templates/a3-template.md`)
+- [ ] Implement problem-classifier skill (Cynefin-based)
+- [ ] Conduct baseline Knowledge Audit
+
+**Integration**:
+- [ ] Define all ports (IKnowledgeRepository, ISemanticIndex, IGraphStore, IRDFSerializer)
+- [ ] Install dependencies (NetworkX, RDFLib, FAISS)
+- [ ] Create domain entities (KnowledgeItem, Pattern, Lesson, Assumption)
+
+**Success Criteria**:
+- All ports defined with zero domain dependencies
+- Supernode validator catches edges >= 100 (warning), >= 1000 (error)
+- JSON-LD context validates against JSON-LD 1.1 spec
+
+**Effort**: 20-25 hours
+
+#### Week 3-4: RDF Serialization
+
+**WORK-031 Contributions**:
+- [ ] RDF serialization adapter (`src/infrastructure/persistence/rdf_adapter.py`)
+- [ ] Implement Turtle serialization for entities
+- [ ] Implement JSON-LD serialization using contexts
+- [ ] SHACL validation shapes (`schemas/worktracker-shapes.ttl`)
+
+**WORK-032 Contributions**:
+- [ ] RDFLib adapter implementing IRDFSerializer
+- [ ] Schema.org mapping documentation
+
+**Integration**:
+- [ ] Automated round-trip tests (JSON <-> TOON <-> JSON-LD <-> Turtle)
+
+**Success Criteria**:
+- All Jerry entities serializable to Turtle and JSON-LD
+- SHACL shapes validate (0 constraint violations)
+- Round-trip tests 100% success rate
+
+**Effort**: 15-20 hours
+
+#### Week 5-6: Graph Layer and Entity Extraction
+
+**WORK-031 Contributions**:
+- [ ] Index `docs/` with text-embedding-3-small
+- [ ] Store embeddings metadata in TOON format
+
+**WORK-032 Contributions**:
+- [ ] NetworkX adapter implementing IGraphStore
+- [ ] Entity extraction from markdown (`src/infrastructure/extraction/markdown_entities.py`)
+- [ ] Relationship detection (REFERENCES, PART_OF, USES)
+- [ ] CLI: `jerry knowledge graph --query "find related to X"`
+- [ ] Graph visualization export (DOT format)
+
+**Integration**:
+- [ ] Graph builder command (`src/application/commands/build_knowledge_graph.py`)
+
+**Success Criteria**:
+- Automatically index `docs/` into graph on update
+- Extract entities: Tasks, Phases, Plans, Concepts, Documents
+- Provide CLI for knowledge queries
+- Graph visualization export (Graphviz)
+
+**Effort**: 20-25 hours
+
+#### Week 7-8: Vector RAG and Integration Testing
+
+**WORK-031 Contributions**:
+- [ ] Performance benchmarks (property graph <50ms P95, RDF export <100ms P95)
+- [ ] Schema evolution integration tests
+- [ ] Contributor guide (`docs/contributing/SERIALIZATION_GUIDE.md`)
+
+**WORK-032 Contributions**:
+- [ ] FAISS adapter implementing ISemanticIndex
+- [ ] Semantic search query (`src/application/queries/semantic_search.py`)
+- [ ] CLI: `jerry knowledge search "semantic query text"`
+
+**Integration**:
+- [ ] HybridRAG foundation (vector + graph retrieval prototyped)
+- [ ] Constitutional amendments (P-030, P-031, P-032)
+
+**Success Criteria**:
+- All performance benchmarks meet targets
+- docs/ indexed with embeddings
+- Vector search returns relevant results
+- Contributor onboarding < 4 hours
+
+**Effort**: 15-20 hours
+
+#### Phase 2 Go/No-Go Gate (Week 8)
+
+Proceed to Phase 3 ONLY if ALL criteria met:
+
+| Criterion | Metric | Target |
+|-----------|--------|--------|
+| Backward Compatibility | % of Phase 1 tests passing | 100% |
+| Hot Path Performance | Query latency P95 | < 50ms |
+| Cold Path Performance | RDF export latency P95 | < 100ms |
+| Vector Search | Semantic search latency | < 2 seconds |
+| Serialization | Round-trip success rate | 100% |
+| Supernode Prevention | Edge count alerts | Working |
+| Documentation | Contributor onboarding time | < 4 hours |
+| User Validation | Positive feedback on capabilities | Confirmed |
+
+**If ANY criterion fails**: Pause Phase 3, address issues, re-evaluate.
+
+### Phase 3: Advanced Capabilities (12 weeks, conditional)
+
+**Timeline**: Q2-Q3 2026 | **Effort**: 60-85 hours
+
+**Trigger**: Proceed ONLY if Phase 2 go/no-go criteria met.
+
+#### Month 4-5: GraphRAG and Grounding
+
+**Deliverables**:
+- [ ] Extend Work Tracker entities with embedding properties
+- [ ] HybridRAG context merger (vector + graph)
+- [ ] Jerry URI citations in LLM responses
+- [ ] MiniCheck grounding verification (optional, soft warnings)
+- [ ] ReAct pattern formalization in problem-solving skill
+
+**Success Criteria**:
+- Claude Code agents query Jerry knowledge base
+- Responses include Jerry URI citations
+- Measurable hallucination reduction (baseline vs RAG)
+
+**Effort**: 25-35 hours
+
+#### Month 5-6: SPARQL and Content Negotiation
+
+**Deliverables**:
+- [ ] pyoxigraph integration for embedded RDF storage
+- [ ] SPARQL endpoint (Flask + pyoxigraph)
+- [ ] Content negotiation for Jerry URIs (Accept: application/ld+json, text/turtle, text/html)
+- [ ] OWL-DL ontology (`ontologies/jerry-ontology.ttl`)
+- [ ] Schema.org vocabulary mapping
+
+**Success Criteria**:
+- SPARQL endpoint responds to queries
+- Content negotiation returns correct format
+- OWL ontology validates
+
+**Effort**: 20-30 hours
+
+#### Month 6-7: Visualization and Monitoring
+
+**Deliverables**:
+- [ ] Cytoscape.js graph visualization
+- [ ] Knowledge architecture health dashboard
+- [ ] CloudEvents integration for monitoring alerts
+- [ ] SECI mode tagging for entities
+- [ ] Knowledge flow pattern analysis
+
+**Success Criteria**:
+- Dashboard deployed and accessible
+- Alerts trigger correctly at thresholds
+- User reviews dashboard weekly
+
+**Effort**: 15-20 hours
+
+#### Phase 3 Go/No-Go Gate (Month 7)
+
+Proceed to Phase 4 evaluation ONLY if:
+- Phase 2 success criteria maintained
+- User validation confirms semantic layer value
+- Use case demand for SPARQL or reasoning (not theoretical)
+- HybridRAG demonstrates measurable hallucination reduction
+
+**Do NOT proceed if**:
+- Phase 2 increased query latency > 100ms (hot path degraded)
+- Maintenance overhead slowed development > 30%
+- No external integration use cases emerged
+- User satisfaction high with Phase 2 alone
+
+### Phase 4: Scale (Triggered, Optional)
+
+**Timeline**: Q4 2026+ | **Trigger-Based**
+
+**Trigger Conditions (MUST meet at least one)**:
+- Multi-tenant SaaS offering required
+- > 10M entities in production (currently: thousands)
+- P95 query latency > 500ms (currently: < 50ms)
+- Clustering/HA required for uptime SLA
+
+**Do NOT proceed unless one trigger met.**
+
+**If Triggered, Evaluate**:
+
+| Option | Description | Cost |
+|--------|-------------|------|
+| **Apache Jena Fuseki** | Open-source, self-hosted, full SPARQL 1.1 | Infrastructure only |
+| **AWS Neptune** | Managed, high availability, production-grade | $100-1000/month |
+| **igraph/graph-tool** | C-based graph libraries (10x faster than NetworkX) | Free |
+| **Stay Embedded** | Index tuning, caching, query optimization | Development time |
+
+**Migration Effort**: 2-4 weeks (schema export, data migration, testing)
+
+**Governance**: Quarterly review against trigger conditions.
+
+---
+
+## Risk Management
+
+### Risk Register Summary
+
+| Risk ID | Description | Probability | Impact | Score | Residual Risk |
+|---------|-------------|-------------|--------|-------|---------------|
+| RISK-1 | Knowledge corpus growth exceeds tool capacity | 60% | HIGH (8) | 4.8/10 | MEDIUM (2.4) |
+| RISK-2 | Supernode performance degradation (Actor vertex) | 70% | HIGH (8) | 5.6/10 | LOW (1.4) |
+| RISK-3 | Architectural complexity slowing development | 50% | MEDIUM (6) | 3.0/10 | MEDIUM (3.0) |
+| RISK-4 | Schema evolution breaking graph traversals | 50% | HIGH (7) | 3.5/10 | MEDIUM (3.5) |
+| RISK-5 | User adoption failure (AAR/A3 protocols) | 50% | MEDIUM (4) | 2.0/10 | MEDIUM (2.0) |
+| RISK-6 | Over-engineering / scope creep | 30% | MEDIUM (6) | 1.8/10 | LOW (1.8) |
+| RISK-7 | Dependency abandonment or breaking changes | 20% | HIGH (7) | 1.4/10 | LOW (1.4) |
+| RISK-8 | Implementation delays / complexity underestimation | 40% | MEDIUM (5) | 2.0/10 | MEDIUM (2.0) |
+| RISK-9 | Premature Phase 4 migration | 10% | HIGH (8) | 0.8/10 | LOW (0.8) |
+| RISK-10 | LLM grounding verification false positives | 40% | LOW (3) | 1.2/10 | LOW (1.2) |
+
+**Overall Risk Profile**: MODERATE (acceptable with active risk management)
+
+### Top Risk Mitigation Strategies
+
+#### RISK-2: Supernode Performance Degradation (CRITICAL)
+
+**Description**: Actor vertex (Claude) accumulates thousands of `CREATED_BY` edges, causing O(n) traversal performance degradation.
+
+**Mitigations**:
+1. **Temporal Partitioning**: Use time-based edge labels (`CREATED_BY_2026_01` not generic `CREATED_BY`)
+2. **Hierarchical Decomposition**: Create intermediate nodes (`Actor:Claude:Session:2026-01-08`)
+3. **Edge Count Validator**: Alerts at 100 edges (warning), 1000 edges (error)
+4. **Constitutional Enforcement**: P-031 (Supernode Prevention) requires mitigation strategy
+5. **Quantitative Testing**: Synthetic test with 10,000 tasks to verify effectiveness
+
+**Contingency**: If degradation detected, refactor Actor vertex to hierarchical model retroactively (1 week effort).
+
+#### RISK-1: Knowledge Corpus Growth (CRITICAL)
+
+**Description**: Knowledge graph exceeds NetworkX capacity (<10K nodes) or FAISS performance limits (search >2s).
+
+**Mitigations**:
+1. **Proactive Monitoring**: Dashboard alerts at 80% capacity (4K nodes, 1s search)
+2. **Port/Adapter Pattern**: Migration paths defined (NetworkX -> igraph, FAISS -> Qdrant)
+3. **Incremental Optimization**: Try index tuning before full migration
+4. **Predefined Migration Scripts**: Test migration with synthetic data
+
+**Contingency**: Evaluate igraph (C-based, 10x faster) or Qdrant. Budget 2-4 weeks.
+
+#### RISK-6: Over-Engineering (MODERATE)
+
+**Description**: Building Phase 3-4 capabilities Jerry never uses.
+
+**Mitigations**:
+1. **Phase Gates**: Explicit go/no-go criteria before Phase 3
+2. **YAGNI Discipline**: Only build features with proven need
+3. **Quarterly ROI Review**: Measure time saved vs. maintenance burden
+4. **Constitutional Gate**: P-032 prevents premature advancement
+5. **User Authority**: Phase 3 requires explicit approval (P-020)
+
+**Contingency**: Maintain Phase 2, defer Phase 3 indefinitely if no demand.
+
+---
+
+## Compliance
+
+### Jerry Constitution Alignment
+
+| Principle | ID | Compliance Status | Implementation |
+|-----------|-----|-------------------|----------------|
+| Truth and Accuracy | P-001 | REINFORCED | Grounding verification, Jerry URI citations |
+| File Persistence | P-002 | REINFORCED | Filesystem remains source of truth |
+| No Recursive Subagents | P-003 | COMPLIANT | ReAct uses tools, not nested agents |
+| User Authority | P-020 | COMPLIANT | Phase gates require user approval |
+| No Deception | P-022 | REINFORCED | Always cite sources, expose uncertainty |
+
+### New Constitutional Principles (WORK-031 Proposals)
+
+**P-030: Schema Evolution Governance (Hard Principle)**
+
+> All graph schema changes MUST:
+> 1. Be documented in schema changelog
+> 2. Include forward migration script
+> 3. Include rollback migration script
+> 4. Pass validation tests before deployment
+>
+> Rationale: Schema changes affect traversal semantics and query assumptions.
+
+**P-031: Supernode Prevention (Medium Principle)**
+
+> Vertices SHOULD be validated for edge degree:
+> - Warning threshold: 100 edges of same label
+> - Error threshold: 1000 edges of same label
+> - HIGH-risk vertices (Actor) require mitigation strategy
+>
+> Rationale: Supernodes degrade performance catastrophically.
+
+**P-032: Phase Gate Compliance (Medium Principle)**
+
+> Phase transitions MUST meet explicit go/no-go criteria. Proceed to Phase N+1 ONLY if:
+> 1. All Phase N success criteria met
+> 2. User validation confirms value delivered
+> 3. No unresolved critical risks
+>
+> Rationale: Prevents premature optimization and scope creep.
+
+### Hexagonal Architecture Compliance
+
+The unified design maintains strict hexagonal architecture:
+
+1. **Domain Layer** (Zero Dependencies):
+   - Entities: KnowledgeItem, Pattern, Lesson, Assumption
+   - Ports: IKnowledgeRepository, ISemanticIndex, IGraphStore, IRDFSerializer
+   - Pure business logic, Python stdlib only
+
+2. **Application Layer** (Depends on Domain):
+   - Commands: CaptureKnowledge, ValidateKnowledge, DeprecateKnowledge
+   - Queries: SearchKnowledge, GetRelatedKnowledge, TraverseKnowledgeGraph
+   - CQRS pattern, orchestrates ports
+
+3. **Infrastructure Layer** (Implements Ports):
+   - Adapters: NetworkXAdapter, FAISSAdapter, RDFLibAdapter, FileSystemAdapter
+   - External libraries isolated here (NetworkX, FAISS, RDFLib)
+   - Swappable implementations via ports
+
+4. **Interface Layer** (Invokes Application):
+   - CLI: `jerry knowledge graph/search`
+   - Skills: knowledge-search skill
+   - Agents: ps-*, qa-*, etc.
+
+---
+
+## Success Metrics
+
+### Quantitative Metrics (Measured Quarterly)
+
+| Metric | Phase 2 Target (Q2 2026) | Phase 3 Target (Q4 2026) | Phase 4 Trigger |
+|--------|--------------------------|--------------------------|-----------------|
+| Knowledge Graph Size | 500+ nodes | 1,000+ nodes | > 8M nodes |
+| Query Performance (P95) | < 50ms | < 50ms | > 500ms |
+| Vector Search (P95) | < 2s | < 2s | > 5s |
+| AAR/A3 Adoption | 50% work items | 70% work items | N/A |
+| docs/ Coverage | 80% indexed | 90% indexed | N/A |
+| Contributor Onboarding | < 4 hours | < 4 hours | N/A |
+
+### Qualitative Metrics (User/Agent Feedback)
+
+| Metric | Phase 2 | Phase 3 | Measurement |
+|--------|---------|---------|-------------|
+| Agent Reasoning | Measurable via RAG | Measurable via GraphRAG | Baseline vs RAG comparison |
+| Faster Discovery | User reports | User reports | Surveys |
+| Knowledge Reuse | "Lessons Applied" reports | SECI tracking | Query logs |
+| Reduced Duplicate Work | 15-25% | 20-30% | Time tracking |
+
+### ROI Tracking
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Time Saved Finding Info | 10-20% | Baseline vs post-KM time tracking |
+| Reduced Duplicate Work | 15-25% | "What exists?" query logs |
+| Implementation Cost | 150 hours | Time tracking |
+| Maintenance Cost (5yr) | 200 hours | Quarterly assessment |
+| Value Created (5yr) | 1,000 hours saved | Extrapolated from metrics |
+| **Net ROI** | **186%** | (1000-350)/350 |
+
+---
+
+## References
+
+### Primary Input Documents
+
+1. **Integration Analysis** (WORK-033 e-001): `docs/research/work-033-e-001-integration-analysis.md`
+   - 72KB, 95% compatibility analysis, 5-layer integration model
+   - Unified 8-week Phase 2 roadmap
+
+2. **Unified Design** (WORK-033 e-002): `docs/design/work-033-e-002-unified-design.md`
+   - 64KB, full domain model, ports, use cases, events
+   - 5 Mermaid diagrams, KnowledgeItem aggregate root
+
+3. **Trade-off Analysis** (WORK-033 e-003): `docs/analysis/work-033-e-003-design-trade-offs.md`
+   - 66KB, SWOT analysis, decision matrix, risk register
+   - Phased Implementation winner (4.6/5, 92%)
+
+4. **ADR-031**: `docs/decisions/ADR-031-knowledge-architecture.md`
+   - Hybrid Property + RDF Architecture (22/25, 88%)
+   - Four-phase maturity roadmap
+
+5. **ADR-032**: `docs/decisions/ADR-032-km-integration.md`
+   - Lightweight KM Stack (8.5/10, 85%)
+   - NetworkX + FAISS + RDFLib recommendation
+
+### Research Foundation (via Synthesis)
+
+- **WORK-031 Research**: 358KB across 5 documents, 71+ citations
+- **WORK-032 Research**: KM fundamentals, protocols, products, Python SDKs, frameworks
+- **Key Finding**: Modern KM = Filesystem + Graph + AI (unanimous)
+
+### Industry Evidence
+
+| Source | Finding | Relevance |
+|--------|---------|-----------|
+| **FalkorDB** | 90% hallucination reduction with GraphRAG | LLM grounding ROI |
+| **LinkedIn** | 63% faster issue resolution (40hrs -> 15hrs) | Knowledge graph value |
+| **Amazon Finance** | 49% -> 86% accuracy with GraphRAG | Agent quality improvement |
+| **Industry Average** | 300-320% ROI from knowledge graph investments | Financial justification |
+| **Netflix UDA** | Production-proven "Model Once, Represent Everywhere" | Architectural validation |
+| **JSON-LD Adoption** | 70% web adoption (Web Data Commons 2024) | Standards maturity |
+| **Schema.org** | 45M+ websites, 803 types, 1,461 properties | Interoperability |
+
+### Technical Standards
+
+- **W3C RDF 1.2**: RDF* for edge properties without reification
+- **W3C SPARQL 1.2**: Improved query performance
+- **W3C JSON-LD 1.1**: 70% web adoption
+- **W3C SHACL**: Shapes Constraint Language for validation
+- **CloudEvents 1.0**: Event specification
+- **Tim Berners-Lee 5-Star**: Linked Open Data model (Jerry at 4 stars, targeting 5)
+
+### Jerry Documentation
+
+- **CLAUDE.md**: Framework root context
+- **Jerry Constitution**: `docs/governance/JERRY_CONSTITUTION.md`
+- **Coding Standards**: `.claude/rules/coding-standards.md`
+- **Jerry URI Scheme**: SPEC-001
+
+---
+
+## Appendices
+
+### Appendix A: Decision Matrix Details
+
+**Evaluation Criteria (Equal Weighting 20% each)**:
+
+| Criterion | Minimal | Phased | Full | Rationale |
+|-----------|---------|--------|------|-----------|
+| **Implementation Complexity** | 5 | 4 | 2 | Minimal simplest, Full has 5 serializers + SPARQL + GraphRAG |
+| **Time to Value** | 2 | 5 | 3 | Phased delivers at Week 8, Full delayed to Week 16 |
+| **Risk Level** | 3 | 5 | 2 | Phased has gates (highest reversibility), Full no checkpoints |
+| **Alignment with Jerry Goals** | 2 | 5 | 4 | Phased balances mission with pragmatism |
+| **Maintainability** | 4 | 4 | 2 | Full has most code surface area |
+
+**Weighted Scores**:
+
+| Option | Complexity | Time to Value | Risk | Alignment | Maintainability | **Total** |
+|--------|------------|---------------|------|-----------|-----------------|-----------|
+| Minimal | 1.0 | 0.4 | 0.6 | 0.4 | 0.8 | **3.2/5 (64%)** |
+| Phased | 0.8 | 1.0 | 1.0 | 1.0 | 0.8 | **4.6/5 (92%)** |
+| Full | 0.4 | 0.6 | 0.4 | 0.8 | 0.4 | **2.6/5 (52%)** |
+
+**Sensitivity Analysis**:
+- Scenario A (Speed Priority): Phased 0.90, Minimal 0.68, Full 0.50
+- Scenario B (Safety Priority): Phased 0.94, Minimal 0.62, Full 0.46
+- Scenario C (Mission Priority): Phased 0.97, Minimal 0.53, Full 0.61
+
+**Robustness**: Phased wins in ALL scenarios.
+
+### Appendix B: SWOT Analysis Summary
+
+**Strengths (8)**:
+- S1: Architectural convergence (95% compatibility, zero conflicts)
+- S2: Production-validated patterns (Netflix UDA, GraphRAG case studies)
+- S3: Hexagonal architecture fit (clean port/adapter separation)
+- S4: Backward compatibility (Phase 1 foundation unchanged)
+- S5: Multiple migration paths (NetworkX -> igraph, FAISS -> Qdrant)
+- S6: Standards compliance (W3C RDF, SPARQL, JSON-LD, Schema.org)
+- S7: Zero operational cost (embedded databases through Phase 3)
+- S8: Comprehensive research base (358KB synthesis, 71+ citations)
+
+**Weaknesses (6)**:
+- W1: Architectural complexity (5 serialization formats)
+- W2: Learning curve (RDF, SPARQL, SHACL, embeddings)
+- W3: Dependency expansion (3 required + 3 optional libraries)
+- W4: Tool capacity limits (NetworkX <10K nodes, FAISS CPU-bound)
+- W5: Multi-representation synchronization overhead
+- W6: Performance trade-offs (RDF export 10x slower than property graph)
+
+**Opportunities (6)**:
+- O1: LLM grounding ROI (90% hallucination reduction potential)
+- O2: Knowledge as competitive moat (300-320% ROI)
+- O3: Community collaboration (graph visualizations, RDF sharing)
+- O4: Progressive ISO 30401 alignment
+- O5: Future AI capabilities (multi-hop reasoning, ontology constraints)
+- O6: Measured ROI tracking ("Lessons Applied" reports)
+
+**Threats (6)**:
+- T1: Premature optimization (building features never used)
+- T2: Over-engineering vs domain features (KM > 20% dev time)
+- T3: Dependency abandonment (library deprecation)
+- T4: User adoption failure (AAR/A3 < 20% compliance)
+- T5: Corpus growth exceeds capacity (>5K nodes)
+- T6: Schema evolution breaking changes
+
+**Net SWOT Score**: +8 (Positive, with strong mitigations)
+
+### Appendix C: Glossary
+
+| Term | Definition |
+|------|------------|
+| **AAR** | After-Action Review - lightweight knowledge capture protocol (3 questions, <5 min) |
+| **A3** | Toyota problem-solving methodology using A3-sized paper |
+| **CQRS** | Command Query Responsibility Segregation - separate read/write models |
+| **FAISS** | Facebook AI Similarity Search - vector similarity library |
+| **GraphRAG** | Graph-enhanced Retrieval Augmented Generation for LLM grounding |
+| **HybridRAG** | Combined vector + graph retrieval approach |
+| **JSON-LD** | JSON for Linked Data - W3C standard for semantic JSON |
+| **KM** | Knowledge Management |
+| **NetworkX** | Python library for graph data structures and algorithms |
+| **Netflix UDA** | Unified Data Architecture - "Model Once, Represent Everywhere" pattern |
+| **OWL** | Web Ontology Language for ontology definition |
+| **Port** | Interface defined in domain layer (hexagonal architecture) |
+| **Adapter** | Implementation of port in infrastructure layer |
+| **RDF** | Resource Description Framework - W3C standard for semantic data |
+| **RDFLib** | Python library for RDF processing |
+| **SECI** | Socialization-Externalization-Combination-Internalization knowledge spiral |
+| **SHACL** | Shapes Constraint Language for RDF validation |
+| **SPARQL** | Query language for RDF databases |
+| **Supernode** | Graph vertex with high edge count causing performance degradation |
+| **Turtle** | Human-readable RDF serialization format |
+
+---
+
+## Changelog
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-09 | ps-architect v2.0.0 | Initial comprehensive ADR created from WORK-033 synthesis |
+
+---
+
+**Document Status**: PROPOSED
+
+**File**: `docs/decisions/ADR-033-unified-km-architecture.md`
+
+**Last Updated**: 2026-01-09
+
+**Agent**: ps-architect v2.0.0
+
+**Word Count**: ~8,500 words
+
+**Constitution Compliance**:
+- P-001 (Truth and Accuracy): All claims cited to input documents
+- P-002 (File Persistence): Decision persisted to markdown file
+- P-004 (Reasoning Transparency): Decision rationale documented at multiple levels
+
+**Next Steps**:
+1. ps-validator review for correctness and completeness
+2. User approval or feedback
+3. If approved: Begin Phase 2 implementation (Week 1-2)
+4. If rejected: Document rationale, consider alternatives

--- a/docs/archive/projects-archive/decisions/ADR-034-unified-wt-km-implementation.md
+++ b/docs/archive/projects-archive/decisions/ADR-034-unified-wt-km-implementation.md
@@ -1,0 +1,1614 @@
+# ADR-034: Unified Work Tracker and Knowledge Management Implementation
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Status** | PROPOSED |
+| **Date** | 2026-01-09 |
+| **Deciders** | Jerry Framework Team |
+| **Technical Area** | Domain Architecture |
+| **Related ADRs** | ADR-033 (Unified KM Architecture) |
+| **Entry ID** | e-005 |
+| **PS ID** | work-034 |
+| **Input Documents** | e-001 (Domain Analysis), e-002 (Domain Synthesis), e-003 (Unified Design), e-004 (Trade-off Analysis) |
+
+---
+
+## Executive Summary
+
+This Architecture Decision Record formalizes the technical implementation strategy for unifying the Work Tracker and Knowledge Management (KM) bounded contexts within the Jerry Framework. The decision synthesizes comprehensive domain analysis (93KB), synthesis (54KB), unified design (87KB), and trade-off analysis (39KB) from WORK-034.
+
+**Key Architectural Decisions:**
+
+1. **Hexagonal Architecture** with strict port/adapter separation (Score: 8.4/10)
+2. **Work Tracker First** implementation sequence for risk mitigation (Score: 8.65/10)
+3. **Hybrid CQRS** pattern for command/query separation (Score: 7.8/10)
+4. **Technology Stack**: NetworkX (8.5/10), FAISS (8.1/10), RDFLib (8.3/10), SQLite (9.0/10)
+5. **Four-Phase Implementation** over 32 weeks with explicit go/no-go gates
+
+**Expected Outcomes:**
+- Persistent task state across Claude Code sessions
+- Automated knowledge capture from completed work
+- Semantic search across patterns, lessons, and assumptions
+- 186% projected ROI over 5 years
+- 4x faster issue discovery by validating KM infrastructure at Work Tracker scale
+
+---
+
+## 1. Context
+
+### 1.1 Problem Statement
+
+Jerry is a framework for behavior and workflow guardrails designed to help solve problems while accruing knowledge, wisdom, and experience. Two critical challenges impede this mission:
+
+**Context Rot**: LLM performance degrades as the context window fills, even when total token count is within technical limits (Chroma Research, 2024). Claude Code agents lose task context during session compaction, preventing resumption of complex multi-session work.
+
+**Knowledge Fragmentation**: Knowledge accumulates across Work Tracker entities (Tasks, Phases, Plans) AND documentation (`docs/` hierarchy), but these exist as isolated silos without semantic connections. Agents cannot answer "what relates to X?" without manual cross-referencing.
+
+### 1.2 Current State
+
+Jerry operates at a foundational level with:
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON formats)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker conceptual model (documented but unimplemented)
+- CloudEvents integration for event interoperability
+
+### 1.3 Strategic Need
+
+The framework requires:
+1. **Persistent Work Tracking**: External memory for task state across sessions
+2. **Knowledge Capture**: Systematic recording of lessons, patterns, and assumptions
+3. **Semantic Discovery**: Finding related knowledge through meaning, not just keywords
+4. **LLM Grounding**: Reducing hallucinations through graph-enhanced retrieval (GraphRAG)
+
+### 1.4 Key Constraints
+
+| Constraint | Source | Requirement |
+|------------|--------|-------------|
+| P-002 (File Persistence) | Jerry Constitution | Filesystem remains source of truth |
+| P-003 (No Recursive Subagents) | Jerry Constitution | Maximum one level of agent nesting |
+| Zero-Dependency Domain | Hexagonal Architecture | Domain layer uses Python stdlib only |
+| Local-First | Privacy/Cost | No required cloud services through Phase 3 |
+| Backward Compatibility | Phase 1 Foundation | Existing property graph foundation unchanged |
+
+---
+
+## 2. Decision
+
+We adopt a **Work Tracker First** implementation strategy using **Hexagonal Architecture** with **Hybrid CQRS** pattern, implemented across four phases over 32 weeks. The technology stack comprises **NetworkX** (graph), **FAISS** (vectors), **RDFLib** (RDF), and **SQLite** (persistence).
+
+### 2.1 Architectural Pattern: Hexagonal Architecture
+
+The unified system follows strict Hexagonal Architecture (Ports & Adapters):
+
+```
+interface/     -> application/, infrastructure/, domain/
+application/   -> domain/ ONLY
+infrastructure/-> domain/, application/
+domain/        -> NOTHING (stdlib only)
+```
+
+**Domain Layer (Zero Dependencies):**
+- Entities: Task, Phase, Plan, KnowledgeItem
+- Value Objects: TaskId, PhaseId, KnowledgeId, Status, Priority, Pattern, Lesson, Assumption
+- Ports: IWorkItemRepository, IKnowledgeRepository, IGraphStore, ISemanticIndex, IEventStore, IRDFSerializer
+
+**Application Layer:**
+- Commands: CreateTask, CompleteTask, CaptureKnowledge, ValidateAssumption
+- Queries: GetTask, ListTasks, SearchKnowledge, GetRelatedKnowledge
+- Cross-domain handlers: MaterializeLesson, DiscoverPattern
+
+**Infrastructure Layer:**
+- SQLiteWorkItemRepository, SQLiteKnowledgeRepository
+- NetworkXGraphStore, FAISSSemanticIndex
+- RDFLibSerializer, SQLiteEventStore
+
+### 2.2 Implementation Sequence: Work Tracker First
+
+Work Tracker serves as the proving ground for KM infrastructure:
+
+| Phase | Duration | Focus | KM Benefit |
+|-------|----------|-------|------------|
+| Phase 1 | Weeks 1-8 | WT entities, repos, CQRS | Validates patterns |
+| Phase 2 | Weeks 9-16 | Shared infrastructure | NetworkX, FAISS proven at small scale |
+| Phase 3 | Weeks 17-24 | KM core | Uses validated infrastructure |
+| Phase 4 | Weeks 25-32 | Integration | Cross-domain features |
+
+### 2.3 Technology Stack
+
+| Component | Technology | Version | Purpose |
+|-----------|------------|---------|---------|
+| Graph Operations | NetworkX | 3.2.1 | Property graph traversal |
+| Vector Search | FAISS | 1.7.4 | Semantic similarity |
+| RDF Serialization | RDFLib | 7.0.0 | Knowledge export |
+| Persistence | SQLite | 3.x | Entity and event storage |
+| Runtime | Python | 3.11+ | Zero-dependency core |
+
+### 2.4 Cross-Domain Integration
+
+Work Tracker entities naturally materialize into KM entities:
+
+| Work Tracker | KM Entity | Relationship | Trigger |
+|--------------|-----------|--------------|---------|
+| Task completion | Lesson | LEARNED_FROM | AAR prompt on completion |
+| Phase completion | Pattern | EMERGED_PATTERN | Pattern analysis of tasks |
+| Plan creation | Assumption | DEPENDS_ON_ASSUMPTION | Assumption extraction |
+| Task execution | Pattern | APPLIED_PATTERN | User records pattern usage |
+
+---
+
+## 3. Rationale
+
+### 3.1 Why Hexagonal Architecture over Layered Architecture
+
+**Trade-off Analysis Score**: Hexagonal 8.4/10 vs. Layered 7.0/10 (+20%)
+
+| Criterion | Hexagonal | Layered | Delta |
+|-----------|-----------|---------|-------|
+| Initial Complexity | High | Medium | +30-40% |
+| Adapter Swapping | Trivial | Significant | -50-70% effort |
+| Testability | Excellent | Good | +40% coverage ease |
+| Domain Isolation | Complete | Partial | +100% isolation |
+| Domain test coverage achievable | 95%+ | 70-80% | +25% |
+| Time to swap SQLite for Postgres | 2 hours | 2-3 days | -95% |
+
+**Decision Driver**: Jerry's requirement for zero-dependency domain layer makes Hexagonal Architecture essential. The initial complexity cost is a one-time investment; maintainability and testability benefits compound over the project lifetime.
+
+### 3.2 Why Work Tracker First over Parallel Development
+
+**Trade-off Analysis Score**: WT First 8.65/10 vs. KM First 6.05/10 vs. Parallel 5.70/10
+
+| Risk Factor | WT First | KM First | Parallel |
+|-------------|----------|----------|----------|
+| Time to discover infrastructure issues | 2 weeks | 8 weeks | 4 weeks |
+| Cost to fix (LOC changed) | ~200 | ~2,000 | ~1,000 |
+| Users impacted by bugs | 1 (developer) | Many (agents) | Split |
+| Team context switching | None | None | High |
+
+**Decision Driver**: The 8-week delayed KM delivery is justified by 4x faster issue discovery and 10x smaller fix costs. Work Tracker's smaller scale (~500 nodes) provides a safer proving ground than KM's target (~5,000+ nodes).
+
+### 3.3 Why NetworkX over Neo4j
+
+**Trade-off Analysis Score**: NetworkX 8.5/10 vs. Neo4j 7.05/10 vs. DGraph 6.35/10
+
+| Factor | NetworkX | Neo4j | DGraph |
+|--------|----------|-------|--------|
+| Startup time | <100ms | 5-10s | 10-30s |
+| Memory (5.5K nodes) | ~15MB | ~200MB | ~500MB |
+| 2-hop traversal | <10ms | <5ms | <5ms |
+| Installation | pip install | Server required | Docker required |
+| Claude Code compatibility | Excellent | Requires setup | Requires setup |
+
+**Decision Driver**: NetworkX provides zero deployment overhead, sufficient performance for 5-50K nodes, and Python-native integration. Neo4j/DGraph introduce unnecessary complexity for Jerry's scale. Migration path to igraph available if needed.
+
+### 3.4 Why FAISS over Pinecone/ChromaDB
+
+**Trade-off Analysis Score**: FAISS 8.1/10 vs. ChromaDB 7.7/10 vs. Pinecone 7.25/10
+
+| Metric | FAISS (Flat) | Pinecone | ChromaDB |
+|--------|--------------|----------|----------|
+| Search latency (k=10, 5K vectors) | <50ms | 50-100ms (network) | <30ms |
+| Annual cost | $0 | $840+ (Standard) | $0 |
+| Offline operation | Full | None | Full |
+| Index build (5K vectors) | <1s | N/A | <2s |
+
+**Decision Driver**: FAISS provides zero network latency, exact search at Jerry's scale (no approximation needed), and Claude Code offline compatibility. IndexFlatL2 sufficient for <10K vectors; migration to IndexIVFFlat if scaling needed.
+
+### 3.5 Why SQLite over PostgreSQL
+
+**Trade-off Analysis Score**: SQLite 9.0/10 vs. DuckDB 8.25/10 vs. PostgreSQL 6.35/10
+
+| Aspect | SQLite | PostgreSQL | DuckDB |
+|--------|--------|------------|--------|
+| Setup | None | Server install | None |
+| Backup | File copy | pg_dump | File copy |
+| Claude Code integration | Trivial | Requires credentials | Trivial |
+| Concurrent writes | Single writer | Multi-writer | Poor |
+
+**Decision Driver**: SQLite provides zero deployment overhead, is built into Python stdlib, and is sufficient for single-writer workload. Jerry's use case (single Claude Code session) doesn't require PostgreSQL's concurrency capabilities.
+
+### 3.6 Why Hybrid CQRS over Pure CRUD
+
+**Trade-off Analysis Score**: Hybrid 7.8/10 vs. CQRS 7.45/10 vs. CRUD 7.25/10
+
+**Full CQRS for:**
+- Task state transitions (events required for KM integration)
+- Knowledge capture (audit trail essential)
+- Cross-domain operations (MaterializeLesson, ApplyPattern)
+
+**Simplified patterns for:**
+- Simple reads (direct repository queries)
+- Tag/note additions (minimal event value)
+
+**Decision Driver**: Events are essential for cross-domain integration (WorkItemCompleted triggers CaptureKnowledge), but full CQRS for all operations adds unnecessary complexity.
+
+---
+
+## 4. Consequences
+
+### 4.1 Positive Consequences
+
+**Immediate Benefits (Phase 1-2, Weeks 1-16):**
+- Task persistence across Claude Code sessions
+- Event-sourced audit trail for all work items
+- Graph-based task hierarchy visualization
+- Semantic search for finding similar tasks
+
+**Medium-Term Benefits (Phase 3, Weeks 17-24):**
+- Automated lesson capture from completed tasks via AAR prompts
+- Pattern discovery from completed phases
+- Assumption tracking in plans with validation workflow
+- Cross-domain queries (find tasks that applied a pattern)
+
+**Long-Term Benefits (Phase 4+):**
+- GraphRAG for LLM grounding (90% hallucination reduction potential)
+- Jerry URI citations in agent responses
+- SPARQL endpoint for external integration
+- Knowledge as competitive moat (300-320% industry ROI)
+
+**Quantified Benefits:**
+
+| Benefit | Year 1 | Year 2 | Year 3 |
+|---------|--------|--------|--------|
+| Time saved finding knowledge | 100 hrs | 300 hrs | 600 hrs |
+| Reduced context rot impact | 50 hrs | 150 hrs | 300 hrs |
+| Pattern reuse value | 20 hrs | 100 hrs | 250 hrs |
+| **Total hours saved** | 170 hrs | 550 hrs | 1,150 hrs |
+| **Value @ $100/hr** | $17,000 | $55,000 | $115,000 |
+
+### 4.2 Negative Consequences
+
+**Accepted Trade-offs:**
+
+| Trade-off | Impact | Mitigation |
+|-----------|--------|------------|
+| Dependency expansion | NetworkX, RDFLib, FAISS in infrastructure | Hexagonal architecture isolates impact |
+| Learning curve | Graph concepts, RDF, embeddings | Documentation, <16 hours onboarding |
+| Architectural complexity | Multiple serialization formats | Netflix UDA pattern, round-trip tests |
+| Performance limits | NetworkX <10K nodes, FAISS CPU-bound | 2-year runway; migration paths defined |
+| Delayed KM delivery | 8 weeks later than parallel approach | Early WT value compensates |
+
+### 4.3 Risks
+
+**Risk Register (from Trade-off Analysis):**
+
+| Risk ID | Description | Probability | Impact | Expected Value | Mitigation |
+|---------|-------------|-------------|--------|----------------|------------|
+| R-001 | Performance degradation at scale | 40% | High ($20K) | $8,000 | Validate at WT scale first |
+| R-002 | Supernode formation | 60% | Medium ($10K) | $6,000 | Edge count validator, alert at 100 |
+| R-003 | User AAR adoption low | 70% | Medium ($8K) | $5,600 | Threshold-based prompts, defer option |
+| R-004 | Event store scaling issues | 20% | High ($15K) | $3,000 | Event partitioning design |
+| R-005 | Schema evolution breaks | 35% | High ($12K) | $4,200 | Migration practice on WT |
+| **Total Expected Risk Cost** | | | | **$26,800** | |
+
+**Mitigation Investment**: $7,300 reduces expected risk to $8,000 (70% reduction).
+
+**Critical Risk Mitigations:**
+
+**R-002 Supernode Prevention:**
+- Temporal partitioning: `CREATED_BY_2026_01` not generic `CREATED_BY`
+- Hierarchical decomposition: `Actor:Claude:Session:2026-01-08`
+- Edge count validator: Warning at 100 edges, error at 1000
+- Constitutional enforcement: P-031 requires mitigation strategy
+
+**R-003 User Adoption:**
+- Threshold-based AAR: Only prompt if `effort_hours > 2`
+- Defer option: "Capture later" with session-end batch
+- Monitor capture rate weekly; pivot to automated if <20% after 4 weeks
+
+---
+
+## 5. Implementation Plan
+
+### 5.1 Phase 1: Work Tracker Foundation (Weeks 1-8)
+
+**Goal**: Establish Work Tracker core with shared infrastructure patterns.
+
+#### Week 1-2: Domain Entities
+
+**Deliverables:**
+- `src/domain/aggregates/task.py` - Task aggregate root
+- `src/domain/aggregates/phase.py` - Phase aggregate root
+- `src/domain/aggregates/plan.py` - Plan aggregate root
+- `src/domain/value_objects/ids.py` - VertexId, TaskId, PhaseId, PlanId
+- `src/domain/value_objects/status.py` - TaskStatus, PhaseStatus, PlanStatus
+- `src/domain/value_objects/priority.py` - Priority enum
+- `src/domain/events/work_tracker.py` - TaskCreated, TaskCompleted, etc.
+
+**Acceptance Criteria:**
+- [ ] All value objects are immutable (frozen dataclasses)
+- [ ] State machine enforces valid status transitions
+- [ ] Domain entities have zero external imports
+- [ ] Entity invariants tested with property-based tests
+
+#### Week 3-4: Repository Layer
+
+**Deliverables:**
+- `src/domain/ports/repositories.py` - IWorkItemRepository protocol
+- `src/domain/ports/event_store.py` - IEventStore protocol
+- `src/infrastructure/persistence/sqlite/work_item_repository.py`
+- `src/infrastructure/persistence/sqlite/event_store.py`
+- `src/infrastructure/persistence/sqlite/migrations/001_initial.sql`
+
+**Acceptance Criteria:**
+- [ ] Repositories implement port interfaces exactly
+- [ ] SQLite schema supports all entity attributes
+- [ ] Event store is append-only
+- [ ] Optimistic concurrency control via version field
+
+#### Week 5-6: CQRS Handlers
+
+**Deliverables:**
+- `src/application/commands/work_tracker/` - All WT commands
+- `src/application/queries/work_tracker/` - All WT queries
+- `src/application/handlers/commands/` - Command handlers
+- `src/application/handlers/queries/` - Query handlers
+- `src/domain/ports/cqrs.py` - ICommandHandler, IQueryHandler protocols
+
+**Acceptance Criteria:**
+- [ ] Commands return domain events
+- [ ] Queries return DTOs (never domain entities)
+- [ ] Handlers use dependency injection for repositories
+- [ ] All handlers have unit tests with mock repositories
+
+#### Week 7-8: CLI and Integration
+
+**Deliverables:**
+- `src/interface/cli/work_tracker.py` - CLI commands
+- `skills/worktracker/SKILL.md` - Natural language interface
+- `tests/bdd/work_tracker/` - BDD scenarios
+- `tests/integration/` - End-to-end tests
+
+**Acceptance Criteria:**
+- [ ] CLI supports: create, list, get, complete, block, unblock
+- [ ] BDD scenarios cover all use cases from UC-001, UC-002
+- [ ] Integration tests verify full stack
+- [ ] Performance: <50ms P95 for all operations
+
+**Phase 1 Exit Criteria:**
+- [ ] 100% of Work Tracker BDD scenarios passing
+- [ ] Domain layer has 95%+ test coverage
+- [ ] ~500 LOC domain, ~800 LOC infrastructure
+- [ ] Event sourcing operational
+
+### 5.2 Phase 2: Shared Infrastructure (Weeks 9-16)
+
+**Goal**: Add graph and search infrastructure using Work Tracker as validation.
+
+#### Week 9-10: NetworkX Graph Adapter
+
+**Deliverables:**
+- `src/domain/ports/graph_store.py` - IGraphStore protocol
+- `src/infrastructure/graph/networkx_store.py` - NetworkXGraphStore adapter
+- Graph vertex creation on task/phase/plan creation
+- Graph edge creation for PART_OF relationships
+
+**Acceptance Criteria:**
+- [ ] IGraphStore protocol matches design specification
+- [ ] All WT entities appear as graph vertices
+- [ ] Task->Phase->Plan hierarchy traversable
+- [ ] Traversal queries complete in <10ms for 500 nodes
+
+#### Week 11-12: RDFLib Serialization
+
+**Deliverables:**
+- `src/domain/ports/rdf_serializer.py` - IRDFSerializer protocol
+- `src/infrastructure/rdf/rdflib_serializer.py` - RDFLibSerializer adapter
+- `schemas/worktracker.ttl` - SHACL shapes for validation
+- `contexts/worktracker.jsonld` - JSON-LD context
+
+**Acceptance Criteria:**
+- [ ] WorkItems serializable to Turtle and JSON-LD
+- [ ] Round-trip tests: JSON -> Turtle -> JSON (100% success)
+- [ ] SHACL validation passes for all entities
+- [ ] RDF export <100ms P95
+
+#### Week 13-14: FAISS Semantic Search
+
+**Deliverables:**
+- `src/domain/ports/semantic_index.py` - ISemanticIndex protocol
+- `src/infrastructure/search/faiss_index.py` - FAISSSemanticIndex adapter
+- Embedding generation for task titles and descriptions
+- Search query handlers
+
+**Acceptance Criteria:**
+- [ ] IndexFlatL2 configured for 1536 dimensions
+- [ ] Search returns top-k results with similarity scores
+- [ ] Search latency <50ms for 500 vectors
+- [ ] Index persistence to disk
+
+#### Week 15-16: Performance Baselines
+
+**Deliverables:**
+- `tests/performance/` - Performance benchmark suite
+- `docs/design/PERFORMANCE_BASELINES.md` - Baseline documentation
+- Supernode validator implementation
+- Dashboard alerts configuration
+
+**Acceptance Criteria:**
+- [ ] All performance targets met (see table below)
+- [ ] Supernode validator alerts at 100 edges
+- [ ] Monitoring dashboards operational
+
+**Performance Targets:**
+
+| Operation | Target P95 | Measured |
+|-----------|------------|----------|
+| Graph traversal (2-hop) | <10ms | |
+| Semantic search (k=5) | <50ms | |
+| Entity CRUD | <20ms | |
+| RDF export (100 entities) | <100ms | |
+
+**Phase 2 Exit Criteria (Go/No-Go Gate):**
+- [ ] All Phase 1 tests still passing (100%)
+- [ ] Hot path performance P95 < 50ms
+- [ ] Cold path (RDF export) P95 < 100ms
+- [ ] Supernode prevention working
+- [ ] Performance baselines documented
+
+### 5.3 Phase 3: KM Integration (Weeks 17-24)
+
+**Goal**: Implement KM entities using validated infrastructure.
+
+#### Week 17-18: KM Entities
+
+**Deliverables:**
+- `src/domain/aggregates/knowledge_item.py` - KnowledgeItem aggregate
+- `src/domain/value_objects/knowledge_types.py` - KnowledgeType, KnowledgeStatus
+- `src/domain/value_objects/pattern.py` - Pattern value object
+- `src/domain/value_objects/lesson.py` - Lesson value object
+- `src/domain/value_objects/assumption.py` - Assumption value object
+- `src/domain/events/knowledge.py` - KM domain events
+
+**Acceptance Criteria:**
+- [ ] KnowledgeItemId discriminates type (PAT/LES/ASM prefix)
+- [ ] Content is discriminated union (Pattern | Lesson | Assumption)
+- [ ] Lifecycle state machine enforced (DRAFT -> VALIDATED -> DEPRECATED)
+- [ ] All value objects serializable to markdown
+
+#### Week 19-20: KM Repository and Graph
+
+**Deliverables:**
+- `src/domain/ports/knowledge_repository.py` - IKnowledgeRepository protocol
+- `src/infrastructure/persistence/sqlite/knowledge_repository.py`
+- Graph vertex creation for KM entities
+- Cross-domain edges (LEARNED_FROM, APPLIED_PATTERN, etc.)
+
+**Acceptance Criteria:**
+- [ ] KM entities stored in separate SQLite database
+- [ ] Graph edges connect WT and KM entities
+- [ ] Bidirectional traversal working (Task->Lesson, Lesson->Task)
+- [ ] find_related() traverses up to max_depth
+
+#### Week 21-22: KM CQRS Handlers
+
+**Deliverables:**
+- `src/application/commands/knowledge/` - All KM commands
+- `src/application/queries/knowledge/` - All KM queries
+- CaptureKnowledgeHandler, ValidateKnowledgeHandler
+- SearchKnowledgeHandler, GetRelatedKnowledgeHandler
+
+**Acceptance Criteria:**
+- [ ] CaptureKnowledge creates correct entity type
+- [ ] SearchKnowledge uses FAISS for semantic ranking
+- [ ] GetRelatedKnowledge traverses graph
+- [ ] All handlers have unit tests
+
+#### Week 23-24: KM CLI and Skill
+
+**Deliverables:**
+- `src/interface/cli/knowledge.py` - KM CLI commands
+- `skills/knowledge/SKILL.md` - Natural language interface
+- `tests/bdd/knowledge/` - BDD scenarios
+- Integration tests for KM
+
+**Acceptance Criteria:**
+- [ ] CLI supports: capture, list, search, related, validate
+- [ ] Skill supports natural language knowledge queries
+- [ ] BDD scenarios cover UC-003, UC-005
+- [ ] KM search integrated with WT search
+
+**Phase 3 Exit Criteria:**
+- [ ] CRUD for all knowledge types working
+- [ ] Semantic search returns relevant results
+- [ ] Graph relationships functional
+- [ ] 100% BDD scenarios passing
+
+### 5.4 Phase 4: Advanced Features (Weeks 25-32)
+
+**Goal**: Full cross-domain integration and advanced capabilities.
+
+#### Week 25-26: Cross-Domain Event Handlers
+
+**Deliverables:**
+- `src/application/event_handlers/aar_prompt_handler.py`
+- `src/application/event_handlers/pattern_detection_handler.py`
+- `src/application/event_handlers/assumption_validation_handler.py`
+- AAR prompt template and workflow
+
+**Acceptance Criteria:**
+- [ ] TaskCompleted triggers AAR prompt (if effort > 2 hours)
+- [ ] PhaseCompleted triggers pattern analysis
+- [ ] User can defer AAR to session end
+- [ ] Lesson automatically linked to source task
+
+#### Week 27-28: Enriched Queries
+
+**Deliverables:**
+- `src/application/queries/enriched/get_enriched_work_item.py`
+- `src/application/queries/enriched/search_with_context.py`
+- EnrichedWorkItemDTO with related knowledge
+- Unified search across WT and KM
+
+**Acceptance Criteria:**
+- [ ] GetEnrichedWorkItem returns task + patterns + lessons + assumptions
+- [ ] Search results include both tasks and knowledge
+- [ ] Response latency <100ms for enriched queries
+- [ ] Graph context (related items) included in results
+
+#### Week 29-30: HybridRAG Foundation
+
+**Deliverables:**
+- `src/application/queries/hybrid_rag.py`
+- Combined vector + graph retrieval
+- Context builder for LLM grounding
+- Jerry URI citation formatter
+
+**Acceptance Criteria:**
+- [ ] HybridRAG retrieves by semantic similarity AND graph proximity
+- [ ] Results ranked by combined score
+- [ ] Citations use Jerry URI format
+- [ ] Context fits within token limits
+
+#### Week 31-32: SPARQL and Advanced Export
+
+**Deliverables:**
+- `src/infrastructure/rdf/pyoxigraph_adapter.py` (optional)
+- SPARQL query endpoint
+- Full graph export in multiple formats
+- API documentation
+
+**Acceptance Criteria:**
+- [ ] SPARQL SELECT queries execute correctly
+- [ ] Export supports Turtle, JSON-LD, N-Triples
+- [ ] Performance documentation complete
+- [ ] User documentation for all features
+
+**Phase 4 Exit Criteria:**
+- [ ] AAR workflow complete and tested
+- [ ] Pattern discovery suggests candidates
+- [ ] Enriched queries operational
+- [ ] HybridRAG demonstrable
+
+---
+
+## 6. Technical Specifications
+
+### 6.1 Domain Model Summary
+
+**Aggregate Roots:**
+
+| Aggregate | Context | Identity Pattern | Key Invariants |
+|-----------|---------|------------------|----------------|
+| Task | Work Tracker | WORK-NNN | Status transitions valid, title required |
+| Phase | Work Tracker | PHASE-NNN | Cannot complete with pending tasks |
+| Plan | Work Tracker | PLAN-NNN | Cannot complete with pending phases |
+| KnowledgeItem | KM | PAT/LES/ASM-NNN | Content matches type, lifecycle valid |
+
+**Value Objects:**
+
+| Value Object | Domain | Invariants |
+|--------------|--------|------------|
+| VertexId | Shared | Immutable, hashable |
+| TaskId | WT | Pattern `^WORK-[0-9]+$` |
+| KnowledgeId | KM | Prefix matches KnowledgeType |
+| Status | WT | Valid transitions only |
+| Priority | Shared | Enum: LOW, NORMAL, HIGH, CRITICAL |
+| Pattern | KM | Problem, solution, context required |
+| Lesson | KM | Situation, action, result required |
+| Assumption | KM | Statement, impact_if_wrong required |
+| JerryUri | Shared | SPEC-001 compliant |
+| CloudEventEnvelope | Shared | CloudEvents 1.0 compliant |
+
+### 6.2 Port Definitions Summary
+
+**Persistence Ports:**
+
+| Port | Methods | Adapter |
+|------|---------|---------|
+| IWorkItemRepository | get_task, save_task, list_tasks, get_phase, save_phase, get_plan, save_plan | SQLiteWorkItemRepository |
+| IKnowledgeRepository | get, save, delete, list_by_type, list_by_tags, get_by_source | SQLiteKnowledgeRepository |
+| IEventStore | append, get, get_by_subject, get_by_type, replay, save_snapshot | SQLiteEventStore |
+
+**Graph Port:**
+
+| Port | Methods | Adapter |
+|------|---------|---------|
+| IGraphStore | add_vertex, get_vertex, add_edge, get_edges, traverse, traverse_incoming, shortest_path, query_vertices | NetworkXGraphStore |
+
+**Search Port:**
+
+| Port | Methods | Adapter |
+|------|---------|---------|
+| ISemanticIndex | add, update, remove, search, search_by_text, get_embedding, rebuild | FAISSSemanticIndex |
+
+**Serialization Port:**
+
+| Port | Methods | Adapter |
+|------|---------|---------|
+| IRDFSerializer | add_triple, add_entity, serialize, query, clear | RDFLibSerializer |
+
+**CQRS Ports:**
+
+| Port | Type | Purpose |
+|------|------|---------|
+| ICommandHandler[C, R] | Primary | Execute commands, emit events |
+| IQueryHandler[Q, R] | Primary | Execute queries, return DTOs |
+| IEventDispatcher | Primary | Route events to handlers |
+
+### 6.3 CQRS Operations Summary
+
+**Work Tracker Commands (16):**
+- CreateTaskCommand, UpdateTaskCommand, DeleteTaskCommand
+- TransitionTaskCommand, CompleteTaskCommand
+- AssignTaskToPhaseCommand, AddTaskTagCommand
+- CreatePhaseCommand, CompletePhaseCommand, ReorderPhasesCommand
+- CreatePlanCommand, ActivatePlanCommand, CompletePlanCommand, ArchivePlanCommand
+- TrackAssumptionCommand
+
+**Work Tracker Queries (10):**
+- GetTaskQuery, ListTasksQuery, SearchTasksQuery, GetTaskHistoryQuery
+- GetPhaseQuery, ListPhasesQuery, GetPhaseProgressQuery
+- GetPlanQuery, ListPlansQuery, GetPlanProgressQuery
+
+**KM Commands (11):**
+- CreatePatternCommand, UpdatePatternCommand
+- CreateLessonCommand, UpdateLessonCommand
+- CreateAssumptionCommand, ValidateAssumptionCommand
+- AddEvidenceCommand, AddKnowledgeTagCommand, DeleteKnowledgeCommand
+- LinkKnowledgeCommand, ApplyPatternCommand
+
+**KM Queries (8):**
+- GetKnowledgeQuery, ListPatternsQuery, ListLessonsQuery, ListAssumptionsQuery
+- SearchKnowledgeQuery, GetRelatedKnowledgeQuery
+- GetPatternApplicationsQuery, GetKnowledgeHistoryQuery, ExportKnowledgeQuery
+
+**Cross-Domain Commands (4):**
+- MaterializeLessonCommand, DiscoverPatternCommand
+- RecordPatternUsageCommand, ValidateAssumptionFromTaskCommand
+
+### 6.4 Event Types
+
+**Work Tracker Events (CloudEvents type: `work-tracker/{EventName}`):**
+
+| Event | Subject | Key Data |
+|-------|---------|----------|
+| TaskCreated | jer:jer:work-tracker:task:WORK-NNN | task_id, title, status, priority |
+| TaskUpdated | jer:jer:work-tracker:task:WORK-NNN | task_id, field, old_value, new_value |
+| TaskStatusChanged | jer:jer:work-tracker:task:WORK-NNN | task_id, previous_status, new_status |
+| TaskCompleted | jer:jer:work-tracker:task:WORK-NNN | task_id, completion_notes, duration_hours |
+| TaskAssigned | jer:jer:work-tracker:task:WORK-NNN | task_id, phase_id |
+| PhaseCreated | jer:jer:work-tracker:phase:PHASE-NNN | phase_id, name, plan_id |
+| PhaseCompleted | jer:jer:work-tracker:phase:PHASE-NNN | phase_id, task_count |
+| PlanCreated | jer:jer:work-tracker:plan:PLAN-NNN | plan_id, name |
+| PlanActivated | jer:jer:work-tracker:plan:PLAN-NNN | plan_id |
+| PlanCompleted | jer:jer:work-tracker:plan:PLAN-NNN | plan_id, phase_count |
+
+**KM Events (CloudEvents type: `knowledge/{EventName}`):**
+
+| Event | Subject | Key Data |
+|-------|---------|----------|
+| PatternCreated | jer:jer:knowledge:pat:PAT-NNN | pattern_id, title, problem |
+| LessonCreated | jer:jer:knowledge:les:LES-NNN | lesson_id, title, source_task_id |
+| AssumptionCreated | jer:jer:knowledge:asm:ASM-NNN | assumption_id, title, statement |
+| KnowledgeValidated | jer:jer:knowledge:{type}:{id} | knowledge_id, validated_by |
+| KnowledgeDeprecated | jer:jer:knowledge:{type}:{id} | knowledge_id, reason |
+| PatternApplied | jer:jer:knowledge:pat:PAT-NNN | pattern_id, task_id, outcome |
+| LessonMaterialized | jer:jer:knowledge:les:LES-NNN | lesson_id, source_task_id, aar_response |
+| PatternDiscovered | jer:jer:knowledge:pat:PAT-NNN | pattern_id, source_phase_id, confidence |
+
+---
+
+## 7. Validation Criteria
+
+### 7.1 Acceptance Tests
+
+**Phase 1 (Work Tracker):**
+- [ ] Create task via CLI returns valid TaskId
+- [ ] Task status transitions follow state machine
+- [ ] Completed tasks emit TaskCompleted event
+- [ ] Events are persisted and replayable
+- [ ] Task hierarchy (Task->Phase->Plan) queryable
+
+**Phase 2 (Infrastructure):**
+- [ ] Graph vertices created for all entities
+- [ ] Graph traversal returns correct related entities
+- [ ] Semantic search returns relevant results (>0.8 similarity for exact matches)
+- [ ] RDF export validates against SHACL shapes
+- [ ] Round-trip serialization is lossless
+
+**Phase 3 (KM):**
+- [ ] Create pattern/lesson/assumption via CLI
+- [ ] Search knowledge by semantic similarity
+- [ ] Get related knowledge via graph traversal
+- [ ] Validate and deprecate workflow functions
+
+**Phase 4 (Integration):**
+- [ ] Task completion prompts for AAR (effort > 2h)
+- [ ] AAR response creates linked Lesson
+- [ ] Phase completion triggers pattern analysis
+- [ ] Enriched work item includes related knowledge
+- [ ] HybridRAG retrieves by both similarity and graph
+
+### 7.2 Performance Requirements
+
+| Operation | P95 Latency | Threshold |
+|-----------|-------------|-----------|
+| Entity CRUD | <20ms | Hard |
+| Graph traversal (depth 2) | <10ms | Hard |
+| Semantic search (k=5) | <50ms | Hard |
+| RDF export (100 entities) | <100ms | Soft |
+| Enriched query | <100ms | Soft |
+| HybridRAG retrieval | <200ms | Soft |
+
+### 7.3 Quality Gates
+
+| Gate | Metric | Target |
+|------|--------|--------|
+| Domain test coverage | Line coverage | >95% |
+| Integration test coverage | Path coverage | >80% |
+| BDD scenario pass rate | Scenarios passing | 100% |
+| Code complexity | Cyclomatic complexity | <10 per function |
+| Documentation | Public function docstrings | 100% |
+| Type hints | Functions with type hints | 100% |
+
+---
+
+## 8. Alternatives Considered
+
+### 8.1 Alternative: Layered Architecture
+
+**Description**: Traditional layered architecture with presentation, business logic, data access layers.
+
+**Why Rejected**:
+- Domain coupled to infrastructure details
+- Testing requires database/external mocks
+- Technology changes ripple through layers
+- Decision matrix score: 7.0/10 vs. Hexagonal 8.4/10
+
+**Trade-off Analysis Reference**: Section 2.1
+
+### 8.2 Alternative: KM First Implementation
+
+**Description**: Implement Knowledge Management before Work Tracker.
+
+**Why Rejected**:
+- Discover issues at 5K nodes vs. 500 nodes
+- 100x fix cost vs. 10x fix cost
+- Late Work Tracker availability delays operational benefits
+- Decision matrix score: 6.05/10 vs. WT First 8.65/10
+
+**Trade-off Analysis Reference**: Section 2.2
+
+### 8.3 Alternative: Parallel Development
+
+**Description**: Implement Work Tracker and KM simultaneously with separate teams.
+
+**Why Rejected**:
+- Duplicated infrastructure
+- Divergent patterns requiring reconciliation
+- High context switching
+- Decision matrix score: 5.70/10 vs. WT First 8.65/10
+
+**Trade-off Analysis Reference**: Section 2.2
+
+### 8.4 Alternative: Neo4j for Graph Storage
+
+**Description**: Use Neo4j enterprise graph database instead of NetworkX.
+
+**Why Rejected**:
+- Server process required
+- 200MB+ memory vs. 15MB
+- 5-10s startup vs. <100ms
+- Overkill for Jerry's scale (<50K nodes Year 3)
+- Decision matrix score: 7.05/10 vs. NetworkX 8.5/10
+
+**Trade-off Analysis Reference**: Section 3.1
+
+### 8.5 Alternative: Pinecone for Vector Search
+
+**Description**: Use Pinecone managed vector database instead of FAISS.
+
+**Why Rejected**:
+- Cloud-only (no offline operation)
+- Network latency (50-100ms vs. <50ms)
+- Recurring cost ($840+/year)
+- Decision matrix score: 7.25/10 vs. FAISS 8.1/10
+
+**Trade-off Analysis Reference**: Section 3.2
+
+### 8.6 Alternative: PostgreSQL for Persistence
+
+**Description**: Use PostgreSQL server instead of SQLite.
+
+**Why Rejected**:
+- Server installation required
+- Credential management complexity
+- Overkill for single-writer workload
+- Decision matrix score: 6.35/10 vs. SQLite 9.0/10
+
+**Trade-off Analysis Reference**: Section 3.4
+
+---
+
+## 9. References
+
+### 9.1 Input Documents
+
+| Document | Size | Location |
+|----------|------|----------|
+| Domain Analysis | 93KB | `docs/research/work-034-e-001-domain-analysis.md` |
+| Domain Synthesis | 54KB | `docs/synthesis/work-034-e-002-domain-synthesis.md` |
+| Unified Design | 87KB | `docs/design/work-034-e-003-unified-design.md` |
+| Trade-off Analysis | 39KB | `docs/analysis/work-034-e-004-tradeoff-analysis.md` |
+| ADR-033 | 44KB | `docs/decisions/ADR-033-unified-km-architecture.md` |
+
+### 9.2 External References
+
+| Reference | Author | Relevance |
+|-----------|--------|-----------|
+| Hexagonal Architecture | Alistair Cockburn (2005) | Core architectural pattern |
+| Domain-Driven Design | Eric Evans (2003) | Bounded contexts, aggregates |
+| CQRS Pattern | Cosmic Python | Command/query separation |
+| CloudEvents 1.0 | CNCF | Event interoperability |
+| Context Rot Research | Chroma (2024) | Problem statement |
+| Netflix UDA | Tech Blog | Multi-representation pattern |
+| FalkorDB GraphRAG | Case Study | 90% hallucination reduction |
+| LinkedIn KG ROI | Case Study | 63% faster resolution |
+
+### 9.3 Jerry Documentation
+
+| Document | Location |
+|----------|----------|
+| Framework Root Context | `CLAUDE.md` |
+| Jerry Constitution | `docs/governance/JERRY_CONSTITUTION.md` |
+| Coding Standards | `.claude/rules/coding-standards.md` |
+| Work Tracker Plan | `docs/plans/WORK_TRACKER_PLAN.md` |
+
+---
+
+## Appendices
+
+### Appendix A: Decision Matrix Summary
+
+| Decision | Option A | Score | Option B | Score | Winner | Margin |
+|----------|----------|-------|----------|-------|--------|--------|
+| Architecture | Hexagonal | 8.4 | Layered | 7.0 | Hexagonal | +20% |
+| Sequence | WT First | 8.65 | KM First | 6.05 | WT First | +43% |
+| CQRS | Hybrid | 7.8 | Pure CRUD | 7.25 | Hybrid | +8% |
+| Graph DB | NetworkX | 8.5 | Neo4j | 7.05 | NetworkX | +21% |
+| Vector Search | FAISS | 8.1 | Pinecone | 7.25 | FAISS | +12% |
+| Database | SQLite | 9.0 | PostgreSQL | 6.35 | SQLite | +42% |
+| RDF Library | RDFLib | 8.3 | Apache Jena | 5.35 | RDFLib | +55% |
+
+**Weighting Factors:**
+- Performance: 25%
+- Maintainability: 20%
+- Testability: 20%
+- Complexity: 15%
+- Dependencies: 10%
+- Risk: 10%
+
+### Appendix B: Risk Register Summary
+
+| Risk | Prob | Impact | Expected | Mitigation Cost | Residual |
+|------|------|--------|----------|-----------------|----------|
+| R-001: Performance degradation | 40% | $20K | $8,000 | $2,000 | $2,000 |
+| R-002: Supernode formation | 60% | $10K | $6,000 | $500 | $1,500 |
+| R-003: Low AAR adoption | 70% | $8K | $5,600 | $1,000 | $2,000 |
+| R-004: Event store scaling | 20% | $15K | $3,000 | $1,500 | $500 |
+| R-005: Schema evolution | 35% | $12K | $4,200 | $1,000 | $1,000 |
+| **Total** | | | **$26,800** | **$6,000** | **$7,000** |
+
+**Net ROI after mitigation**: 114% over 3 years (vs. 186% without risk)
+
+### Appendix C: Open Questions
+
+**Requiring Resolution During Implementation:**
+
+1. **Embedding Model Choice**: text-embedding-3-small (1536d) vs. text-embedding-3-large (3072d)?
+   - Trade-off: Quality vs. storage/latency
+   - Recommendation: Start with small, evaluate quality
+
+2. **Event Retention Policy**: Forever (audit) vs. N days (storage)?
+   - Trade-off: Compliance vs. storage growth
+   - Recommendation: Keep all, compress after 90 days
+
+3. **Graph Persistence Strategy**: On every change vs. periodic?
+   - Trade-off: Durability vs. performance
+   - Recommendation: On change with debounce (5s)
+
+4. **Cross-Domain Transaction Handling**: What if Lesson save fails after Task complete?
+   - Trade-off: Consistency vs. complexity
+   - Recommendation: Eventually consistent with retry queue
+
+5. **AAR Skip Tracking**: Log skipped prompts for follow-up?
+   - Trade-off: Completeness vs. noise
+   - Recommendation: Yes, surface at session end
+
+6. **Pattern Confidence Decay**: Decrease if unused for N months?
+   - Trade-off: Relevance vs. data loss
+   - Recommendation: No decay, mark as "stale" instead
+
+**Assumptions Requiring Validation:**
+
+| Assumption | Validation Method | Risk if Wrong |
+|------------|-------------------|---------------|
+| ~15MB RAM for graph acceptable | Benchmark test | Performance degradation |
+| 60%+ AAR completion rate | Usage metrics | KM value diminished |
+| 5,500 nodes Year 1 realistic | Historical tracking | Scale planning wrong |
+| NetworkX <10ms at 5K nodes | Performance test | Need alternative |
+| FAISS works offline | Integration test | Need alternative |
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | `docs/decisions/ADR-034-unified-wt-km-implementation.md` |
+| **Created** | 2026-01-09 |
+| **Author** | ps-architect v2.0.0 |
+| **Word Count** | ~8,500 words |
+| **Tables** | 75+ |
+| **Status** | PROPOSED |
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): All claims traced to input documents with scores
+- P-002 (File Persistence): Decision persisted to markdown file
+- P-004 (Reasoning Transparency): Rationale documented for all decisions
+- P-010 (Task Tracking): Supports WORK-034 Step 5
+
+**Next Steps:**
+1. Review ADR with stakeholders
+2. If approved: Transition status to ACCEPTED
+3. Begin Phase 1 implementation (Week 1-2: Domain Entities)
+4. Create implementation work items from deliverables
+
+---
+
+## Appendix D: Detailed Data Schemas
+
+### D.1 SQLite Schema - Work Tracker
+
+```sql
+-- Work Tracker Database Schema
+-- File: ~/.jerry/data/work_tracker.db
+
+-- Tasks table
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'PENDING',
+    priority TEXT NOT NULL DEFAULT 'NORMAL',
+    phase_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (phase_id) REFERENCES phases(id),
+    CHECK (status IN ('PENDING', 'IN_PROGRESS', 'BLOCKED', 'COMPLETED', 'CANCELLED')),
+    CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'CRITICAL'))
+);
+
+CREATE INDEX idx_tasks_status ON tasks(status);
+CREATE INDEX idx_tasks_phase_id ON tasks(phase_id);
+CREATE INDEX idx_tasks_created_at ON tasks(created_at);
+
+-- Task tags junction table
+CREATE TABLE IF NOT EXISTS task_tags (
+    task_id TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    category TEXT,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (task_id, tag),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_task_tags_tag ON task_tags(tag);
+
+-- Task metadata (JSON key-value)
+CREATE TABLE IF NOT EXISTS task_metadata (
+    task_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (task_id, key),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+-- Phases table
+CREATE TABLE IF NOT EXISTS phases (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'PENDING',
+    plan_id TEXT,
+    phase_order INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    FOREIGN KEY (plan_id) REFERENCES plans(id),
+    CHECK (status IN ('PENDING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'))
+);
+
+CREATE INDEX idx_phases_status ON phases(status);
+CREATE INDEX idx_phases_plan_id ON phases(plan_id);
+
+-- Plans table
+CREATE TABLE IF NOT EXISTS plans (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'DRAFT',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    CHECK (status IN ('DRAFT', 'ACTIVE', 'COMPLETED', 'ARCHIVED'))
+);
+
+CREATE INDEX idx_plans_status ON plans(status);
+
+-- Plan assumptions junction table
+CREATE TABLE IF NOT EXISTS plan_assumptions (
+    plan_id TEXT NOT NULL,
+    assumption_id TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'UNTESTED',
+    validated_at TEXT,
+    PRIMARY KEY (plan_id, assumption_id),
+    FOREIGN KEY (plan_id) REFERENCES plans(id) ON DELETE CASCADE,
+    CHECK (status IN ('UNTESTED', 'VALIDATED', 'INVALIDATED'))
+);
+```
+
+### D.2 SQLite Schema - Knowledge Management
+
+```sql
+-- Knowledge Management Database Schema
+-- File: ~/.jerry/data/knowledge.db
+
+-- Knowledge items table
+CREATE TABLE IF NOT EXISTS knowledge_items (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    summary TEXT,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    source_uri TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    CHECK (type IN ('PATTERN', 'LESSON', 'ASSUMPTION')),
+    CHECK (confidence >= 0.0 AND confidence <= 1.0)
+);
+
+CREATE INDEX idx_knowledge_type ON knowledge_items(type);
+CREATE INDEX idx_knowledge_created_at ON knowledge_items(created_at);
+CREATE INDEX idx_knowledge_source_uri ON knowledge_items(source_uri);
+
+-- Pattern-specific attributes
+CREATE TABLE IF NOT EXISTS patterns (
+    knowledge_id TEXT PRIMARY KEY,
+    problem TEXT NOT NULL,
+    solution TEXT NOT NULL,
+    context TEXT NOT NULL,
+    consequences TEXT NOT NULL,
+    forces TEXT, -- JSON array
+    alternatives TEXT, -- JSON array
+    application_count INTEGER NOT NULL DEFAULT 0,
+    success_rate REAL NOT NULL DEFAULT 0.0,
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge_items(id) ON DELETE CASCADE
+);
+
+-- Lesson-specific attributes
+CREATE TABLE IF NOT EXISTS lessons (
+    knowledge_id TEXT PRIMARY KEY,
+    situation TEXT NOT NULL,
+    action TEXT NOT NULL,
+    result TEXT NOT NULL,
+    reflection TEXT NOT NULL,
+    source_task_id TEXT,
+    applicability TEXT,
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge_items(id) ON DELETE CASCADE
+);
+
+-- Assumption-specific attributes
+CREATE TABLE IF NOT EXISTS assumptions (
+    knowledge_id TEXT PRIMARY KEY,
+    statement TEXT NOT NULL,
+    rationale TEXT NOT NULL,
+    risk_if_wrong TEXT NOT NULL,
+    validation_criteria TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'UNTESTED',
+    validated_at TEXT,
+    validated_by TEXT,
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge_items(id) ON DELETE CASCADE,
+    CHECK (status IN ('UNTESTED', 'VALIDATED', 'INVALIDATED'))
+);
+
+-- Evidence table
+CREATE TABLE IF NOT EXISTS evidence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    knowledge_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    source_uri TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    description TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge_items(id) ON DELETE CASCADE,
+    CHECK (type IN ('TASK_COMPLETION', 'USER_FEEDBACK', 'PATTERN_MATCH', 'EXPERT_VALIDATION', 'AUTOMATED_TEST')),
+    CHECK (confidence >= 0.0 AND confidence <= 1.0)
+);
+
+CREATE INDEX idx_evidence_knowledge_id ON evidence(knowledge_id);
+CREATE INDEX idx_evidence_type ON evidence(type);
+
+-- Knowledge tags junction table
+CREATE TABLE IF NOT EXISTS knowledge_tags (
+    knowledge_id TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    category TEXT,
+    PRIMARY KEY (knowledge_id, tag),
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_knowledge_tags_tag ON knowledge_tags(tag);
+
+-- Knowledge relationships
+CREATE TABLE IF NOT EXISTS knowledge_relations (
+    from_id TEXT NOT NULL,
+    to_id TEXT NOT NULL,
+    relationship TEXT NOT NULL,
+    properties TEXT, -- JSON object
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (from_id, to_id, relationship),
+    FOREIGN KEY (from_id) REFERENCES knowledge_items(id) ON DELETE CASCADE,
+    FOREIGN KEY (to_id) REFERENCES knowledge_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_relations_to_id ON knowledge_relations(to_id);
+CREATE INDEX idx_relations_relationship ON knowledge_relations(relationship);
+```
+
+### D.3 SQLite Schema - Event Store
+
+```sql
+-- Event Store Database Schema
+-- File: ~/.jerry/data/events.db
+
+-- Events table (append-only)
+CREATE TABLE IF NOT EXISTS events (
+    id TEXT PRIMARY KEY,
+    sequence INTEGER NOT NULL UNIQUE,
+    specversion TEXT NOT NULL DEFAULT '1.0',
+    type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    time TEXT NOT NULL,
+    datacontenttype TEXT NOT NULL DEFAULT 'application/json',
+    data TEXT NOT NULL
+);
+
+CREATE INDEX idx_events_sequence ON events(sequence);
+CREATE INDEX idx_events_type ON events(type);
+CREATE INDEX idx_events_subject ON events(subject);
+CREATE INDEX idx_events_time ON events(time);
+
+-- Snapshots table
+CREATE TABLE IF NOT EXISTS snapshots (
+    subject TEXT PRIMARY KEY,
+    data TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+-- Event sequence counter
+CREATE TABLE IF NOT EXISTS event_sequence (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    last_sequence INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT OR IGNORE INTO event_sequence (id, last_sequence) VALUES (1, 0);
+```
+
+### D.4 Directory Structure
+
+```
+~/.jerry/                               # User data directory
+├── data/
+│   ├── work_tracker.db                 # SQLite: Work Tracker entities
+│   ├── knowledge.db                    # SQLite: KM entities
+│   └── events.db                       # SQLite: Event store (append-only)
+├── graph/
+│   ├── unified_graph.gpickle           # NetworkX: Property graph
+│   └── unified_graph.json              # NetworkX: JSON backup
+├── search/
+│   ├── semantic.index                  # FAISS: Vector index
+│   ├── semantic.mapping                # ID -> embedding mapping
+│   └── embeddings.cache                # Cached embedding vectors
+├── export/
+│   ├── knowledge.ttl                   # RDFLib: Turtle export
+│   ├── knowledge.jsonld                # RDFLib: JSON-LD export
+│   └── knowledge.nq                    # RDFLib: N-Quads export
+├── schemas/
+│   ├── worktracker.shacl.ttl           # SHACL validation shapes
+│   ├── knowledge.shacl.ttl             # SHACL validation shapes
+│   └── events.schema.json              # JSON Schema for events
+└── config/
+    ├── jerry.yaml                      # Main configuration
+    └── adapters.yaml                   # Adapter configuration
+```
+
+### D.5 Configuration Schema
+
+```yaml
+# ~/.jerry/config/jerry.yaml
+version: "1.0"
+
+# Work Tracker configuration
+work_tracker:
+  enabled: true
+  database: "${JERRY_HOME}/data/work_tracker.db"
+  default_priority: "NORMAL"
+  auto_start_on_creation: false
+
+# Knowledge Management configuration
+knowledge:
+  enabled: true
+  database: "${JERRY_HOME}/data/knowledge.db"
+  aar_threshold_hours: 2.0
+  aar_defer_enabled: true
+  pattern_detection:
+    enabled: true
+    min_tasks_in_phase: 3
+    similarity_threshold: 0.8
+
+# Event Store configuration
+events:
+  database: "${JERRY_HOME}/data/events.db"
+  retention_days: null  # null = forever
+  snapshot_interval: 100  # events before snapshot
+
+# Graph Store configuration
+graph:
+  adapter: "networkx"
+  path: "${JERRY_HOME}/graph/unified_graph.gpickle"
+  auto_save: true
+  save_debounce_seconds: 5
+  supernode_warning_threshold: 100
+  supernode_error_threshold: 1000
+
+# Semantic Index configuration
+search:
+  adapter: "faiss"
+  path: "${JERRY_HOME}/search/semantic.index"
+  dimension: 1536
+  embedding_model: "text-embedding-3-small"
+  cache_embeddings: true
+  rebuild_interval_hours: 24
+
+# RDF Export configuration
+rdf:
+  adapter: "rdflib"
+  default_format: "turtle"
+  export_path: "${JERRY_HOME}/export"
+  base_uri: "https://jerry.framework/"
+  namespaces:
+    jerry: "https://jerry.framework/ontology/"
+    wt: "https://jerry.framework/work-tracker/"
+    km: "https://jerry.framework/knowledge/"
+
+# Performance tuning
+performance:
+  query_timeout_ms: 5000
+  graph_traversal_max_depth: 5
+  search_max_results: 100
+  batch_size: 50
+
+# Logging configuration
+logging:
+  level: "INFO"
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  file: "${JERRY_HOME}/logs/jerry.log"
+```
+
+---
+
+## Appendix E: Sequence Diagram - Full Task Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI
+    participant CTH as CreateTaskHandler
+    participant TR as TaskRepository
+    participant GS as GraphStore
+    participant ES as EventStore
+    participant ED as EventDispatcher
+    participant STH as StartTaskHandler
+    participant CTH2 as CompleteTaskHandler
+    participant AAR as AARHandler
+    participant MLH as MaterializeLessonHandler
+    participant KR as KnowledgeRepository
+    participant SI as SemanticIndex
+
+    Note over U,SI: Phase 1: Task Creation
+    U->>CLI: create task "Implement feature X"
+    CLI->>CTH: CreateTaskCommand
+    CTH->>CTH: Generate WORK-042
+    CTH->>TR: save(task)
+    CTH->>GS: add_vertex(WORK-042, "Task")
+    CTH->>ES: append(TaskCreated)
+    CTH->>ED: dispatch(TaskCreated)
+    CTH-->>CLI: TaskId(WORK-042)
+    CLI-->>U: Created WORK-042
+
+    Note over U,SI: Phase 2: Task Start
+    U->>CLI: start WORK-042
+    CLI->>STH: StartTaskCommand(WORK-042)
+    STH->>TR: get(WORK-042)
+    STH->>STH: Validate transition
+    STH->>STH: task.start()
+    STH->>TR: save(task)
+    STH->>ES: append(TaskStarted)
+    STH-->>CLI: success
+    CLI-->>U: Started WORK-042
+
+    Note over U,SI: Phase 3: Task Completion with AAR
+    U->>CLI: complete WORK-042 --notes "Feature works"
+    CLI->>CTH2: CompleteTaskCommand(WORK-042)
+    CTH2->>TR: get(WORK-042)
+    CTH2->>CTH2: Validate IN_PROGRESS -> COMPLETED
+    CTH2->>CTH2: task.complete()
+    CTH2->>TR: save(task)
+    CTH2->>GS: update_vertex(WORK-042, {status: COMPLETED})
+    CTH2->>ES: append(TaskCompleted)
+    CTH2->>ED: dispatch(TaskCompleted)
+    ED->>AAR: handle(TaskCompleted)
+
+    Note over AAR,SI: AAR Workflow
+    AAR->>AAR: Check effort > threshold
+    AAR->>U: Prompt for AAR
+    U-->>AAR: AARResponse{situation, action, result, reflection}
+    AAR->>MLH: MaterializeLessonCommand
+    MLH->>MLH: Create Lesson from AAR
+    MLH->>KR: save(lesson)
+    MLH->>GS: add_vertex(LES-042, "Lesson")
+    MLH->>GS: add_edge(WORK-042, LES-042, "LEARNED_FROM")
+    MLH->>SI: add(LES-042, embedding)
+    MLH->>ES: append(LessonMaterialized)
+    MLH->>ED: dispatch(LessonMaterialized)
+    MLH-->>AAR: LES-042
+
+    AAR-->>ED: complete
+    CTH2-->>CLI: success
+    CLI-->>U: Completed WORK-042, created LES-042
+```
+
+---
+
+## Appendix F: Graph Relationship Matrix
+
+### F.1 Work Tracker Internal Relationships
+
+| From Entity | Edge Label | To Entity | Cardinality | Description |
+|-------------|------------|-----------|-------------|-------------|
+| Task | PART_OF | Phase | N:1 | Task belongs to phase |
+| Task | BLOCKS | Task | N:M | Task blocks another task |
+| Task | DEPENDS_ON | Task | N:M | Task depends on another |
+| Task | SUBTASK_OF | Task | N:1 | Subtask hierarchy |
+| Phase | PART_OF | Plan | N:1 | Phase belongs to plan |
+| Phase | FOLLOWS | Phase | 1:1 | Phase ordering |
+
+### F.2 KM Internal Relationships
+
+| From Entity | Edge Label | To Entity | Cardinality | Description |
+|-------------|------------|-----------|-------------|-------------|
+| Pattern | RELATED_TO | Pattern | N:M | Related patterns |
+| Pattern | SUPERSEDES | Pattern | N:1 | Version replacement |
+| Lesson | APPLIES_TO | Pattern | N:M | Lesson supports pattern |
+| Lesson | RELATED_TO | Lesson | N:M | Related lessons |
+| Assumption | CONTRADICTS | Assumption | N:M | Conflicting assumptions |
+| Assumption | SUPPORTS | Assumption | N:M | Supporting assumptions |
+| KnowledgeItem | EVIDENCED_BY | Evidence | 1:N | Supporting evidence |
+
+### F.3 Cross-Domain Relationships
+
+| From (WT) | Edge Label | To (KM) | Cardinality | Trigger |
+|-----------|------------|---------|-------------|---------|
+| Task | LEARNED_FROM | Lesson | 1:N | AAR completion |
+| Task | APPLIED_PATTERN | Pattern | N:M | User records usage |
+| Task | VALIDATED_ASSUMPTION | Assumption | N:M | Task result validates |
+| Phase | EMERGED_PATTERN | Pattern | 1:N | Pattern discovery |
+| Phase | CONSOLIDATED_LESSONS | Lesson | 1:N | Phase completion |
+| Plan | DEPENDS_ON_ASSUMPTION | Assumption | N:M | Plan creation |
+| Plan | BASED_ON_PATTERN | Pattern | N:M | Plan design |
+
+### F.4 Edge Property Schema
+
+```python
+# Standard edge properties
+EDGE_PROPERTIES = {
+    "LEARNED_FROM": {
+        "created_at": str,  # ISO datetime
+        "created_by": str,  # Jerry URI of actor
+        "aar_id": str,      # Reference to AAR response
+    },
+    "APPLIED_PATTERN": {
+        "applied_at": str,
+        "applied_by": str,
+        "outcome": str | None,  # success/failure/partial
+        "notes": str | None,
+    },
+    "VALIDATED_ASSUMPTION": {
+        "validated_at": str,
+        "validated_by": str,
+        "validation_result": str,  # validated/invalidated
+        "confidence_delta": float,
+        "evidence_summary": str,
+    },
+    "EMERGED_PATTERN": {
+        "discovered_at": str,
+        "discovery_method": str,  # manual/automated
+        "confidence_score": float,
+        "source_task_count": int,
+    },
+}
+```
+
+---
+
+## Appendix G: Performance Benchmarks
+
+### G.1 Baseline Targets
+
+| Operation | Target P50 | Target P95 | Target P99 | Max |
+|-----------|------------|------------|------------|-----|
+| Task CRUD | 5ms | 20ms | 50ms | 100ms |
+| Phase CRUD | 5ms | 20ms | 50ms | 100ms |
+| Plan CRUD | 10ms | 30ms | 75ms | 150ms |
+| Knowledge CRUD | 10ms | 30ms | 75ms | 150ms |
+| Graph vertex add | 1ms | 5ms | 10ms | 20ms |
+| Graph edge add | 1ms | 5ms | 10ms | 20ms |
+| Graph traversal (d=2) | 2ms | 10ms | 25ms | 50ms |
+| Semantic search (k=5) | 10ms | 50ms | 100ms | 200ms |
+| Semantic search (k=20) | 20ms | 75ms | 150ms | 300ms |
+| RDF export (100 entities) | 20ms | 100ms | 200ms | 500ms |
+| Event append | 1ms | 5ms | 10ms | 20ms |
+| Event replay (100) | 10ms | 50ms | 100ms | 200ms |
+
+### G.2 Scale Projections
+
+| Metric | Year 1 | Year 2 | Year 3 | Technology Limit |
+|--------|--------|--------|--------|------------------|
+| Graph nodes | 5,500 | 15,000 | 35,000 | ~100,000 (NetworkX) |
+| Graph edges | 16,500 | 45,000 | 105,000 | ~500,000 (NetworkX) |
+| Vector embeddings | 4,000 | 12,000 | 30,000 | Unlimited (FAISS) |
+| Events stored | 25,000 | 100,000 | 300,000 | Unlimited (SQLite) |
+| Knowledge items | 2,000 | 6,000 | 15,000 | N/A |
+| Tasks tracked | 3,000 | 8,000 | 18,000 | N/A |
+
+### G.3 Benchmark Suite
+
+```python
+# tests/performance/benchmark_suite.py
+
+import pytest
+from timeit import timeit
+
+class TestPerformanceBenchmarks:
+    """Performance benchmarks for Phase 2 validation."""
+
+    @pytest.mark.benchmark
+    def test_task_crud_p95(self, task_repository, sample_task):
+        """Task CRUD should complete under 20ms P95."""
+        times = []
+        for _ in range(100):
+            times.append(timeit(
+                lambda: task_repository.save(sample_task),
+                number=1
+            ))
+        p95 = sorted(times)[95]
+        assert p95 < 0.020, f"P95 {p95*1000:.2f}ms exceeds 20ms target"
+
+    @pytest.mark.benchmark
+    def test_graph_traversal_p95(self, graph_store, sample_graph_500):
+        """Graph traversal (depth 2) should complete under 10ms P95."""
+        times = []
+        for node_id in sample_graph_500.sample_nodes(100):
+            times.append(timeit(
+                lambda: graph_store.traverse(node_id, max_depth=2),
+                number=1
+            ))
+        p95 = sorted(times)[95]
+        assert p95 < 0.010, f"P95 {p95*1000:.2f}ms exceeds 10ms target"
+
+    @pytest.mark.benchmark
+    def test_semantic_search_p95(self, semantic_index, sample_embeddings_500):
+        """Semantic search (k=5) should complete under 50ms P95."""
+        times = []
+        for query in sample_embeddings_500.sample_queries(100):
+            times.append(timeit(
+                lambda: semantic_index.search(query, k=5),
+                number=1
+            ))
+        p95 = sorted(times)[95]
+        assert p95 < 0.050, f"P95 {p95*1000:.2f}ms exceeds 50ms target"
+```
+
+---
+
+## Appendix H: Migration Paths
+
+### H.1 NetworkX to igraph (If Scale Exceeded)
+
+**Trigger**: Graph traversal P95 > 50ms at 50,000 nodes
+
+**Migration Steps**:
+1. Create IGraphStore adapter for igraph
+2. Write graph export/import utility
+3. Run parallel operation for validation
+4. Switch adapter configuration
+5. Archive NetworkX files
+
+**Estimated Effort**: 16-24 hours
+
+### H.2 FAISS IndexFlatL2 to IndexIVFFlat (If Scale Exceeded)
+
+**Trigger**: Search P95 > 100ms at 50,000 vectors
+
+**Migration Steps**:
+1. Configure IVF parameters (nlist, nprobe)
+2. Train index on representative vectors
+3. Rebuild index with IVF structure
+4. Validate recall at 95%+ threshold
+5. Update configuration
+
+**Estimated Effort**: 8-16 hours
+
+### H.3 SQLite to PostgreSQL (If Concurrency Required)
+
+**Trigger**: Multiple concurrent writers needed
+
+**Migration Steps**:
+1. Create PostgreSQL adapter implementations
+2. Write schema migration scripts
+3. Deploy PostgreSQL server
+4. Migrate data using pg_dump/restore
+5. Update connection configuration
+6. Validate data integrity
+
+**Estimated Effort**: 40-60 hours
+
+### H.4 Local to Cloud (If Collaboration Required)
+
+**Trigger**: Multi-user collaboration needed
+
+**Migration Steps**:
+1. Deploy PostgreSQL to managed service
+2. Deploy FAISS to managed vector DB (Pinecone)
+3. Deploy Neo4j to managed service
+4. Update adapters and configuration
+5. Implement authentication/authorization
+6. Migrate data with downtime window
+
+**Estimated Effort**: 80-120 hours
+
+---
+
+*End of Architecture Decision Record*

--- a/docs/archive/projects-archive/design/work-033-e-002-unified-design.md
+++ b/docs/archive/projects-archive/design/work-033-e-002-unified-design.md
@@ -1,0 +1,2012 @@
+# Unified Knowledge Management Design for Jerry
+# WORK-033 Entry 002: Architectural Design Document
+
+**PS ID:** work-033
+**Entry ID:** e-002
+**Topic:** Unified Knowledge Management Architecture (WORK-031 + WORK-032)
+**Type:** Design Document
+**Date:** 2026-01-09
+**Agent:** ps-architect v2.0.0
+**Status:** PROPOSED
+
+---
+
+## Document Provenance
+
+This design document synthesizes and unifies:
+- **WORK-031** (ADR-031): Knowledge Architecture - Hybrid Property + RDF (22/25, 88%)
+- **WORK-032** (ADR-032): KM Integration - Lightweight Stack (8.5/10, 85%)
+- **Integration Analysis** (work-033-e-001): 95% compatibility, 5-layer model
+- **Graph Data Model Analysis**: Property Graph foundation, Netflix UDA pattern
+- **Domain Alignment**: EntityBase, VertexId, Jerry URI scheme
+
+**Key Finding:** Both decisions independently converged on identical architectural patterns, enabling seamless integration without conflicts.
+
+---
+
+# L0: Executive Summary (Plain Language)
+
+## What is Knowledge Management in Jerry?
+
+Jerry is designed to help solve problems while accumulating knowledge, wisdom, and experience. Currently, Jerry stores knowledge as markdown files in the `docs/` folder, tracked by git. This works well for small amounts of information, but as knowledge grows, it becomes harder to:
+
+- **Find related information**: "What else do we know about X?"
+- **Discover patterns**: "Has this problem been solved before?"
+- **Ground AI agents**: "What evidence supports this claim?"
+- **Track relationships**: "What depends on what?"
+
+**Knowledge Management (KM)** adds three capabilities to Jerry:
+
+1. **Graph Layer** (NetworkX): Understand relationships between concepts
+2. **Semantic Search** (FAISS): Find conceptually similar information, not just keyword matches
+3. **Standards Export** (RDFLib): Share knowledge with other systems using web standards
+
+Think of it like upgrading from a filing cabinet (files only) to a library system (files + card catalog + search).
+
+## Why Does Jerry Need This?
+
+Jerry's core mission is to **accrue knowledge while solving problems**. Without KM:
+
+- Agents repeat work because they can't find what already exists
+- Lessons learned sit unused because they're not discoverable
+- Context rot degrades LLM performance as knowledge grows
+- No way to answer "what relates to X?" without manual searching
+
+**Industry evidence** shows that knowledge graphs:
+- Reduce hallucinations by 90% (FalkorDB case study)
+- Save 10-20% of time finding information
+- Improve decision quality through better-informed choices
+
+## How Does It Work?
+
+Jerry's KM system has **three complementary layers**:
+
+```
+Layer 1: FILESYSTEM (Source of Truth)
+├─ Markdown files in docs/ (human-readable)
+├─ Git versioning (history, provenance)
+└─ Direct agent access (no database required)
+      ↓
+Layer 2: GRAPH + VECTOR (Discovery and Retrieval)
+├─ NetworkX: Relationship tracking (what connects to what)
+├─ FAISS: Semantic search (find similar concepts)
+└─ RDFLib: Standards export (share with other tools)
+      ↓
+Layer 3: AI INTEGRATION (Agent Intelligence)
+├─ HybridRAG: Combine graph traversal + semantic search
+├─ Jerry URI citations: Always show sources
+└─ Grounding verification: Check facts against knowledge
+```
+
+**Key Principle:** Filesystem remains the source of truth. Graph and vector layers are **indexes** that can be rebuilt from files at any time. No vendor lock-in, no data loss risk.
+
+## What Gets Built?
+
+Jerry will have **knowledge items** of three types:
+
+1. **Patterns (PAT)**: Reusable solutions to recurring problems
+   - Example: "Hybrid architecture prevents vendor lock-in"
+   - Contains: Context, Problem, Solution, Consequences
+
+2. **Lessons (LES)**: Experience from past work
+   - Example: "SHACL validation caught schema drift early"
+   - Contains: What happened, What learned, How to prevent recurrence
+
+3. **Assumptions (ASM)**: Beliefs that need validation
+   - Example: "Jerry will remain single-tenant through 2026"
+   - Contains: What we assume, Impact if wrong, How to validate
+
+Each knowledge item:
+- Lives as a markdown file in `docs/knowledge/`
+- Has a unique ID (PAT-001, LES-042, ASM-003)
+- Connects to other items via relationships (REFERENCES, APPLIES_TO, VALIDATES)
+- Can be searched semantically ("find lessons about database migration")
+- Exports to RDF for integration with external tools
+
+## What's the Timeline?
+
+**Phase 1 (Q1 2026, 8 weeks):**
+- Week 1-2: Foundation (ports, adapters, protocols)
+- Week 3-4: RDF serialization (export to web standards)
+- Week 5-6: Graph layer (relationship discovery)
+- Week 7-8: Vector search (semantic retrieval)
+
+**Phase 2 (Q2-Q3 2026, 12 weeks):**
+- GraphRAG integration (agent knowledge retrieval)
+- SPARQL endpoint (query language for knowledge graph)
+- Visualization (see knowledge as interactive graphs)
+
+**Phase 3 (Q4 2026+, optional):**
+- Only if needed: scale to production-grade tools
+- Triggers: >10M items, multi-tenant, clustering requirements
+
+## What Are the Risks?
+
+| Risk | Mitigation |
+|------|------------|
+| **Complexity overhead** | Ports/adapters isolate changes; can rollback to filesystem-only |
+| **Tool capacity limits** | NetworkX handles <10K nodes (sufficient for 1-2 years); migration path to igraph defined |
+| **User adoption** | Lightweight protocols (AAR = 3 questions, <5 min); show value via "Lessons Applied" reports |
+| **Over-engineering** | Strict phase gates; YAGNI discipline; quarterly ROI review |
+
+**Overall Risk:** MODERATE (same as individual decisions). Combined mitigations stronger than either alone.
+
+## Success Criteria
+
+After Phase 1 (Q1 2026), Jerry will be able to:
+- ✅ Answer "what relates to X?" via graph traversal
+- ✅ Find conceptually similar documents via semantic search
+- ✅ Export knowledge graph as RDF/Turtle (web standards)
+- ✅ Ground agent responses in retrieved knowledge with citations
+- ✅ Track knowledge reuse ("which patterns applied to new problems?")
+
+**Measurable Targets:**
+- 500+ knowledge items by Q2 2026
+- 10-20% time saved finding information
+- 15-25% reduced duplicate work
+
+---
+
+# L1: Technical Design (Software Engineer)
+
+## 1. Domain Model: Knowledge Entities
+
+### 1.1 KnowledgeItem (Aggregate Root)
+
+```python
+# src/domain/knowledge/entities/knowledge_item.py
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+from enum import Enum, auto
+
+from ...graph.primitives import Vertex, VertexId
+from ...identity import JerryUri
+from ..value_objects import Pattern, Lesson, Assumption
+
+
+class KnowledgeType(Enum):
+    """Type classification for knowledge items."""
+    PATTERN = "PAT"      # Reusable solution to recurring problem
+    LESSON = "LES"       # Experience and learning from past work
+    ASSUMPTION = "ASM"   # Belief that requires validation
+
+
+class KnowledgeStatus(Enum):
+    """Lifecycle status for knowledge items."""
+    DRAFT = auto()        # Being captured, not yet validated
+    VALIDATED = auto()    # Reviewed and confirmed as accurate
+    DEPRECATED = auto()   # No longer applicable or superseded
+
+
+@dataclass(frozen=True)
+class KnowledgeItemId(VertexId):
+    """Strongly-typed identifier for KnowledgeItem vertices."""
+
+    def __post_init__(self):
+        # Validate format: PAT-001, LES-042, ASM-003
+        if not self.value.startswith(("PAT-", "LES-", "ASM-")):
+            raise ValueError(
+                f"KnowledgeItemId must start with PAT-, LES-, or ASM-: {self.value}"
+            )
+
+    @classmethod
+    def generate(cls, km_type: KnowledgeType, sequence: int) -> "KnowledgeItemId":
+        """Generate ID from type and sequence."""
+        return cls(f"{km_type.value}-{sequence:03d}")
+
+    @property
+    def km_type(self) -> KnowledgeType:
+        """Extract knowledge type from ID."""
+        prefix = self.value.split("-")[0]
+        return KnowledgeType(prefix)
+
+
+@dataclass
+class KnowledgeItem(Vertex):
+    """
+    Aggregate root for knowledge management.
+
+    Represents a unit of knowledge captured, validated, and reused.
+    Extends Vertex for graph storage compatibility.
+
+    Design Principles:
+    - EntityBase compliance (IAuditable, IVersioned)
+    - Property Graph vertex (TinkerPop alignment)
+    - Jerry URI scheme (SPEC-001)
+    - Netflix UDA "Model Once, Represent Everywhere"
+
+    Provenance:
+    - WORK-031: Semantic web architecture
+    - WORK-032: Practical KM implementation
+    - Graph Data Model Analysis: Vertex/Edge abstractions
+    """
+
+    # Identity (VertexId base class)
+    id: KnowledgeItemId
+    uri: JerryUri = field(init=False)
+
+    # Core properties
+    title: str                          # Human-readable name (max 80 chars)
+    km_type: KnowledgeType              # PAT, LES, or ASM
+    status: KnowledgeStatus = KnowledgeStatus.DRAFT
+
+    # Type-specific content (value objects)
+    content: Pattern | Lesson | Assumption  # Discriminated union by km_type
+
+    # Context and applicability
+    context: str = ""                   # When/where this applies
+    tags: List[str] = field(default_factory=list)
+
+    # Relationships (stored as edges in graph)
+    related_items: List[KnowledgeItemId] = field(default_factory=list)
+    evidence_refs: List[str] = field(default_factory=list)  # Jerry URIs
+
+    # Audit trail (IAuditable)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_by: str = "system:km"
+    modified_at: datetime = field(default_factory=datetime.utcnow)
+    modified_by: str = "system:km"
+
+    # Versioning (IVersioned)
+    version: str = ""
+    content_hash: str = ""
+
+    # Metadata
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Initialize vertex properties."""
+        # Set vertex label based on type
+        object.__setattr__(self, "label", f"KnowledgeItem:{self.km_type.value}")
+
+        # Compute Jerry URI (SPEC-001)
+        object.__setattr__(
+            self,
+            "uri",
+            JerryUri.for_entity(
+                domain="knowledge",
+                entity_type=self.km_type.value.lower(),
+                entity_id=self.id.value,
+                version=self.content_hash[:8] if self.content_hash else None
+            )
+        )
+
+        # Populate vertex properties for graph storage
+        self.properties = {
+            "title": self.title,
+            "km_type": self.km_type.value,
+            "status": self.status.name,
+            "context": self.context,
+            "tags": self.tags,
+            "evidence_refs": self.evidence_refs,
+            "created_at": self.created_at.isoformat(),
+            "created_by": self.created_by,
+            "modified_at": self.modified_at.isoformat(),
+            "modified_by": self.modified_by,
+            "version": self.version,
+            "content_hash": self.content_hash,
+        }
+
+    def validate(self) -> None:
+        """
+        Transition from DRAFT to VALIDATED.
+
+        Emits: KnowledgeItemValidated event
+        """
+        if self.status != KnowledgeStatus.DRAFT:
+            raise ValueError(f"Cannot validate knowledge in {self.status} status")
+
+        object.__setattr__(self, "status", KnowledgeStatus.VALIDATED)
+        object.__setattr__(self, "modified_at", datetime.utcnow())
+
+    def deprecate(self, reason: str) -> None:
+        """
+        Mark knowledge as no longer applicable.
+
+        Args:
+            reason: Why this knowledge is deprecated
+
+        Emits: KnowledgeItemDeprecated event
+        """
+        object.__setattr__(self, "status", KnowledgeStatus.DEPRECATED)
+        self.metadata["deprecation_reason"] = reason
+        object.__setattr__(self, "modified_at", datetime.utcnow())
+
+    def add_evidence(self, evidence_uri: JerryUri) -> None:
+        """Link evidence to support this knowledge item."""
+        self.evidence_refs.append(str(evidence_uri))
+        object.__setattr__(self, "modified_at", datetime.utcnow())
+
+    def relate_to(self, other: KnowledgeItemId) -> None:
+        """Create relationship to another knowledge item."""
+        if other not in self.related_items:
+            self.related_items.append(other)
+            object.__setattr__(self, "modified_at", datetime.utcnow())
+```
+
+### 1.2 Value Objects (Knowledge Content)
+
+```python
+# src/domain/knowledge/value_objects/pattern.py
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """
+    Value object for Pattern knowledge (PAT).
+
+    Captures: Context, Problem, Solution, Consequences
+    Based on: Architecture Decision Record (ADR) format
+    """
+
+    context: str            # Situation where problem occurs
+    problem: str            # Challenge to be solved
+    solution: str           # Approach that addresses problem
+    consequences: str       # Trade-offs and implications
+
+    # Optional: Forces and alternatives
+    forces: List[str] = None       # Competing concerns
+    alternatives: List[str] = None  # Other options considered
+
+    def to_markdown(self) -> str:
+        """Serialize to markdown format."""
+        md = f"## Context\n\n{self.context}\n\n"
+        md += f"## Problem\n\n{self.problem}\n\n"
+        md += f"## Solution\n\n{self.solution}\n\n"
+        md += f"## Consequences\n\n{self.consequences}\n\n"
+
+        if self.forces:
+            md += f"## Forces\n\n" + "\n".join(f"- {f}" for f in self.forces) + "\n\n"
+
+        if self.alternatives:
+            md += f"## Alternatives Considered\n\n"
+            md += "\n".join(f"- {a}" for a in self.alternatives) + "\n\n"
+
+        return md
+
+
+# src/domain/knowledge/value_objects/lesson.py
+
+@dataclass(frozen=True)
+class Lesson:
+    """
+    Value object for Lesson knowledge (LES).
+
+    Captures: What happened, What learned, Prevention
+    Based on: After-Action Review (AAR) format
+    """
+
+    what_happened: str      # Specific situation or incident
+    what_learned: str       # Insight gained from experience
+    prevention: str         # How to avoid or repeat outcome
+
+    # Optional: Impact and confidence
+    impact: str = ""        # Magnitude of learning (LOW, MEDIUM, HIGH)
+    confidence: float = 1.0  # How certain we are (0.0-1.0)
+
+    def to_markdown(self) -> str:
+        """Serialize to markdown format."""
+        md = f"## What Happened\n\n{self.what_happened}\n\n"
+        md += f"## What We Learned\n\n{self.what_learned}\n\n"
+        md += f"## How to Apply This\n\n{self.prevention}\n\n"
+
+        if self.impact:
+            md += f"**Impact:** {self.impact}\n\n"
+
+        if self.confidence < 1.0:
+            md += f"**Confidence:** {self.confidence:.0%}\n\n"
+
+        return md
+
+
+# src/domain/knowledge/value_objects/assumption.py
+
+@dataclass(frozen=True)
+class Assumption:
+    """
+    Value object for Assumption knowledge (ASM).
+
+    Captures: What we assume, Impact if wrong, Validation path
+    Based on: Risk management and architectural assumptions
+    """
+
+    statement: str          # What we're assuming to be true
+    impact_if_wrong: str    # Consequences if assumption proves false
+    validation_path: str    # How to verify or invalidate
+
+    # Optional: Confidence and monitoring
+    confidence: float = 0.5  # How confident we are (0.0-1.0)
+    review_date: str = ""    # When to re-evaluate (ISO 8601)
+
+    def to_markdown(self) -> str:
+        """Serialize to markdown format."""
+        md = f"## Assumption\n\n{self.statement}\n\n"
+        md += f"## Impact if Wrong\n\n{self.impact_if_wrong}\n\n"
+        md += f"## Validation Path\n\n{self.validation_path}\n\n"
+        md += f"**Confidence:** {self.confidence:.0%}\n\n"
+
+        if self.review_date:
+            md += f"**Review Date:** {self.review_date}\n\n"
+
+        return md
+```
+
+## 2. Domain Ports (Hexagonal Architecture)
+
+### 2.1 IKnowledgeRepository (Persistence Port)
+
+```python
+# src/domain/knowledge/ports/repository.py
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+from ..entities import KnowledgeItem, KnowledgeItemId, KnowledgeType, KnowledgeStatus
+
+
+class IKnowledgeRepository(ABC):
+    """
+    Port for knowledge item persistence operations.
+
+    Infrastructure adapters:
+    - FileSystemAdapter: Markdown files in docs/knowledge/
+    - GraphAdapter: NetworkX for relationship queries
+    - RDFAdapter: Turtle/JSON-LD export
+
+    Hexagonal Architecture: Domain defines port, infrastructure implements.
+    """
+
+    @abstractmethod
+    def save(self, item: KnowledgeItem) -> None:
+        """
+        Persist knowledge item.
+
+        Implementation must:
+        - Write to filesystem (source of truth)
+        - Update graph index (if enabled)
+        - Emit domain events
+        """
+        pass
+
+    @abstractmethod
+    def find_by_id(self, id: KnowledgeItemId) -> Optional[KnowledgeItem]:
+        """Retrieve knowledge item by ID."""
+        pass
+
+    @abstractmethod
+    def find_by_type(
+        self,
+        km_type: KnowledgeType,
+        status: Optional[KnowledgeStatus] = None
+    ) -> List[KnowledgeItem]:
+        """Find all items of a specific type and optional status."""
+        pass
+
+    @abstractmethod
+    def find_by_tag(self, tag: str) -> List[KnowledgeItem]:
+        """Find items tagged with specific label."""
+        pass
+
+    @abstractmethod
+    def find_related(
+        self,
+        item_id: KnowledgeItemId,
+        max_depth: int = 2
+    ) -> List[KnowledgeItem]:
+        """
+        Find knowledge items related to given item.
+
+        Uses graph traversal to discover:
+        - Direct references (depth 1)
+        - Transitive relationships (depth 2+)
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, id: KnowledgeItemId) -> None:
+        """Remove knowledge item (soft delete via DEPRECATED status preferred)."""
+        pass
+```
+
+### 2.2 ISemanticIndex (Vector Search Port)
+
+```python
+# src/domain/knowledge/ports/semantic_index.py
+
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+from ..entities import KnowledgeItem, KnowledgeItemId
+
+
+class ISemanticIndex(ABC):
+    """
+    Port for semantic search operations.
+
+    Infrastructure adapters:
+    - FAISSAdapter: CPU-based vector similarity (Phase 1)
+    - FAISSGPUAdapter: GPU-accelerated search (Phase 3, if needed)
+    - ChromaDBAdapter: Alternative with built-in embeddings
+
+    Design: Adapter manages embedding generation and index persistence.
+    """
+
+    @abstractmethod
+    def index(self, item: KnowledgeItem) -> None:
+        """
+        Add knowledge item to semantic index.
+
+        Implementation must:
+        - Generate embeddings (text-embedding-3-small or local model)
+        - Store vectors with metadata (ID, type, tags)
+        - Handle incremental updates
+        """
+        pass
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        filters: dict = None
+    ) -> List[Tuple[KnowledgeItemId, float]]:
+        """
+        Semantic search for similar knowledge items.
+
+        Args:
+            query: Natural language query
+            top_k: Number of results to return
+            filters: Optional constraints (type, status, tags)
+
+        Returns:
+            List of (KnowledgeItemId, similarity_score) tuples
+        """
+        pass
+
+    @abstractmethod
+    def reindex(self, items: List[KnowledgeItem]) -> None:
+        """Rebuild index from scratch (expensive operation)."""
+        pass
+
+    @abstractmethod
+    def remove(self, item_id: KnowledgeItemId) -> None:
+        """Remove item from index."""
+        pass
+```
+
+### 2.3 IGraphStore (Graph Operations Port)
+
+```python
+# src/domain/knowledge/ports/graph_store.py
+
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+from ..entities import KnowledgeItem, KnowledgeItemId
+from ...graph.primitives import Edge
+
+
+class IGraphStore(ABC):
+    """
+    Port for graph operations on knowledge items.
+
+    Infrastructure adapters:
+    - NetworkXAdapter: In-memory property graph (Phase 1)
+    - RDFLibAdapter: RDF triple export (Phase 2)
+    - PyoxigraphAdapter: Embedded RDF + SPARQL (Phase 3)
+
+    Design: Supports both property graph and RDF paradigms.
+    """
+
+    @abstractmethod
+    def add_vertex(self, item: KnowledgeItem) -> None:
+        """Add knowledge item as graph vertex."""
+        pass
+
+    @abstractmethod
+    def add_edge(
+        self,
+        from_id: KnowledgeItemId,
+        to_id: KnowledgeItemId,
+        label: str,
+        properties: Dict[str, Any] = None
+    ) -> Edge:
+        """
+        Create relationship between knowledge items.
+
+        Edge labels:
+        - REFERENCES: General citation
+        - APPLIES_TO: Pattern applies to task/phase
+        - VALIDATES: Evidence validates assumption
+        - SUPERSEDES: New knowledge replaces old
+        """
+        pass
+
+    @abstractmethod
+    def traverse(
+        self,
+        start_id: KnowledgeItemId,
+        edge_label: str,
+        max_depth: int = 2
+    ) -> List[KnowledgeItemId]:
+        """
+        Graph traversal from starting vertex.
+
+        Gremlin equivalent:
+            g.V(start_id).out(edge_label).limit(max_depth)
+        """
+        pass
+
+    @abstractmethod
+    def export_rdf(
+        self,
+        format: str = "turtle"
+    ) -> str:
+        """
+        Export knowledge graph as RDF.
+
+        Formats:
+        - turtle: Human-readable RDF (Phase 2)
+        - jsonld: JSON-LD with contexts (Phase 2)
+        - ntriples: Line-oriented RDF
+
+        Uses: RDFLib or pyoxigraph adapter
+        """
+        pass
+
+    @abstractmethod
+    def query_sparql(self, query: str) -> List[Dict[str, Any]]:
+        """
+        Execute SPARQL query against knowledge graph.
+
+        Phase 3 only (requires pyoxigraph adapter).
+        Returns empty list if not supported.
+        """
+        pass
+```
+
+## 3. Application Layer: Use Cases (CQRS)
+
+### 3.1 Commands (Write Operations)
+
+```python
+# src/application/knowledge/commands/capture_knowledge.py
+
+from dataclasses import dataclass
+from typing import Optional
+from ....domain.knowledge.entities import (
+    KnowledgeItem, KnowledgeItemId, KnowledgeType, KnowledgeStatus
+)
+from ....domain.knowledge.value_objects import Pattern, Lesson, Assumption
+from ....domain.knowledge.ports import IKnowledgeRepository, ISemanticIndex, IGraphStore
+from ....domain.events import DomainEventPublisher
+from ..events import KnowledgeItemCreated
+
+
+@dataclass
+class CaptureKnowledgeCommand:
+    """Command to capture new knowledge item."""
+    title: str
+    km_type: KnowledgeType
+    content: Pattern | Lesson | Assumption
+    context: str = ""
+    tags: list[str] = None
+    related_items: list[KnowledgeItemId] = None
+    evidence_refs: list[str] = None
+    created_by: str = "system:km"
+
+
+class CaptureKnowledgeHandler:
+    """
+    Use case: Capture new knowledge item.
+
+    Flow:
+    1. Generate ID based on type and sequence
+    2. Create KnowledgeItem aggregate
+    3. Persist to repository (filesystem + graph)
+    4. Index for semantic search
+    5. Emit KnowledgeItemCreated event
+
+    CQRS: Command handler for write operation
+    """
+
+    def __init__(
+        self,
+        repository: IKnowledgeRepository,
+        semantic_index: ISemanticIndex,
+        graph_store: IGraphStore,
+        event_publisher: DomainEventPublisher
+    ):
+        self.repository = repository
+        self.semantic_index = semantic_index
+        self.graph_store = graph_store
+        self.event_publisher = event_publisher
+
+    def handle(self, command: CaptureKnowledgeCommand) -> KnowledgeItemId:
+        """Execute command and return new knowledge item ID."""
+
+        # Generate next sequence number for type
+        existing = self.repository.find_by_type(command.km_type)
+        next_seq = len(existing) + 1
+
+        # Create knowledge item
+        item_id = KnowledgeItemId.generate(command.km_type, next_seq)
+        item = KnowledgeItem(
+            id=item_id,
+            title=command.title,
+            km_type=command.km_type,
+            status=KnowledgeStatus.DRAFT,
+            content=command.content,
+            context=command.context,
+            tags=command.tags or [],
+            related_items=command.related_items or [],
+            evidence_refs=command.evidence_refs or [],
+            created_by=command.created_by,
+            modified_by=command.created_by,
+        )
+
+        # Persist (filesystem source of truth)
+        self.repository.save(item)
+
+        # Index for semantic search
+        self.semantic_index.index(item)
+
+        # Add to graph
+        self.graph_store.add_vertex(item)
+
+        # Create relationship edges
+        for related_id in item.related_items:
+            self.graph_store.add_edge(
+                from_id=item.id,
+                to_id=related_id,
+                label="REFERENCES"
+            )
+
+        # Emit event
+        event = KnowledgeItemCreated(
+            item_id=item_id,
+            km_type=command.km_type,
+            title=command.title,
+            created_by=command.created_by
+        )
+        self.event_publisher.publish(event)
+
+        return item_id
+```
+
+```python
+# src/application/knowledge/commands/validate_knowledge.py
+
+@dataclass
+class ValidateKnowledgeCommand:
+    """Command to validate knowledge item."""
+    item_id: KnowledgeItemId
+    validated_by: str = "system:validator"
+
+
+class ValidateKnowledgeHandler:
+    """
+    Use case: Transition knowledge from DRAFT to VALIDATED.
+
+    Flow:
+    1. Load item from repository
+    2. Call item.validate() (domain logic)
+    3. Persist updated item
+    4. Emit KnowledgeItemValidated event
+    """
+
+    def __init__(
+        self,
+        repository: IKnowledgeRepository,
+        event_publisher: DomainEventPublisher
+    ):
+        self.repository = repository
+        self.event_publisher = event_publisher
+
+    def handle(self, command: ValidateKnowledgeCommand) -> None:
+        # Load item
+        item = self.repository.find_by_id(command.item_id)
+        if not item:
+            raise ValueError(f"Knowledge item not found: {command.item_id}")
+
+        # Validate (domain logic)
+        item.validate()
+        object.__setattr__(item, "modified_by", command.validated_by)
+
+        # Persist
+        self.repository.save(item)
+
+        # Emit event
+        event = KnowledgeItemValidated(
+            item_id=command.item_id,
+            validated_by=command.validated_by
+        )
+        self.event_publisher.publish(event)
+```
+
+```python
+# src/application/knowledge/commands/deprecate_knowledge.py
+
+@dataclass
+class DeprecateKnowledgeCommand:
+    """Command to deprecate knowledge item."""
+    item_id: KnowledgeItemId
+    reason: str
+    deprecated_by: str = "system:km"
+
+
+class DeprecateKnowledgeHandler:
+    """
+    Use case: Mark knowledge as no longer applicable.
+
+    Flow:
+    1. Load item from repository
+    2. Call item.deprecate(reason)
+    3. Persist updated item
+    4. Remove from semantic index (optional: keep with deprecation flag)
+    5. Emit KnowledgeItemDeprecated event
+    """
+
+    def __init__(
+        self,
+        repository: IKnowledgeRepository,
+        semantic_index: ISemanticIndex,
+        event_publisher: DomainEventPublisher
+    ):
+        self.repository = repository
+        self.semantic_index = semantic_index
+        self.event_publisher = event_publisher
+
+    def handle(self, command: DeprecateKnowledgeCommand) -> None:
+        # Load item
+        item = self.repository.find_by_id(command.item_id)
+        if not item:
+            raise ValueError(f"Knowledge item not found: {command.item_id}")
+
+        # Deprecate (domain logic)
+        item.deprecate(command.reason)
+        object.__setattr__(item, "modified_by", command.deprecated_by)
+
+        # Persist
+        self.repository.save(item)
+
+        # Remove from index (or mark as deprecated)
+        self.semantic_index.remove(command.item_id)
+
+        # Emit event
+        event = KnowledgeItemDeprecated(
+            item_id=command.item_id,
+            reason=command.reason,
+            deprecated_by=command.deprecated_by
+        )
+        self.event_publisher.publish(event)
+```
+
+### 3.2 Queries (Read Operations)
+
+```python
+# src/application/knowledge/queries/search_knowledge.py
+
+from dataclasses import dataclass
+from typing import List, Optional
+from ....domain.knowledge.entities import KnowledgeItem, KnowledgeType
+from ....domain.knowledge.ports import IKnowledgeRepository, ISemanticIndex
+
+
+@dataclass
+class SearchKnowledgeQuery:
+    """Query for semantic knowledge search."""
+    query_text: str
+    km_type: Optional[KnowledgeType] = None
+    top_k: int = 5
+    min_similarity: float = 0.5
+
+
+@dataclass
+class KnowledgeSearchResult:
+    """Result of semantic search."""
+    item: KnowledgeItem
+    similarity_score: float
+    excerpt: str  # Relevant snippet
+
+
+class SearchKnowledgeHandler:
+    """
+    Use case: Semantic search across knowledge base.
+
+    Flow:
+    1. Query semantic index (FAISS vector similarity)
+    2. Filter by type if specified
+    3. Load full items from repository
+    4. Return ranked results with scores
+
+    CQRS: Query handler for read operation
+    """
+
+    def __init__(
+        self,
+        repository: IKnowledgeRepository,
+        semantic_index: ISemanticIndex
+    ):
+        self.repository = repository
+        self.semantic_index = semantic_index
+
+    def handle(self, query: SearchKnowledgeQuery) -> List[KnowledgeSearchResult]:
+        # Semantic search
+        filters = {"type": query.km_type.value} if query.km_type else {}
+
+        matches = self.semantic_index.search(
+            query=query.query_text,
+            top_k=query.top_k,
+            filters=filters
+        )
+
+        # Load full items and create results
+        results = []
+        for item_id, score in matches:
+            if score < query.min_similarity:
+                continue
+
+            item = self.repository.find_by_id(item_id)
+            if item:
+                results.append(
+                    KnowledgeSearchResult(
+                        item=item,
+                        similarity_score=score,
+                        excerpt=self._extract_excerpt(item, query.query_text)
+                    )
+                )
+
+        return results
+
+    def _extract_excerpt(self, item: KnowledgeItem, query: str) -> str:
+        """Extract relevant snippet from knowledge item."""
+        # TODO: Implement text excerpt extraction
+        return item.title
+```
+
+```python
+# src/application/knowledge/queries/get_related_knowledge.py
+
+@dataclass
+class GetRelatedKnowledgeQuery:
+    """Query for related knowledge items."""
+    item_id: KnowledgeItemId
+    max_depth: int = 2
+    include_deprecated: bool = False
+
+
+class GetRelatedKnowledgeHandler:
+    """
+    Use case: Find knowledge items related to a given item.
+
+    Flow:
+    1. Traverse graph from starting item
+    2. Follow relationship edges (REFERENCES, APPLIES_TO, etc.)
+    3. Load items from repository
+    4. Filter by status if needed
+
+    Uses: Graph traversal (NetworkX adapter)
+    """
+
+    def __init__(
+        self,
+        repository: IKnowledgeRepository,
+        graph_store: IGraphStore
+    ):
+        self.repository = repository
+        self.graph_store = graph_store
+
+    def handle(self, query: GetRelatedKnowledgeQuery) -> List[KnowledgeItem]:
+        # Graph traversal
+        related_ids = self.repository.find_related(
+            item_id=query.item_id,
+            max_depth=query.max_depth
+        )
+
+        # Load items
+        items = [self.repository.find_by_id(id) for id in related_ids]
+        items = [item for item in items if item]  # Filter None
+
+        # Filter deprecated if needed
+        if not query.include_deprecated:
+            items = [
+                item for item in items
+                if item.status != KnowledgeStatus.DEPRECATED
+            ]
+
+        return items
+```
+
+```python
+# src/application/knowledge/queries/traverse_knowledge_graph.py
+
+@dataclass
+class TraverseKnowledgeGraphQuery:
+    """Query for graph traversal patterns."""
+    start_id: KnowledgeItemId
+    edge_label: str  # REFERENCES, APPLIES_TO, VALIDATES, etc.
+    max_depth: int = 2
+
+
+class TraverseKnowledgeGraphHandler:
+    """
+    Use case: Execute graph traversal pattern.
+
+    Flow:
+    1. Start from given vertex
+    2. Follow edges with specific label
+    3. Return path up to max depth
+
+    Gremlin equivalent:
+        g.V(start_id).out(edge_label).path()
+    """
+
+    def __init__(self, graph_store: IGraphStore):
+        self.graph_store = graph_store
+
+    def handle(self, query: TraverseKnowledgeGraphQuery) -> List[KnowledgeItemId]:
+        return self.graph_store.traverse(
+            start_id=query.start_id,
+            edge_label=query.edge_label,
+            max_depth=query.max_depth
+        )
+```
+
+## 4. Domain Events (CloudEvents 1.0)
+
+```python
+# src/domain/knowledge/events/knowledge_events.py
+
+from dataclasses import dataclass
+from datetime import datetime
+from ....domain.events import DomainEvent
+from ..entities import KnowledgeItemId, KnowledgeType
+
+
+@dataclass
+class KnowledgeItemCreated(DomainEvent):
+    """
+    Event: New knowledge item captured.
+
+    CloudEvents 1.0 compliance:
+    - type: jer:jer:knowledge:facts/KnowledgeItemCreated
+    - source: jer:jer:knowledge:system
+    """
+    item_id: KnowledgeItemId
+    km_type: KnowledgeType
+    title: str
+    created_by: str
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if not self.timestamp:
+            object.__setattr__(self, "timestamp", datetime.utcnow())
+
+    @property
+    def event_type(self) -> str:
+        return "jer:jer:knowledge:facts/KnowledgeItemCreated"
+
+    @property
+    def event_source(self) -> str:
+        return "jer:jer:knowledge:system"
+
+
+@dataclass
+class KnowledgeItemValidated(DomainEvent):
+    """Event: Knowledge item validated and approved."""
+    item_id: KnowledgeItemId
+    validated_by: str
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if not self.timestamp:
+            object.__setattr__(self, "timestamp", datetime.utcnow())
+
+    @property
+    def event_type(self) -> str:
+        return "jer:jer:knowledge:facts/KnowledgeItemValidated"
+
+    @property
+    def event_source(self) -> str:
+        return f"jer:jer:knowledge:item:{self.item_id.value}"
+
+
+@dataclass
+class KnowledgeItemDeprecated(DomainEvent):
+    """Event: Knowledge item marked as no longer applicable."""
+    item_id: KnowledgeItemId
+    reason: str
+    deprecated_by: str
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if not self.timestamp:
+            object.__setattr__(self, "timestamp", datetime.utcnow())
+
+    @property
+    def event_type(self) -> str:
+        return "jer:jer:knowledge:facts/KnowledgeItemDeprecated"
+
+    @property
+    def event_source(self) -> str:
+        return f"jer:jer:knowledge:item:{self.item_id.value}"
+
+
+@dataclass
+class KnowledgeRelationCreated(DomainEvent):
+    """Event: Relationship created between knowledge items."""
+    from_id: KnowledgeItemId
+    to_id: KnowledgeItemId
+    relation_type: str  # REFERENCES, APPLIES_TO, VALIDATES, etc.
+    created_by: str
+    timestamp: datetime = None
+
+    def __post_init__(self):
+        if not self.timestamp:
+            object.__setattr__(self, "timestamp", datetime.utcnow())
+
+    @property
+    def event_type(self) -> str:
+        return "jer:jer:knowledge:facts/KnowledgeRelationCreated"
+
+    @property
+    def event_source(self) -> str:
+        return f"jer:jer:knowledge:item:{self.from_id.value}"
+```
+
+---
+
+# L2: Strategic Architecture (Principal Architect)
+
+## 1. Component Architecture
+
+### 1.1 Hexagonal Architecture Integration
+
+```mermaid
+graph TB
+    subgraph "User/Agent Interactions"
+        UI[CLI: jerry knowledge]
+        AGENT[Agents: ps-*, qa-*, etc]
+        SKILL[Skills: knowledge-search]
+    end
+
+    subgraph "Application Layer (Use Cases)"
+        CMD_CAP[CaptureKnowledgeHandler]
+        CMD_VAL[ValidateKnowledgeHandler]
+        CMD_DEP[DeprecateKnowledgeHandler]
+        QRY_SEARCH[SearchKnowledgeHandler]
+        QRY_RELATED[GetRelatedKnowledgeHandler]
+        QRY_TRAVERSE[TraverseKnowledgeGraphHandler]
+    end
+
+    subgraph "Domain Layer (Zero Dependencies)"
+        KM_ENTITY[KnowledgeItem<br/>Aggregate Root]
+        KM_VO[Value Objects:<br/>Pattern, Lesson, Assumption]
+        KM_EVENTS[Domain Events:<br/>Created, Validated, Deprecated]
+
+        subgraph "Ports (Interfaces)"
+            PORT_REPO[IKnowledgeRepository]
+            PORT_INDEX[ISemanticIndex]
+            PORT_GRAPH[IGraphStore]
+        end
+    end
+
+    subgraph "Infrastructure Layer (Adapters)"
+        subgraph "WORK-032: Lightweight Stack"
+            ADAPTER_FS[FileSystemAdapter<br/>Markdown in docs/knowledge/]
+            ADAPTER_NX[NetworkXAdapter<br/>Property graph operations]
+            ADAPTER_FAISS[FAISSAdapter<br/>Vector similarity search]
+            ADAPTER_RDF[RDFLibAdapter<br/>RDF serialization]
+        end
+
+        subgraph "WORK-031: Semantic Web (Phase 3)"
+            ADAPTER_PYOX[PyoxigraphAdapter<br/>SPARQL endpoint]
+        end
+    end
+
+    subgraph "Storage (Multi-Representation)"
+        FS[Filesystem<br/>docs/knowledge/*.md<br/>SOURCE OF TRUTH]
+        GRAPH_MEM[In-Memory Graph<br/>NetworkX]
+        VECTOR_INDEX[FAISS Index<br/>.jerry/indexes/]
+        RDF_EXPORT[RDF Files<br/>knowledge-graph.ttl]
+    end
+
+    UI --> CMD_CAP
+    UI --> QRY_SEARCH
+    AGENT --> CMD_CAP
+    AGENT --> QRY_RELATED
+    SKILL --> QRY_SEARCH
+
+    CMD_CAP --> KM_ENTITY
+    CMD_VAL --> KM_ENTITY
+    CMD_DEP --> KM_ENTITY
+
+    CMD_CAP --> PORT_REPO
+    CMD_CAP --> PORT_INDEX
+    CMD_CAP --> PORT_GRAPH
+
+    QRY_SEARCH --> PORT_REPO
+    QRY_SEARCH --> PORT_INDEX
+    QRY_RELATED --> PORT_GRAPH
+    QRY_TRAVERSE --> PORT_GRAPH
+
+    PORT_REPO -.implements.-> ADAPTER_FS
+    PORT_INDEX -.implements.-> ADAPTER_FAISS
+    PORT_GRAPH -.implements.-> ADAPTER_NX
+    PORT_GRAPH -.implements.-> ADAPTER_RDF
+    PORT_GRAPH -.implements.-> ADAPTER_PYOX
+
+    ADAPTER_FS --> FS
+    ADAPTER_NX --> GRAPH_MEM
+    ADAPTER_FAISS --> VECTOR_INDEX
+    ADAPTER_RDF --> RDF_EXPORT
+
+    KM_ENTITY --> KM_VO
+    KM_ENTITY --> KM_EVENTS
+
+    style KM_ENTITY fill:#e1f5ff
+    style PORT_REPO fill:#fff3cd
+    style PORT_INDEX fill:#fff3cd
+    style PORT_GRAPH fill:#fff3cd
+    style FS fill:#d4edda
+    style ADAPTER_NX fill:#f8d7da
+    style ADAPTER_FAISS fill:#f8d7da
+    style ADAPTER_RDF fill:#f8d7da
+```
+
+**Key Design Decisions:**
+
+1. **Hexagonal Architecture Compliance**:
+   - Domain layer defines ports (interfaces)
+   - Infrastructure layer provides adapters (implementations)
+   - Application layer orchestrates use cases
+   - Zero dependencies in domain (pure Python stdlib)
+
+2. **Multi-Adapter Strategy** (Netflix UDA):
+   - FileSystemAdapter: Source of truth (markdown files)
+   - NetworkXAdapter: Graph operations (relationship queries)
+   - FAISSAdapter: Semantic search (vector similarity)
+   - RDFLibAdapter: Standards export (Turtle, JSON-LD)
+   - PyoxigraphAdapter: SPARQL endpoint (Phase 3)
+
+3. **WORK-031 + WORK-032 Integration**:
+   - WORK-032 provides Phase 1-2 adapters (NetworkX, FAISS, RDFLib)
+   - WORK-031 provides Phase 3 adapter (pyoxigraph)
+   - Both use same ports (swappable implementations)
+
+## 2. Class Diagram: Knowledge Management Entities
+
+```mermaid
+classDiagram
+    class EntityBase {
+        <<abstract>>
+        +JerryId id
+        +JerryUri uri
+        +str slug
+        +str name
+        +datetime created_at
+        +str created_by
+        +datetime modified_at
+        +str modified_by
+        +str version
+        +str content_hash
+        +Dict metadata
+        +List~str~ tags
+    }
+
+    class Vertex {
+        <<abstract>>
+        +VertexId id
+        +str label
+        +Dict~str,Any~ properties
+        +datetime created_at
+        +datetime modified_at
+        +set_property(key, value)
+        +get_property(key, default)
+    }
+
+    class KnowledgeItem {
+        +KnowledgeItemId id
+        +JerryUri uri
+        +str title
+        +KnowledgeType km_type
+        +KnowledgeStatus status
+        +Pattern|Lesson|Assumption content
+        +str context
+        +List~str~ tags
+        +List~KnowledgeItemId~ related_items
+        +List~str~ evidence_refs
+        +validate()
+        +deprecate(reason)
+        +add_evidence(uri)
+        +relate_to(other)
+    }
+
+    class KnowledgeType {
+        <<enumeration>>
+        PATTERN
+        LESSON
+        ASSUMPTION
+    }
+
+    class KnowledgeStatus {
+        <<enumeration>>
+        DRAFT
+        VALIDATED
+        DEPRECATED
+    }
+
+    class Pattern {
+        <<value object>>
+        +str context
+        +str problem
+        +str solution
+        +str consequences
+        +List~str~ forces
+        +List~str~ alternatives
+        +to_markdown() str
+    }
+
+    class Lesson {
+        <<value object>>
+        +str what_happened
+        +str what_learned
+        +str prevention
+        +str impact
+        +float confidence
+        +to_markdown() str
+    }
+
+    class Assumption {
+        <<value object>>
+        +str statement
+        +str impact_if_wrong
+        +str validation_path
+        +float confidence
+        +str review_date
+        +to_markdown() str
+    }
+
+    class KnowledgeItemId {
+        <<value object>>
+        +str value
+        +generate(type, seq) KnowledgeItemId
+        +km_type KnowledgeType
+    }
+
+    class VertexId {
+        <<value object>>
+        +str value
+    }
+
+    class JerryUri {
+        <<value object>>
+        +str partition
+        +str domain
+        +str resource
+        +str version
+        +for_entity(...) JerryUri
+    }
+
+    EntityBase <|-- Vertex
+    Vertex <|-- KnowledgeItem
+    KnowledgeItem --> KnowledgeType
+    KnowledgeItem --> KnowledgeStatus
+    KnowledgeItem --> Pattern
+    KnowledgeItem --> Lesson
+    KnowledgeItem --> Assumption
+    KnowledgeItemId --|> VertexId
+    KnowledgeItem --> KnowledgeItemId
+    KnowledgeItem --> JerryUri
+```
+
+**Inheritance Hierarchy:**
+
+1. **EntityBase**: Common properties (IAuditable, IVersioned)
+2. **Vertex**: Graph abstraction (TinkerPop alignment)
+3. **KnowledgeItem**: Domain-specific aggregate root
+
+**Value Objects:**
+- **KnowledgeItemId**: Strongly-typed identity (PAT-001, LES-042, ASM-003)
+- **Pattern, Lesson, Assumption**: Knowledge content (discriminated union)
+- **JerryUri**: Resource identifier (SPEC-001)
+
+## 3. Sequence Diagram: Capture Knowledge Workflow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as jerry CLI
+    participant Handler as CaptureKnowledgeHandler
+    participant KM as KnowledgeItem
+    participant Repo as IKnowledgeRepository
+    participant Index as ISemanticIndex
+    participant Graph as IGraphStore
+    participant Events as EventPublisher
+    participant FS as FileSystem
+    participant FAISS as FAISS Index
+    participant NX as NetworkX
+
+    User->>CLI: jerry knowledge capture<br/>--type PAT<br/>--title "Hybrid prevents lock-in"
+    CLI->>Handler: CaptureKnowledgeCommand
+
+    Note over Handler: Generate ID: PAT-001
+    Handler->>KM: new KnowledgeItem(PAT-001)
+    KM-->>Handler: item (DRAFT status)
+
+    Handler->>Repo: save(item)
+    Repo->>FS: Write PAT-001.md
+    FS-->>Repo: OK
+    Repo-->>Handler: OK
+
+    Handler->>Index: index(item)
+    Index->>Index: Generate embedding<br/>(text-embedding-3-small)
+    Index->>FAISS: Add vector + metadata
+    FAISS-->>Index: OK
+    Index-->>Handler: OK
+
+    Handler->>Graph: add_vertex(item)
+    Graph->>NX: Add node with properties
+    NX-->>Graph: OK
+    Graph-->>Handler: OK
+
+    Note over Handler: If related_items exist
+    loop For each related item
+        Handler->>Graph: add_edge(PAT-001, REF-ID, "REFERENCES")
+        Graph->>NX: Add edge
+        NX-->>Graph: OK
+    end
+
+    Handler->>Events: publish(KnowledgeItemCreated)
+    Events-->>Handler: OK
+
+    Handler-->>CLI: PAT-001
+    CLI-->>User: Knowledge captured: PAT-001<br/>Status: DRAFT<br/>File: docs/knowledge/patterns/PAT-001.md
+```
+
+**Key Steps:**
+
+1. **Command Creation**: User invokes CLI with knowledge details
+2. **ID Generation**: Sequential ID based on type (PAT, LES, ASM)
+3. **Aggregate Creation**: KnowledgeItem entity with DRAFT status
+4. **Persistence**: Write to filesystem (source of truth)
+5. **Indexing**: Generate embedding and add to FAISS
+6. **Graph Update**: Add vertex and relationship edges (NetworkX)
+7. **Event Publication**: Emit KnowledgeItemCreated event
+
+**Design Principles:**
+
+- Filesystem write is authoritative (can rebuild indexes from files)
+- Idempotent operations (can replay if index/graph corruption)
+- Event sourcing for audit trail
+
+## 4. Sequence Diagram: Retrieve Knowledge Workflow (HybridRAG)
+
+```mermaid
+sequenceDiagram
+    actor Agent
+    participant Skill as knowledge-search skill
+    participant Handler as SearchKnowledgeHandler
+    participant Index as ISemanticIndex
+    participant Graph as IGraphStore
+    participant Repo as IKnowledgeRepository
+    participant FAISS as FAISS Index
+    participant NX as NetworkX
+    participant FS as FileSystem
+
+    Agent->>Skill: "Find patterns about database migration"
+    Skill->>Handler: SearchKnowledgeQuery<br/>(query_text, km_type=PATTERN, top_k=5)
+
+    Note over Handler: Phase 1: Vector RAG
+    Handler->>Index: search(query, top_k=5, filters)
+    Index->>Index: Generate query embedding
+    Index->>FAISS: Similarity search
+    FAISS-->>Index: [(PAT-007, 0.89), (PAT-012, 0.76), ...]
+    Index-->>Handler: Top-K IDs + scores
+
+    Note over Handler: Phase 2: Graph Expansion (optional)
+    loop For each result
+        Handler->>Graph: traverse(item_id, "REFERENCES", depth=1)
+        Graph->>NX: Get related vertices
+        NX-->>Graph: Related IDs
+        Graph-->>Handler: Related IDs
+    end
+
+    Note over Handler: Phase 3: Load Full Items
+    loop For each ID
+        Handler->>Repo: find_by_id(item_id)
+        Repo->>FS: Read markdown file
+        FS-->>Repo: File content
+        Repo->>Repo: Parse to KnowledgeItem
+        Repo-->>Handler: KnowledgeItem
+    end
+
+    Note over Handler: Phase 4: Rank and Filter
+    Handler->>Handler: Deduplicate<br/>Filter by status<br/>Rank by score
+
+    Handler-->>Skill: List[KnowledgeSearchResult]
+
+    Skill->>Skill: Format as context<br/>with Jerry URI citations
+    Skill-->>Agent: "Found 3 patterns:\n\n1. PAT-007: Hybrid Architecture...<br/>   (jer:jer:knowledge:pat:pat-007)\n\n2. PAT-012: Incremental Migration...<br/>   (jer:jer:knowledge:pat:pat-012)"
+```
+
+**HybridRAG Flow:**
+
+1. **Vector RAG** (WORK-032): Semantic similarity search via FAISS
+2. **Graph RAG** (WORK-031): Expand to related items via NetworkX traversal
+3. **Deduplication**: Merge results from both sources
+4. **Grounding**: Load full items from filesystem (source of truth)
+5. **Citation**: Return Jerry URIs for transparency
+
+**Performance Targets** (from WORK-031):
+- Vector search: <2 seconds (WORK-032)
+- Graph traversal: <50ms P95 (WORK-031)
+- Total retrieval: <3 seconds end-to-end
+
+## 5. Entity-Relationship Diagram: Knowledge Graph
+
+```mermaid
+erDiagram
+    KNOWLEDGE_ITEM {
+        KnowledgeItemId id PK
+        JerryUri uri
+        string title
+        KnowledgeType km_type
+        KnowledgeStatus status
+        string context
+        string[] tags
+        datetime created_at
+        string created_by
+        datetime modified_at
+        string modified_by
+    }
+
+    PATTERN {
+        string context
+        string problem
+        string solution
+        string consequences
+        string[] forces
+        string[] alternatives
+    }
+
+    LESSON {
+        string what_happened
+        string what_learned
+        string prevention
+        string impact
+        float confidence
+    }
+
+    ASSUMPTION {
+        string statement
+        string impact_if_wrong
+        string validation_path
+        float confidence
+        string review_date
+    }
+
+    TASK {
+        TaskId id PK
+        string title
+        TaskStatus status
+    }
+
+    PHASE {
+        PhaseId id PK
+        string title
+        PhaseStatus status
+    }
+
+    EVIDENCE {
+        JerryUri uri PK
+        string type
+    }
+
+    KNOWLEDGE_ITEM ||--o{ PATTERN : "content (if PAT)"
+    KNOWLEDGE_ITEM ||--o{ LESSON : "content (if LES)"
+    KNOWLEDGE_ITEM ||--o{ ASSUMPTION : "content (if ASM)"
+
+    KNOWLEDGE_ITEM ||--o{ KNOWLEDGE_ITEM : "REFERENCES"
+    KNOWLEDGE_ITEM ||--o{ KNOWLEDGE_ITEM : "SUPERSEDES"
+    KNOWLEDGE_ITEM ||--o{ TASK : "APPLIES_TO"
+    KNOWLEDGE_ITEM ||--o{ PHASE : "APPLIES_TO"
+    KNOWLEDGE_ITEM ||--o{ EVIDENCE : "EVIDENCED_BY"
+    KNOWLEDGE_ITEM ||--o{ EVIDENCE : "VALIDATES"
+```
+
+**Relationship Types:**
+
+| Edge Label | From | To | Semantics |
+|------------|------|-----|-----------|
+| **REFERENCES** | KnowledgeItem | KnowledgeItem | General citation |
+| **SUPERSEDES** | KnowledgeItem | KnowledgeItem | Newer replaces older |
+| **APPLIES_TO** | KnowledgeItem | Task/Phase | Pattern/Lesson used in work |
+| **EVIDENCED_BY** | KnowledgeItem | Evidence | Supporting documentation |
+| **VALIDATES** | Assumption | Evidence | Evidence confirms/refutes assumption |
+
+**Graph Properties:**
+
+- **Multi-graph**: Multiple edges between same vertices allowed
+- **Directed**: All edges have explicit source → target
+- **Attributed**: Both vertices and edges have properties
+- **Labeled**: Typed via labels (not inheritance)
+
+## 6. Integration with Existing Jerry Architecture
+
+### 6.1 Work Tracker Integration
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    WORK TRACKER                                   │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐                   │
+│  │   Plan   │───►│  Phase   │───►│   Task   │                   │
+│  └──────────┘    └──────────┘    └──────────┘                   │
+│                                         │                         │
+└─────────────────────────────────────────┼─────────────────────────┘
+                                          │
+                                          │ APPLIES_TO
+                                          ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                 KNOWLEDGE MANAGEMENT                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │   Pattern    │  │    Lesson    │  │  Assumption  │           │
+│  │   (PAT)      │  │    (LES)     │  │    (ASM)     │           │
+│  └──────────────┘  └──────────────┘  └──────────────┘           │
+│                                                                   │
+│  Example:                                                         │
+│  TASK-042 (Implement SHACL validation)                           │
+│     ├─ APPLIES: PAT-001 (Hybrid Architecture)                    │
+│     └─ LEARNED: LES-012 (Schema validation catches drift)        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Integration Points:**
+
+1. **Task → Pattern**: "Which pattern did we apply?"
+2. **Task → Lesson**: "What did we learn from this?"
+3. **Phase → Assumption**: "What assumptions does this phase rely on?"
+
+**Use Cases:**
+- After-Action Review: Capture lessons from completed tasks
+- Pattern Application: Link pattern to task that uses it
+- Assumption Tracking: Monitor assumptions per phase/plan
+
+### 6.2 Filesystem Integration
+
+```
+docs/
+├── knowledge/                    # Knowledge Management root
+│   ├── patterns/                # Patterns (PAT)
+│   │   ├── PAT-001-hybrid-architecture.md
+│   │   ├── PAT-002-four-phase-maturity.md
+│   │   └── PAT-003-netflix-uda.md
+│   │
+│   ├── lessons/                 # Lessons Learned (LES)
+│   │   ├── LES-001-shacl-validation.md
+│   │   ├── LES-002-supernode-detection.md
+│   │   └── LES-003-rdflib-performance.md
+│   │
+│   ├── assumptions/             # Assumptions (ASM)
+│   │   ├── ASM-001-single-tenant.md
+│   │   ├── ASM-002-entity-count.md
+│   │   └── ASM-003-embedded-sufficient.md
+│   │
+│   └── index.md                 # Knowledge catalog (auto-generated)
+│
+├── decisions/                   # ADRs (Evidence)
+├── research/                    # Research reports (Evidence)
+├── experience/                  # Raw experience notes
+└── wisdom/                      # Distilled wisdom
+```
+
+**File Format** (Markdown with YAML frontmatter):
+
+```markdown
+---
+id: PAT-001
+uri: jer:jer:knowledge:pat:pat-001+a1b2c3d4
+title: Hybrid Property Graph + RDF Architecture
+km_type: PATTERN
+status: VALIDATED
+context: |
+  Need standards compliance without sacrificing performance
+tags:
+  - architecture
+  - semantic-web
+  - property-graph
+related_items:
+  - ADR-031
+  - PAT-002
+evidence_refs:
+  - jer:jer:work-tracker:decisions:ADR-031
+created_at: 2026-01-08T10:30:00Z
+created_by: user:architect
+modified_at: 2026-01-09T14:20:00Z
+modified_by: user:validator
+content_hash: a1b2c3d4e5f6g7h8
+version: 2026-01-09T14:20:00Z_a1b2c3d4
+---
+
+# Hybrid Property Graph + RDF Architecture
+
+## Context
+
+Jerry needs a knowledge architecture that provides:
+- Fast operational queries (property graph)
+- Standards compliance (RDF/SPARQL)
+- Backward compatibility (existing Phase 1)
+
+## Problem
+
+Pure property graph lacks semantic web interoperability.
+Pure RDF has poor query performance (50-500ms vs 5-10ms).
+
+## Solution
+
+Use property graph as primary storage, RDF as export layer.
+Implement Netflix UDA "Model Once, Represent Everywhere" pattern.
+
+## Consequences
+
+**Positive:**
+- Best of both worlds: fast operations + standards compliance
+- Incremental adoption (Phase 2: RDF export, Phase 3: SPARQL)
+
+**Negative:**
+- Multiple serializers to maintain
+- Synchronization overhead between representations
+
+## Forces
+
+- Performance: Property graph wins (5-10ms traversals)
+- Standards: RDF required for 5-star Linked Open Data
+- Complexity: Multi-representation adds overhead
+
+## Alternatives Considered
+
+1. Property graph only: No semantic web integration
+2. RDF only: 10x slower query performance
+3. Vector DB only: Can't answer relational queries
+```
+
+### 6.3 Event Integration (CloudEvents)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                     EVENT STREAM                                  │
+│                                                                   │
+│  CloudEvent: KnowledgeItemCreated                                 │
+│  ├─ type: jer:jer:knowledge:facts/KnowledgeItemCreated          │
+│  ├─ source: jer:jer:knowledge:system                            │
+│  ├─ subject: jer:jer:knowledge:pat:pat-001                      │
+│  ├─ time: 2026-01-09T10:30:00Z                                  │
+│  └─ data:                                                         │
+│      ├─ item_id: PAT-001                                         │
+│      ├─ km_type: PATTERN                                         │
+│      ├─ title: "Hybrid Architecture"                             │
+│      └─ created_by: user:architect                               │
+│                                                                   │
+│  CloudEvent: KnowledgeItemValidated                               │
+│  ├─ type: jer:jer:knowledge:facts/KnowledgeItemValidated        │
+│  ├─ source: jer:jer:knowledge:item:pat-001                      │
+│  ├─ subject: jer:jer:knowledge:pat:pat-001                      │
+│  ├─ time: 2026-01-09T14:20:00Z                                  │
+│  └─ data:                                                         │
+│      ├─ item_id: PAT-001                                         │
+│      └─ validated_by: user:validator                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Event Consumers:**
+- Audit trail (who created/modified what)
+- Notification system (new knowledge available)
+- Analytics (knowledge growth metrics)
+- External integrations (webhook triggers)
+
+---
+
+# Implementation Roadmap
+
+## Phase 1: Foundation (Q1 2026, Weeks 1-2)
+
+**Deliverables:**
+```python
+# Port definitions (domain layer)
+src/domain/knowledge/ports/
+├── repository.py            # IKnowledgeRepository
+├── semantic_index.py        # ISemanticIndex
+└── graph_store.py           # IGraphStore
+
+# Entities and value objects
+src/domain/knowledge/entities/
+└── knowledge_item.py        # KnowledgeItem, KnowledgeItemId
+
+src/domain/knowledge/value_objects/
+├── pattern.py               # Pattern value object
+├── lesson.py                # Lesson value object
+└── assumption.py            # Assumption value object
+
+# Events
+src/domain/knowledge/events/
+└── knowledge_events.py      # Created, Validated, Deprecated
+
+# Infrastructure adapters
+src/infrastructure/knowledge/
+├── filesystem_adapter.py    # Markdown persistence
+├── networkx_adapter.py      # Graph operations
+├── faiss_adapter.py         # Vector search
+└── rdflib_adapter.py        # RDF serialization
+
+# Dependencies
+requirements.txt:
+  networkx==3.2.1
+  rdflib==7.0.0
+  faiss-cpu==1.7.4
+```
+
+**Success Criteria:**
+- ✅ Create PAT-001 (pattern) via CLI
+- ✅ Search "hybrid architecture" finds PAT-001
+- ✅ Export knowledge graph as Turtle
+- ✅ All tests passing
+
+## Phase 2: Integration (Q1 2026, Weeks 3-8)
+
+**Week 3-4: RDF Serialization** (WORK-031)
+- JSON-LD contexts (`contexts/knowledge.jsonld`)
+- SHACL validation shapes (`schemas/knowledge-shapes.ttl`)
+- Automated round-trip tests (JSON ↔ Turtle ↔ JSON-LD)
+
+**Week 5-6: Graph Layer** (WORK-032)
+- Entity extraction from markdown
+- Relationship detection (REFERENCES, APPLIES_TO)
+- CLI: `jerry knowledge graph --query "find related to PAT-001"`
+
+**Week 7-8: Vector RAG**
+- FAISS index for semantic search
+- CLI: `jerry knowledge search "database migration patterns"`
+- Integration tests (HybridRAG workflow)
+
+**Success Criteria:**
+- ✅ 500+ knowledge items indexed
+- ✅ Semantic search <2 seconds
+- ✅ Graph traversal <50ms P95
+- ✅ RDF export validated
+
+## Phase 3: AI Integration (Q2-Q3 2026)
+
+**Month 4-5: GraphRAG** (WORK-031 + WORK-032)
+- HybridRAG: Vector + Graph retrieval
+- Jerry URI citations in agent responses
+- Grounding verification (MiniCheck, optional)
+
+**Month 5-6: SPARQL Endpoint** (WORK-031)
+- pyoxigraph adapter (RDF triple store)
+- Flask HTTP endpoint for SPARQL queries
+- Content negotiation (Accept: text/turtle, application/ld+json)
+
+**Month 6-7: Visualization**
+- Cytoscape.js graph visualization
+- Knowledge architecture health dashboard
+
+**Success Criteria:**
+- ✅ Agents retrieve knowledge via HybridRAG
+- ✅ SPARQL queries functional
+- ✅ Measurable hallucination reduction
+
+## Phase 4: Optimization (Q4 2026+, Triggered)
+
+**Trigger Conditions:**
+- Knowledge graph >5K nodes
+- FAISS search >1 second
+- Multi-tenant requirements
+- ACID transaction needs
+
+**Potential Upgrades:**
+- NetworkX → igraph (C-based performance)
+- FAISS CPU → FAISS GPU
+- Neo4j Community Edition (native graph DB)
+
+---
+
+# Appendix A: Technology Stack Summary
+
+| Layer | Component | Library | WORK Source | Phase |
+|-------|-----------|---------|-------------|-------|
+| **Domain** | Entities, Ports | Python stdlib | Both | 1 |
+| **Persistence** | Markdown files | Python stdlib | WORK-032 | 1 |
+| **Graph** | Property graph | NetworkX 3.2.1 | WORK-032 | 1 |
+| **Vector** | Semantic search | FAISS 1.7.4 | WORK-032 | 1 |
+| **RDF** | Serialization | RDFLib 7.0.0 | WORK-032 | 2 |
+| **RDF** | Triple store | pyoxigraph | WORK-031 | 3 |
+| **NLP** | Entity extraction | spaCy (optional) | WORK-032 | 2 |
+| **Docs** | Document processing | Docling (optional) | WORK-032 | 3 |
+
+**Total Dependencies:** 3 required (NetworkX, FAISS, RDFLib), 3 optional
+
+---
+
+# Appendix B: Design Decisions Summary
+
+| Decision | WORK-031 | WORK-032 | Unified Design |
+|----------|----------|----------|----------------|
+| **Architecture** | Hybrid Property + RDF | Lightweight KM | ✅ Same (100% alignment) |
+| **Graph Library** | TinkerPop/Gremlin (conceptual) | NetworkX | ✅ NetworkX (WORK-032) |
+| **RDF Library** | pyoxigraph (Phase 3) | RDFLib (Phase 2) | ✅ Both (phased adoption) |
+| **Vector Store** | TOON metadata + index | FAISS | ✅ Both (complementary) |
+| **Filesystem** | Source of truth | Source of truth | ✅ Same (P-002) |
+| **Validation** | SHACL (Phase 2) | AAR/A3 protocols | ✅ Both (complementary) |
+| **Phase 2 Scope** | 8 weeks, semantic layer | 4-10 weeks, integration | ✅ Merged (8 weeks) |
+| **Jerry URI** | Unified identifier | Not explicit | ✅ SPEC-001 (both use) |
+| **HybridRAG** | Phase 3 feature | Phase 3 AI layer | ✅ Same architecture |
+| **Netflix UDA** | Explicit pattern | Implicit follow | ✅ Both embrace |
+
+**Compatibility Score:** 95% (from integration analysis)
+
+---
+
+# Appendix C: Risk Mitigation Matrix
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| **Knowledge corpus growth** | 60% | High | Port/adapter enables swap to igraph/graph-tool |
+| **Tool capacity limits** | 40% | High | Quarterly monitoring, <5K nodes = 1-2 year runway |
+| **Dependency abandonment** | 20% | Medium | Pin versions, hexagonal architecture isolates impact |
+| **Implementation delays** | 40% | Medium | Phased rollout, MVP in 1 month, strict scope gates |
+| **User adoption (protocols)** | 50% | Medium | Lightweight AAR (3 questions, <5 min), show value |
+| **Over-engineering** | 30% | Medium | YAGNI discipline, quarterly ROI review, phase gates |
+| **Supernode (Actor vertex)** | High | High | Edge count validator (100/1000 thresholds) |
+| **Complexity overhead** | Medium | Medium | Netflix UDA pattern, round-trip tests, documentation |
+
+**Overall Risk:** MODERATE (same as individual decisions)
+
+**Residual Risk:** LOW (combined mitigations stronger than either alone)
+
+---
+
+# Appendix D: Success Metrics
+
+## Phase 1 Go/No-Go (Week 8)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Backward Compatibility** | 100% | All Phase 1 tests passing |
+| **Graph Query Latency (P95)** | <50ms | Benchmark suite |
+| **Vector Search Latency** | <2s | Benchmark suite |
+| **RDF Export Latency (P95)** | <100ms | Benchmark suite |
+| **Knowledge Items Created** | 10+ | Manual verification |
+| **Search Accuracy** | Qualitative pass | User evaluation |
+
+## Phase 2 Success (Q2 2026)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Knowledge Graph Size** | 500+ nodes | Dashboard |
+| **Adoption Rate** | 50% work items | AAR completion tracking |
+| **Coverage** | 80% docs/ indexed | Indexing metrics |
+| **Time Saved** | 10-20% | User surveys, time tracking |
+| **Reduced Duplicate Work** | 15-25% | "What exists?" query logs |
+
+## Phase 3 Impact (Q3 2026)
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Agent Reasoning** | Measurable improvement | Baseline vs RAG evaluation |
+| **Hallucination Reduction** | Qualitative improvement | User feedback |
+| **SPARQL Endpoint** | Queries functional | Test suite |
+| **Knowledge Reuse** | Patterns applied to new problems | "Lessons Applied" reports |
+
+---
+
+**Document Status:** PROPOSED
+**File:** `/home/user/jerry/docs/design/work-033-e-002-unified-design.md`
+**Date:** 2026-01-09
+**Agent:** ps-architect v2.0.0
+**Word Count:** ~9,800 words
+**Diagrams:** 5 Mermaid diagrams
+
+**Next Step:** Link artifact and proceed to ps-validator review

--- a/docs/archive/projects-archive/design/work-034-e-003-unified-design.md
+++ b/docs/archive/projects-archive/design/work-034-e-003-unified-design.md
@@ -1,0 +1,2757 @@
+# WORK-034 Unified Design: Work Tracker + Knowledge Management Integration
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **PS ID** | work-034 |
+| **Entry ID** | e-003 |
+| **Date** | 2026-01-09 |
+| **Author** | ps-architect v2.0.0 |
+| **Input** | work-034-e-002-domain-synthesis.md (54KB), work-034-e-001-domain-analysis.md (93KB) |
+| **Reference** | WORK_TRACKER_PLAN.md (89KB) |
+| **Output Target** | 60-80KB |
+| **Status** | COMPLETE |
+
+---
+
+## Executive Summary
+
+This unified design document specifies the complete technical architecture for integrating the Work Tracker and Knowledge Management (KM) bounded contexts within the Jerry Framework. The design addresses the core challenge of context rot in AI coding assistants by establishing Work Tracker as a proving ground for KM infrastructure patterns before scaling to full knowledge graph capabilities.
+
+The architecture establishes a shared kernel containing VertexId, JerryUri, and CloudEvents infrastructure that both domains inherit. Work Tracker entities (Task, Phase, Plan) naturally materialize into KM entities (Lesson, Pattern, Assumption) through event-driven completion workflows. This bidirectional relationship enables knowledge accumulation without requiring explicit knowledge capture—completing a Task can automatically prompt for lessons learned, phases can surface patterns, and plans track assumptions.
+
+The design specifies Hexagonal Architecture with clear port definitions for all external concerns: IGraphStore (NetworkX adapter), ISemanticIndex (FAISS adapter), IRDFSerializer (RDFLib adapter), IEventStore (SQLite adapter), and domain-specific repositories. The CQRS pattern separates read and write operations, with commands emitting CloudEvents 1.0-compliant events that drive cross-domain integration.
+
+The four-phase implementation plan (32 weeks total) validates infrastructure at Work Tracker's smaller scale (~500 nodes) before scaling to KM's target (~5,000+ nodes), reducing risk by enabling 4x faster issue discovery and 10x smaller fix costs compared to direct KM implementation. Key risks include performance degradation at scale, supernode formation in the knowledge graph, and user adoption of AAR (After Action Review) prompts.
+
+Expected outcomes include: persistent task state across Claude Code sessions, automated knowledge capture from completed work, semantic search across patterns and lessons, and a validated infrastructure ready for full Knowledge Management deployment.
+
+---
+
+## 1. 5W1H Analysis
+
+### 1.1 WHO: Stakeholders, Users, and Systems
+
+| Stakeholder | Role | Primary Concerns | Success Metrics |
+|-------------|------|------------------|-----------------|
+| **Claude Code Users** | End users | Task persistence, knowledge reuse | Session continuity, pattern discovery |
+| **Jerry Framework Developers** | Maintainers | Architecture quality, testability | Test coverage >80%, clean boundaries |
+| **AI Agents (ps-*)** | Automated actors | Reliable task tracking, knowledge access | Response latency <100ms |
+| **Claude Code Platform** | Host environment | Resource efficiency, stability | Memory <100MB, no crashes |
+
+**System Actors:**
+
+```python
+class Actor(Enum):
+    """All actors that interact with the unified system."""
+    USER = "user"                    # Human via CLI/Skill
+    ORCHESTRATOR = "orchestrator"    # Jerry orchestrator agent
+    PS_RESEARCHER = "ps-researcher"  # Problem-solving researcher
+    PS_ARCHITECT = "ps-architect"    # Problem-solving architect
+    PS_VALIDATOR = "ps-validator"    # Problem-solving validator
+    SYSTEM = "system"                # Automated triggers (timers, events)
+    HOOK = "hook"                    # Claude Code hooks
+```
+
+### 1.2 WHAT: Components, Entities, and Interfaces
+
+**Aggregate Roots (Domain Entities with Identity):**
+
+| Aggregate | Context | Key Attributes | Invariants |
+|-----------|---------|----------------|------------|
+| Task | Work Tracker | id, title, status, phase_id | Status transitions must be valid |
+| Phase | Work Tracker | id, name, tasks[], status | Phase cannot complete with pending tasks |
+| Plan | Work Tracker | id, name, phases[], status | Plan cannot complete with pending phases |
+| KnowledgeItem | KM | id, content, type, evidence[], tags[] | Content is required, type must be valid |
+
+**Value Objects (Immutable, Identity-less):**
+
+| Value Object | Context | Properties | Validation Rules |
+|--------------|---------|------------|------------------|
+| TaskId | Shared | value: str | Format: WORK-NNN |
+| PhaseId | Shared | value: str | Format: PHASE-NNN |
+| PlanId | Shared | value: str | Format: PLAN-NNN |
+| KnowledgeId | Shared | value: str | Format: PAT-NNN, LES-NNN, ASM-NNN |
+| JerryUri | Shared | partition, tenant, domain, resource_type, resource_id, version | Valid URI format |
+| Status | Work Tracker | value: StatusEnum | One of: PENDING, IN_PROGRESS, COMPLETED, BLOCKED |
+| Priority | Shared | value: PriorityEnum | One of: LOW, NORMAL, HIGH, CRITICAL |
+| Evidence | KM | type, source, confidence, timestamp | Confidence in [0.0, 1.0] |
+| Tag | KM | name, category | Name non-empty |
+
+**Primary Interfaces (Ports):**
+
+| Port | Type | Purpose | Adapters |
+|------|------|---------|----------|
+| IWorkItemRepository | Secondary | Work Tracker persistence | SQLiteWorkItemRepository |
+| IKnowledgeRepository | Secondary | KM persistence | SQLiteKnowledgeRepository |
+| IGraphStore | Secondary | Graph operations | NetworkXGraphStore |
+| ISemanticIndex | Secondary | Vector search | FAISSSemanticIndex |
+| IEventStore | Secondary | Event persistence | SQLiteEventStore |
+| IRDFSerializer | Secondary | RDF export | RDFLibSerializer |
+| ICommandHandler[C, R] | Primary | Command execution | Per-command handlers |
+| IQueryHandler[Q, R] | Primary | Query execution | Per-query handlers |
+
+### 1.3 WHEN: Timeline, Phases, and Triggers
+
+**Implementation Timeline:**
+
+| Phase | Duration | Weeks | Key Deliverables |
+|-------|----------|-------|------------------|
+| Phase 1: Foundation | 8 weeks | 1-8 | Work Tracker entities, SQLite repos, CQRS, CLI |
+| Phase 2: Shared Infrastructure | 8 weeks | 9-16 | NetworkX, FAISS, RDFLib adapters |
+| Phase 3: KM Integration | 8 weeks | 17-24 | KM entities, cross-domain handlers |
+| Phase 4: Advanced Features | 8 weeks | 25-32 | HybridRAG, SPARQL, enriched queries |
+
+**Event Triggers:**
+
+| Event | Trigger Condition | Handler | Side Effects |
+|-------|-------------------|---------|--------------|
+| TaskCreated | User creates task | EventDispatcher | Audit log, notification |
+| TaskCompleted | Task status → COMPLETED | AARPromptHandler | Prompt for lesson |
+| PhaseCompleted | All phase tasks complete | PatternAnalyzer | Analyze for patterns |
+| LessonMaterialized | AAR response captured | GraphUpdateHandler | Create Task→Lesson edge |
+| PatternDiscovered | Similarity threshold met | KnowledgeAlertHandler | Notify user |
+
+### 1.4 WHERE: Deployment, Storage, and Integration Points
+
+**Storage Architecture:**
+
+```
+~/.jerry/                          # User data directory
+├── data/
+│   ├── work_tracker.db            # SQLite: Work Tracker entities
+│   ├── knowledge.db               # SQLite: KM entities
+│   └── events.db                  # SQLite: Event store (append-only)
+├── graph/
+│   ├── knowledge_graph.gpickle    # NetworkX: Property graph
+│   └── semantic.index             # FAISS: Vector index
+├── export/
+│   ├── knowledge.ttl              # RDFLib: Turtle export
+│   └── knowledge.jsonld           # RDFLib: JSON-LD export
+└── cache/
+    └── embeddings/                # Cached embeddings
+```
+
+**Integration Points:**
+
+| Integration | Type | Protocol | Purpose |
+|-------------|------|----------|---------|
+| Claude Code CLI | Primary Adapter | stdin/stdout | User interaction |
+| Skills Layer | Primary Adapter | SKILL.md format | Natural language interface |
+| Hooks | Event Consumer | Python callback | Governance enforcement |
+| MCP Servers | External | JSON-RPC | Extended capabilities |
+| Context7 | External | REST API | Documentation retrieval |
+
+### 1.5 WHY: Business Drivers and Technical Rationale
+
+**Business Drivers:**
+
+1. **Context Rot Mitigation**: AI assistants degrade as context fills; persistent state prevents loss
+2. **Knowledge Accumulation**: Patterns and lessons learned compound over time
+3. **Session Continuity**: Work resumes seamlessly after context compaction or session restart
+4. **Quality Improvement**: Captured patterns inform better solutions in future sessions
+
+**Technical Rationale:**
+
+| Decision | Rationale | Trade-off |
+|----------|-----------|-----------|
+| Hexagonal Architecture | Testable boundaries, adapter swapping | Initial complexity |
+| Work Tracker First | Proves infrastructure at small scale | Delayed KM features |
+| Event Sourcing | Full audit trail, temporal queries | Storage growth |
+| NetworkX over Neo4j | Zero dependencies, sufficient scale | Limited query language |
+| FAISS over Pinecone | Local execution, no network | Manual index management |
+| SQLite over Postgres | Single file, no server | Concurrent write limits |
+
+### 1.6 HOW: Implementation Approach and Patterns
+
+**Core Patterns:**
+
+| Pattern | Application | Implementation Notes |
+|---------|-------------|----------------------|
+| Hexagonal Architecture | All layers | Ports in domain, adapters in infrastructure |
+| CQRS | All operations | Commands return events, queries return DTOs |
+| Event Sourcing | Audit and replay | Events are immutable, state is derived |
+| Repository | Aggregate persistence | One repository per aggregate root |
+| Domain Events | Cross-aggregate communication | CloudEvents 1.0 envelope |
+| Saga | Multi-step workflows | Orchestration via event handlers |
+| Unit of Work | Transaction management | Commit/rollback semantic |
+
+**Technology Stack:**
+
+| Component | Technology | Version | Purpose |
+|-----------|------------|---------|---------|
+| Runtime | Python | 3.11+ | Zero-dependency core |
+| Graph | NetworkX | 3.2.1 | Property graph |
+| Vector Search | FAISS | 1.7.4 | Semantic similarity |
+| RDF | RDFLib | 7.0.0 | Knowledge export |
+| Persistence | SQLite | 3.x | Entity and event storage |
+| Testing | pytest | 8.x | BDD scenarios |
+| CLI | argparse | stdlib | Command-line interface |
+
+---
+
+## 2. Bounded Context Diagram
+
+```mermaid
+graph TB
+    subgraph "Jerry Framework Bounded Contexts"
+        subgraph WT["Work Tracker (Core Subdomain)"]
+            Task[Task AR]
+            Phase[Phase AR]
+            Plan[Plan AR]
+            WTRepo[IWorkItemRepository]
+        end
+
+        subgraph KM["Knowledge Management (Supporting Subdomain)"]
+            KI[KnowledgeItem AR]
+            Pattern[Pattern VO]
+            Lesson[Lesson VO]
+            Assumption[Assumption VO]
+            KMRepo[IKnowledgeRepository]
+        end
+
+        subgraph GOV["Governance (Generic Subdomain)"]
+            Agent[Agent]
+            Rule[Rule]
+            Hook[Hook]
+            Constitution[Constitution]
+        end
+
+        subgraph SK["Shared Kernel"]
+            VertexId[VertexId Base]
+            JerryUri[Jerry URI]
+            CloudEvent[CloudEvent Envelope]
+            IGraphStore[IGraphStore Port]
+            IEventStore[IEventStore Port]
+            ISemanticIndex[ISemanticIndex Port]
+        end
+    end
+
+    WT -->|"Customer-Supplier"| KM
+    WT -->|"Conformist"| GOV
+    KM -->|"Conformist"| GOV
+
+    WT -.->|"uses"| SK
+    KM -.->|"uses"| SK
+    GOV -.->|"uses"| SK
+
+    Task -->|"LEARNED_FROM"| Lesson
+    Task -->|"APPLIED_PATTERN"| Pattern
+    Task -->|"VALIDATED_ASSUMPTION"| Assumption
+    Phase -->|"EMERGED_PATTERN"| Pattern
+    Plan -->|"DEPENDS_ON_ASSUMPTION"| Assumption
+```
+
+**Context Relationship Types:**
+
+| Relationship | From | To | Description |
+|--------------|------|-----|-------------|
+| Customer-Supplier | Work Tracker | KM | WT produces events, KM consumes |
+| Conformist | Work Tracker | Governance | WT follows governance rules |
+| Conformist | KM | Governance | KM follows governance rules |
+| Shared Kernel | All | Shared Kernel | Common infrastructure |
+
+---
+
+## 3. Package Diagram
+
+```mermaid
+graph TB
+    subgraph "Hexagonal Architecture"
+        subgraph Interface["interface/ (Primary Adapters)"]
+            CLI[cli/]
+            Skill[skill/]
+            API[api/]
+        end
+
+        subgraph Application["application/ (Use Cases)"]
+            Commands[commands/]
+            Queries[queries/]
+            Handlers[handlers/]
+            EventHandlers[event_handlers/]
+        end
+
+        subgraph Domain["domain/ (Pure Business Logic)"]
+            Aggregates[aggregates/]
+            ValueObjects[value_objects/]
+            Ports[ports/]
+            Events[events/]
+            Services[services/]
+        end
+
+        subgraph Infrastructure["infrastructure/ (Secondary Adapters)"]
+            Persistence[persistence/]
+            Graph[graph/]
+            Search[search/]
+            RDF[rdf/]
+            EventStore[event_store/]
+        end
+    end
+
+    Interface -->|"uses"| Application
+    Application -->|"uses"| Domain
+    Infrastructure -.->|"implements"| Domain
+
+    CLI -->|"dispatches"| Commands
+    CLI -->|"dispatches"| Queries
+    Handlers -->|"uses"| Aggregates
+    Handlers -->|"uses"| Ports
+    Persistence -.->|"implements"| Ports
+    Graph -.->|"implements"| Ports
+    Search -.->|"implements"| Ports
+```
+
+**Package Dependencies (Enforced by Architecture Tests):**
+
+| Package | May Import From | Must Not Import From |
+|---------|-----------------|----------------------|
+| domain/ | stdlib only | application/, infrastructure/, interface/ |
+| application/ | domain/, stdlib | infrastructure/, interface/ |
+| infrastructure/ | domain/, application/, libs | interface/ |
+| interface/ | all inner layers | - |
+
+---
+
+## 4. Domain Model - Class Diagrams
+
+### 4.1 Shared Kernel
+
+```mermaid
+classDiagram
+    class VertexId {
+        <<abstract>>
+        +value: str
+        +__str__() str
+        +__hash__() int
+        +__eq__(other) bool
+    }
+
+    class TaskId {
+        +value: str
+        +validate() bool
+    }
+
+    class PhaseId {
+        +value: str
+        +validate() bool
+    }
+
+    class PlanId {
+        +value: str
+        +validate() bool
+    }
+
+    class KnowledgeId {
+        +value: str
+        +knowledge_type: KnowledgeType
+        +validate() bool
+    }
+
+    class JerryUri {
+        <<value_object>>
+        +partition: str
+        +tenant: str
+        +domain: str
+        +resource_type: str
+        +resource_id: str
+        +version: str | None
+        +parse(uri: str) JerryUri
+        +to_uri() str
+    }
+
+    class CloudEventEnvelope {
+        <<value_object>>
+        +specversion: str = "1.0"
+        +type: str
+        +source: str
+        +subject: str
+        +id: str
+        +time: datetime
+        +datacontenttype: str
+        +data: dict
+        +to_dict() dict
+        +from_dict(d: dict) CloudEventEnvelope
+    }
+
+    class Priority {
+        <<enumeration>>
+        LOW
+        NORMAL
+        HIGH
+        CRITICAL
+    }
+
+    class KnowledgeType {
+        <<enumeration>>
+        PATTERN
+        LESSON
+        ASSUMPTION
+    }
+
+    VertexId <|-- TaskId
+    VertexId <|-- PhaseId
+    VertexId <|-- PlanId
+    VertexId <|-- KnowledgeId
+```
+
+### 4.2 Work Tracker Domain
+
+```mermaid
+classDiagram
+    class Task {
+        <<aggregate_root>>
+        +id: TaskId
+        +title: str
+        +description: str | None
+        +status: TaskStatus
+        +priority: Priority
+        +phase_id: PhaseId | None
+        +created_at: datetime
+        +updated_at: datetime
+        +completed_at: datetime | None
+        +tags: list[Tag]
+        +metadata: dict
+        +create(id, title, ...) Task
+        +update(title, description, ...) Task
+        +transition_to(status) Task
+        +complete() Task
+        +assign_to_phase(phase_id) Task
+        +add_tag(tag) Task
+        +remove_tag(tag) Task
+    }
+
+    class TaskStatus {
+        <<enumeration>>
+        PENDING
+        IN_PROGRESS
+        COMPLETED
+        BLOCKED
+        CANCELLED
+    }
+
+    class Phase {
+        <<aggregate_root>>
+        +id: PhaseId
+        +name: str
+        +description: str | None
+        +status: PhaseStatus
+        +plan_id: PlanId | None
+        +task_ids: list[TaskId]
+        +order: int
+        +created_at: datetime
+        +updated_at: datetime
+        +completed_at: datetime | None
+        +create(id, name, ...) Phase
+        +add_task(task_id) Phase
+        +remove_task(task_id) Phase
+        +complete() Phase
+        +can_complete() bool
+    }
+
+    class PhaseStatus {
+        <<enumeration>>
+        PENDING
+        IN_PROGRESS
+        COMPLETED
+        CANCELLED
+    }
+
+    class Plan {
+        <<aggregate_root>>
+        +id: PlanId
+        +name: str
+        +description: str | None
+        +status: PlanStatus
+        +phase_ids: list[PhaseId]
+        +created_at: datetime
+        +updated_at: datetime
+        +completed_at: datetime | None
+        +assumptions: list[AssumptionRef]
+        +create(id, name, ...) Plan
+        +add_phase(phase_id) Plan
+        +remove_phase(phase_id) Plan
+        +reorder_phases(phase_ids) Plan
+        +complete() Plan
+        +can_complete() bool
+        +track_assumption(assumption_id) Plan
+    }
+
+    class PlanStatus {
+        <<enumeration>>
+        DRAFT
+        ACTIVE
+        COMPLETED
+        ARCHIVED
+    }
+
+    class Tag {
+        <<value_object>>
+        +name: str
+        +category: str | None
+    }
+
+    class AssumptionRef {
+        <<value_object>>
+        +assumption_id: KnowledgeId
+        +status: AssumptionStatus
+        +validated_at: datetime | None
+    }
+
+    class AssumptionStatus {
+        <<enumeration>>
+        UNTESTED
+        VALIDATED
+        INVALIDATED
+    }
+
+    Task --> TaskStatus
+    Task --> Priority
+    Task --> Tag
+    Phase --> PhaseStatus
+    Phase --> TaskId : contains
+    Plan --> PlanStatus
+    Plan --> PhaseId : contains
+    Plan --> AssumptionRef
+    AssumptionRef --> KnowledgeId
+```
+
+### 4.3 Knowledge Management Domain
+
+```mermaid
+classDiagram
+    class KnowledgeItem {
+        <<aggregate_root>>
+        +id: KnowledgeId
+        +type: KnowledgeType
+        +title: str
+        +content: str
+        +summary: str | None
+        +evidence: list[Evidence]
+        +tags: list[Tag]
+        +confidence: float
+        +created_at: datetime
+        +updated_at: datetime
+        +source_uri: JerryUri | None
+        +embedding: list[float] | None
+        +create(id, type, title, content, ...) KnowledgeItem
+        +update_content(content) KnowledgeItem
+        +add_evidence(evidence) KnowledgeItem
+        +update_confidence() KnowledgeItem
+        +add_tag(tag) KnowledgeItem
+        +set_embedding(embedding) KnowledgeItem
+    }
+
+    class Evidence {
+        <<value_object>>
+        +type: EvidenceType
+        +source: JerryUri
+        +confidence: float
+        +description: str
+        +timestamp: datetime
+        +validate() bool
+    }
+
+    class EvidenceType {
+        <<enumeration>>
+        TASK_COMPLETION
+        USER_FEEDBACK
+        PATTERN_MATCH
+        EXPERT_VALIDATION
+        AUTOMATED_TEST
+    }
+
+    class Pattern {
+        <<knowledge_subtype>>
+        +problem: str
+        +solution: str
+        +context: str
+        +consequences: str
+        +related_patterns: list[KnowledgeId]
+        +application_count: int
+        +success_rate: float
+    }
+
+    class Lesson {
+        <<knowledge_subtype>>
+        +situation: str
+        +action: str
+        +result: str
+        +reflection: str
+        +source_task_id: TaskId
+        +applicability: str
+    }
+
+    class Assumption {
+        <<knowledge_subtype>>
+        +statement: str
+        +rationale: str
+        +risk_if_wrong: str
+        +validation_criteria: str
+        +status: AssumptionStatus
+        +validated_at: datetime | None
+        +validated_by: JerryUri | None
+    }
+
+    KnowledgeItem --> KnowledgeType
+    KnowledgeItem --> Evidence
+    KnowledgeItem --> Tag
+    KnowledgeItem --> JerryUri
+    Evidence --> EvidenceType
+    Evidence --> JerryUri
+    Pattern --|> KnowledgeItem
+    Lesson --|> KnowledgeItem
+    Assumption --|> KnowledgeItem
+    Lesson --> TaskId : source
+```
+
+### 4.4 Cross-Domain Integration
+
+```mermaid
+classDiagram
+    class TaskCompletedHandler {
+        +handle(event: TaskCompleted) None
+        -prompt_for_aar(task: Task) AARResponse | None
+        -materialize_lesson(task: Task, aar: AARResponse) KnowledgeItem
+    }
+
+    class PhaseCompletedHandler {
+        +handle(event: PhaseCompleted) None
+        -analyze_patterns(phase: Phase) list[PatternCandidate]
+        -suggest_patterns(candidates: list[PatternCandidate]) None
+    }
+
+    class PatternApplicationHandler {
+        +handle(event: PatternApplied) None
+        -update_application_count(pattern_id: KnowledgeId) None
+        -track_outcome(task_id: TaskId, pattern_id: KnowledgeId) None
+    }
+
+    class AssumptionValidationHandler {
+        +handle(event: TaskCompleted) None
+        -check_assumption_validation(task: Task) list[KnowledgeId]
+        -mark_validated(assumption_id: KnowledgeId, evidence: Evidence) None
+    }
+
+    class KnowledgeMaterializer {
+        +materialize_lesson(task: Task, aar: AARResponse) Lesson
+        +materialize_pattern(analysis: PatternAnalysis) Pattern
+        +materialize_assumption(statement: str, context: str) Assumption
+        -create_graph_edge(from_id: VertexId, to_id: VertexId, label: str) None
+    }
+
+    class AARResponse {
+        <<value_object>>
+        +situation: str
+        +action: str
+        +result: str
+        +reflection: str
+        +suggested_tags: list[str]
+    }
+
+    class PatternCandidate {
+        <<value_object>>
+        +problem: str
+        +solution: str
+        +occurrences: int
+        +similarity_score: float
+        +source_tasks: list[TaskId]
+    }
+
+    TaskCompletedHandler --> KnowledgeMaterializer
+    TaskCompletedHandler --> AARResponse
+    PhaseCompletedHandler --> PatternCandidate
+    PhaseCompletedHandler --> KnowledgeMaterializer
+    PatternApplicationHandler --> KnowledgeId
+    AssumptionValidationHandler --> Evidence
+```
+
+---
+
+## 5. Port Definitions
+
+### 5.1 IWorkItemRepository
+
+```python
+from abc import ABC, abstractmethod
+from typing import Protocol, Iterator
+
+from src.domain.aggregates.task import Task
+from src.domain.aggregates.phase import Phase
+from src.domain.aggregates.plan import Plan
+from src.domain.value_objects.ids import TaskId, PhaseId, PlanId
+
+
+class IWorkItemRepository(Protocol):
+    """
+    Secondary port for Work Tracker aggregate persistence.
+
+    Implementations must ensure:
+    - Atomic operations per aggregate
+    - Optimistic concurrency control
+    - Proper identity map caching
+    """
+
+    # Task operations
+    def get_task(self, task_id: TaskId) -> Task | None:
+        """
+        Retrieve a task by its unique identifier.
+
+        Args:
+            task_id: The unique task identifier.
+
+        Returns:
+            The Task aggregate if found, None otherwise.
+        """
+        ...
+
+    def save_task(self, task: Task) -> None:
+        """
+        Persist a task aggregate.
+
+        Args:
+            task: The Task aggregate to persist.
+
+        Raises:
+            ConcurrencyError: If optimistic lock fails.
+        """
+        ...
+
+    def delete_task(self, task_id: TaskId) -> bool:
+        """
+        Remove a task from persistence.
+
+        Args:
+            task_id: The unique task identifier.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        ...
+
+    def list_tasks(
+        self,
+        phase_id: PhaseId | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0
+    ) -> Iterator[Task]:
+        """
+        List tasks with optional filtering.
+
+        Args:
+            phase_id: Filter by phase assignment.
+            status: Filter by task status.
+            limit: Maximum results to return.
+            offset: Number of results to skip.
+
+        Yields:
+            Task aggregates matching the criteria.
+        """
+        ...
+
+    # Phase operations
+    def get_phase(self, phase_id: PhaseId) -> Phase | None:
+        """Retrieve a phase by its unique identifier."""
+        ...
+
+    def save_phase(self, phase: Phase) -> None:
+        """Persist a phase aggregate."""
+        ...
+
+    def delete_phase(self, phase_id: PhaseId) -> bool:
+        """Remove a phase from persistence."""
+        ...
+
+    def list_phases(
+        self,
+        plan_id: PlanId | None = None,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0
+    ) -> Iterator[Phase]:
+        """List phases with optional filtering."""
+        ...
+
+    # Plan operations
+    def get_plan(self, plan_id: PlanId) -> Plan | None:
+        """Retrieve a plan by its unique identifier."""
+        ...
+
+    def save_plan(self, plan: Plan) -> None:
+        """Persist a plan aggregate."""
+        ...
+
+    def delete_plan(self, plan_id: PlanId) -> bool:
+        """Remove a plan from persistence."""
+        ...
+
+    def list_plans(
+        self,
+        status: str | None = None,
+        limit: int = 100,
+        offset: int = 0
+    ) -> Iterator[Plan]:
+        """List plans with optional filtering."""
+        ...
+```
+
+### 5.2 IKnowledgeRepository
+
+```python
+from abc import ABC, abstractmethod
+from typing import Protocol, Iterator
+
+from src.domain.aggregates.knowledge_item import KnowledgeItem
+from src.domain.value_objects.ids import KnowledgeId
+from src.domain.value_objects.knowledge_type import KnowledgeType
+
+
+class IKnowledgeRepository(Protocol):
+    """
+    Secondary port for Knowledge Management aggregate persistence.
+
+    Implementations must ensure:
+    - Support for all knowledge types (Pattern, Lesson, Assumption)
+    - Tag-based retrieval
+    - Embedding storage and retrieval
+    """
+
+    def get(self, knowledge_id: KnowledgeId) -> KnowledgeItem | None:
+        """
+        Retrieve a knowledge item by its unique identifier.
+
+        Args:
+            knowledge_id: The unique knowledge identifier (PAT-NNN, LES-NNN, ASM-NNN).
+
+        Returns:
+            The KnowledgeItem aggregate if found, None otherwise.
+        """
+        ...
+
+    def save(self, item: KnowledgeItem) -> None:
+        """
+        Persist a knowledge item aggregate.
+
+        Args:
+            item: The KnowledgeItem aggregate to persist.
+
+        Raises:
+            ConcurrencyError: If optimistic lock fails.
+        """
+        ...
+
+    def delete(self, knowledge_id: KnowledgeId) -> bool:
+        """
+        Remove a knowledge item from persistence.
+
+        Args:
+            knowledge_id: The unique knowledge identifier.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        ...
+
+    def list_by_type(
+        self,
+        knowledge_type: KnowledgeType,
+        limit: int = 100,
+        offset: int = 0
+    ) -> Iterator[KnowledgeItem]:
+        """
+        List knowledge items of a specific type.
+
+        Args:
+            knowledge_type: PATTERN, LESSON, or ASSUMPTION.
+            limit: Maximum results to return.
+            offset: Number of results to skip.
+
+        Yields:
+            KnowledgeItem aggregates of the specified type.
+        """
+        ...
+
+    def list_by_tags(
+        self,
+        tags: list[str],
+        match_all: bool = False,
+        limit: int = 100,
+        offset: int = 0
+    ) -> Iterator[KnowledgeItem]:
+        """
+        List knowledge items with specified tags.
+
+        Args:
+            tags: Tags to filter by.
+            match_all: If True, item must have ALL tags; if False, ANY tag.
+            limit: Maximum results to return.
+            offset: Number of results to skip.
+
+        Yields:
+            KnowledgeItem aggregates with matching tags.
+        """
+        ...
+
+    def get_by_source(self, source_uri: str) -> Iterator[KnowledgeItem]:
+        """
+        Retrieve knowledge items linked to a source URI.
+
+        Args:
+            source_uri: Jerry URI of the source entity.
+
+        Yields:
+            KnowledgeItem aggregates linked to the source.
+        """
+        ...
+```
+
+### 5.3 IGraphStore
+
+```python
+from typing import Protocol, Iterator, Any
+from dataclasses import dataclass
+
+from src.domain.value_objects.ids import VertexId
+
+
+@dataclass(frozen=True)
+class Edge:
+    """Represents a directed edge in the graph."""
+    from_id: VertexId
+    to_id: VertexId
+    label: str
+    properties: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Vertex:
+    """Represents a vertex in the graph."""
+    id: VertexId
+    label: str
+    properties: dict[str, Any]
+
+
+class IGraphStore(Protocol):
+    """
+    Secondary port for property graph operations.
+
+    Implementations:
+    - NetworkXGraphStore: In-memory using NetworkX
+    - Future: Neo4jGraphStore for scaled deployments
+    """
+
+    # Vertex operations
+    def add_vertex(
+        self,
+        id: VertexId,
+        label: str,
+        properties: dict[str, Any] | None = None
+    ) -> None:
+        """
+        Add a vertex to the graph.
+
+        Args:
+            id: Unique vertex identifier (TaskId, KnowledgeId, etc.).
+            label: Vertex type label (Task, Pattern, Lesson, etc.).
+            properties: Optional vertex properties.
+
+        Raises:
+            DuplicateVertexError: If vertex already exists.
+        """
+        ...
+
+    def get_vertex(self, id: VertexId) -> Vertex | None:
+        """
+        Retrieve a vertex by its identifier.
+
+        Args:
+            id: Unique vertex identifier.
+
+        Returns:
+            The Vertex if found, None otherwise.
+        """
+        ...
+
+    def update_vertex(
+        self,
+        id: VertexId,
+        properties: dict[str, Any]
+    ) -> None:
+        """
+        Update vertex properties (merge, not replace).
+
+        Args:
+            id: Unique vertex identifier.
+            properties: Properties to merge.
+
+        Raises:
+            VertexNotFoundError: If vertex does not exist.
+        """
+        ...
+
+    def remove_vertex(self, id: VertexId) -> bool:
+        """
+        Remove a vertex and all its edges.
+
+        Args:
+            id: Unique vertex identifier.
+
+        Returns:
+            True if removed, False if not found.
+        """
+        ...
+
+    # Edge operations
+    def add_edge(
+        self,
+        from_id: VertexId,
+        to_id: VertexId,
+        label: str,
+        properties: dict[str, Any] | None = None
+    ) -> Edge:
+        """
+        Add a directed edge between vertices.
+
+        Args:
+            from_id: Source vertex identifier.
+            to_id: Target vertex identifier.
+            label: Edge relationship label (LEARNED_FROM, APPLIED_PATTERN, etc.).
+            properties: Optional edge properties.
+
+        Returns:
+            The created Edge.
+
+        Raises:
+            VertexNotFoundError: If either vertex does not exist.
+        """
+        ...
+
+    def get_edges(
+        self,
+        from_id: VertexId | None = None,
+        to_id: VertexId | None = None,
+        label: str | None = None
+    ) -> Iterator[Edge]:
+        """
+        Retrieve edges with optional filtering.
+
+        Args:
+            from_id: Filter by source vertex.
+            to_id: Filter by target vertex.
+            label: Filter by edge label.
+
+        Yields:
+            Edges matching the criteria.
+        """
+        ...
+
+    def remove_edge(
+        self,
+        from_id: VertexId,
+        to_id: VertexId,
+        label: str
+    ) -> bool:
+        """
+        Remove a specific edge.
+
+        Args:
+            from_id: Source vertex identifier.
+            to_id: Target vertex identifier.
+            label: Edge relationship label.
+
+        Returns:
+            True if removed, False if not found.
+        """
+        ...
+
+    # Traversal operations
+    def traverse(
+        self,
+        start_id: VertexId,
+        edge_label: str | None = None,
+        max_depth: int = 2
+    ) -> list[VertexId]:
+        """
+        Traverse outgoing edges from a vertex.
+
+        Args:
+            start_id: Starting vertex identifier.
+            edge_label: Filter by edge label (None for all).
+            max_depth: Maximum traversal depth.
+
+        Returns:
+            List of reachable vertex identifiers.
+        """
+        ...
+
+    def traverse_incoming(
+        self,
+        end_id: VertexId,
+        edge_label: str | None = None,
+        max_depth: int = 2
+    ) -> list[VertexId]:
+        """
+        Traverse incoming edges to a vertex.
+
+        Args:
+            end_id: Target vertex identifier.
+            edge_label: Filter by edge label (None for all).
+            max_depth: Maximum traversal depth.
+
+        Returns:
+            List of source vertex identifiers.
+        """
+        ...
+
+    def shortest_path(
+        self,
+        from_id: VertexId,
+        to_id: VertexId
+    ) -> list[VertexId] | None:
+        """
+        Find the shortest path between two vertices.
+
+        Args:
+            from_id: Source vertex identifier.
+            to_id: Target vertex identifier.
+
+        Returns:
+            Ordered list of vertex IDs in the path, or None if no path exists.
+        """
+        ...
+
+    # Query operations
+    def query_vertices(
+        self,
+        label: str | None = None,
+        properties: dict[str, Any] | None = None,
+        limit: int = 100
+    ) -> Iterator[Vertex]:
+        """
+        Query vertices by label and/or properties.
+
+        Args:
+            label: Filter by vertex label.
+            properties: Filter by property values (exact match).
+            limit: Maximum results to return.
+
+        Yields:
+            Vertices matching the criteria.
+        """
+        ...
+
+    # Persistence
+    def save(self, path: str) -> None:
+        """Persist graph to disk."""
+        ...
+
+    def load(self, path: str) -> None:
+        """Load graph from disk."""
+        ...
+```
+
+### 5.4 ISemanticIndex
+
+```python
+from typing import Protocol
+from dataclasses import dataclass
+
+from src.domain.value_objects.ids import VertexId
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """Result from semantic search."""
+    id: VertexId
+    score: float  # Similarity score [0.0, 1.0]
+    distance: float  # L2 distance
+
+
+class ISemanticIndex(Protocol):
+    """
+    Secondary port for vector similarity search.
+
+    Implementations:
+    - FAISSSemanticIndex: Using FAISS library
+    - Future: PineconeSemanticIndex for cloud deployments
+    """
+
+    def add(
+        self,
+        id: VertexId,
+        embedding: list[float],
+        metadata: dict | None = None
+    ) -> None:
+        """
+        Add an embedding to the index.
+
+        Args:
+            id: Entity identifier.
+            embedding: Vector embedding (typically 1536 dimensions).
+            metadata: Optional metadata for filtering.
+
+        Raises:
+            DimensionMismatchError: If embedding dimension doesn't match index.
+        """
+        ...
+
+    def update(
+        self,
+        id: VertexId,
+        embedding: list[float]
+    ) -> None:
+        """
+        Update an existing embedding.
+
+        Args:
+            id: Entity identifier.
+            embedding: New vector embedding.
+
+        Raises:
+            NotFoundError: If id not in index.
+        """
+        ...
+
+    def remove(self, id: VertexId) -> bool:
+        """
+        Remove an embedding from the index.
+
+        Args:
+            id: Entity identifier.
+
+        Returns:
+            True if removed, False if not found.
+        """
+        ...
+
+    def search(
+        self,
+        query_embedding: list[float],
+        k: int = 10,
+        threshold: float = 0.0
+    ) -> list[SearchResult]:
+        """
+        Find k-nearest neighbors to the query embedding.
+
+        Args:
+            query_embedding: Query vector.
+            k: Number of results to return.
+            threshold: Minimum similarity score (0.0 = no threshold).
+
+        Returns:
+            List of SearchResult ordered by similarity (descending).
+        """
+        ...
+
+    def search_by_text(
+        self,
+        query_text: str,
+        k: int = 10,
+        threshold: float = 0.0
+    ) -> list[SearchResult]:
+        """
+        Search using text (embedding generated internally).
+
+        Args:
+            query_text: Natural language query.
+            k: Number of results to return.
+            threshold: Minimum similarity score.
+
+        Returns:
+            List of SearchResult ordered by similarity (descending).
+        """
+        ...
+
+    def get_embedding(self, id: VertexId) -> list[float] | None:
+        """
+        Retrieve stored embedding for an entity.
+
+        Args:
+            id: Entity identifier.
+
+        Returns:
+            The embedding vector if found, None otherwise.
+        """
+        ...
+
+    # Persistence
+    def save(self, path: str) -> None:
+        """Persist index to disk."""
+        ...
+
+    def load(self, path: str) -> None:
+        """Load index from disk."""
+        ...
+
+    # Index management
+    def rebuild(self) -> None:
+        """Rebuild index for optimal search performance."""
+        ...
+
+    @property
+    def dimension(self) -> int:
+        """Return the embedding dimension of this index."""
+        ...
+
+    @property
+    def count(self) -> int:
+        """Return the number of embeddings in the index."""
+        ...
+```
+
+### 5.5 IEventStore
+
+```python
+from typing import Protocol, Iterator
+from datetime import datetime
+
+from src.domain.events.base import CloudEventEnvelope
+
+
+class IEventStore(Protocol):
+    """
+    Secondary port for event persistence.
+
+    Implements append-only log semantics for event sourcing.
+    Events are immutable once stored.
+    """
+
+    def append(self, event: CloudEventEnvelope) -> str:
+        """
+        Append an event to the store.
+
+        Args:
+            event: CloudEvents 1.0 compliant event.
+
+        Returns:
+            The assigned event ID.
+
+        Raises:
+            EventStoreError: If append fails.
+        """
+        ...
+
+    def get(self, event_id: str) -> CloudEventEnvelope | None:
+        """
+        Retrieve a specific event by ID.
+
+        Args:
+            event_id: The unique event identifier.
+
+        Returns:
+            The event if found, None otherwise.
+        """
+        ...
+
+    def get_by_subject(
+        self,
+        subject: str,
+        after: datetime | None = None,
+        before: datetime | None = None
+    ) -> Iterator[CloudEventEnvelope]:
+        """
+        Retrieve events for a specific subject (entity).
+
+        Args:
+            subject: The entity URI (Jerry URI format).
+            after: Only events after this time.
+            before: Only events before this time.
+
+        Yields:
+            Events in chronological order.
+        """
+        ...
+
+    def get_by_type(
+        self,
+        event_type: str,
+        after: datetime | None = None,
+        limit: int = 100
+    ) -> Iterator[CloudEventEnvelope]:
+        """
+        Retrieve events of a specific type.
+
+        Args:
+            event_type: The event type (e.g., "work-tracker/TaskCompleted").
+            after: Only events after this time.
+            limit: Maximum events to return.
+
+        Yields:
+            Events in chronological order.
+        """
+        ...
+
+    def replay(
+        self,
+        after: datetime | None = None,
+        before: datetime | None = None,
+        types: list[str] | None = None
+    ) -> Iterator[CloudEventEnvelope]:
+        """
+        Replay events for reconstruction.
+
+        Args:
+            after: Start time for replay.
+            before: End time for replay.
+            types: Filter by event types.
+
+        Yields:
+            Events in chronological order.
+        """
+        ...
+
+    @property
+    def last_sequence(self) -> int:
+        """Return the last sequence number."""
+        ...
+
+    def get_snapshot(self, subject: str) -> dict | None:
+        """
+        Get the latest snapshot for a subject.
+
+        Args:
+            subject: The entity URI.
+
+        Returns:
+            Snapshot data if available, None otherwise.
+        """
+        ...
+
+    def save_snapshot(self, subject: str, data: dict, sequence: int) -> None:
+        """
+        Save a snapshot for faster replay.
+
+        Args:
+            subject: The entity URI.
+            data: Snapshot state.
+            sequence: Event sequence at snapshot time.
+        """
+        ...
+```
+
+### 5.6 IRDFSerializer
+
+```python
+from typing import Protocol
+
+from src.domain.value_objects.ids import VertexId
+
+
+class IRDFSerializer(Protocol):
+    """
+    Secondary port for RDF serialization.
+
+    Enables knowledge export in standard semantic web formats
+    for interoperability with external tools.
+    """
+
+    def add_triple(
+        self,
+        subject: str,
+        predicate: str,
+        object_: str,
+        object_type: str = "uri"
+    ) -> None:
+        """
+        Add a triple to the graph.
+
+        Args:
+            subject: Subject URI.
+            predicate: Predicate URI.
+            object_: Object value.
+            object_type: "uri", "literal", or "typed_literal".
+        """
+        ...
+
+    def add_entity(
+        self,
+        id: VertexId,
+        rdf_type: str,
+        properties: dict
+    ) -> None:
+        """
+        Add an entity with properties.
+
+        Args:
+            id: Entity identifier.
+            rdf_type: RDF type URI.
+            properties: Property name-value pairs.
+        """
+        ...
+
+    def serialize(self, format: str = "turtle") -> str:
+        """
+        Serialize the graph to a string.
+
+        Args:
+            format: Output format ("turtle", "xml", "json-ld", "n3").
+
+        Returns:
+            Serialized RDF string.
+        """
+        ...
+
+    def save(self, path: str, format: str = "turtle") -> None:
+        """
+        Save the graph to a file.
+
+        Args:
+            path: Output file path.
+            format: Output format.
+        """
+        ...
+
+    def load(self, path: str, format: str | None = None) -> None:
+        """
+        Load a graph from file.
+
+        Args:
+            path: Input file path.
+            format: Input format (auto-detected if None).
+        """
+        ...
+
+    def query(self, sparql: str) -> list[dict]:
+        """
+        Execute a SPARQL query.
+
+        Args:
+            sparql: SPARQL query string.
+
+        Returns:
+            List of result bindings.
+        """
+        ...
+
+    def clear(self) -> None:
+        """Clear all triples from the graph."""
+        ...
+
+    @property
+    def triple_count(self) -> int:
+        """Return the number of triples in the graph."""
+        ...
+```
+
+### 5.7 Generic CQRS Handlers
+
+```python
+from typing import Protocol, TypeVar, Generic
+from abc import abstractmethod
+
+C = TypeVar("C")  # Command type
+Q = TypeVar("Q")  # Query type
+R = TypeVar("R")  # Result type
+
+
+class ICommandHandler(Protocol[C, R]):
+    """
+    Primary port for command handling.
+
+    Commands represent write operations that modify state.
+    They return a result and may emit domain events.
+    """
+
+    @abstractmethod
+    def handle(self, command: C) -> R:
+        """
+        Execute the command.
+
+        Args:
+            command: The command to execute.
+
+        Returns:
+            Command result (may include emitted events).
+
+        Raises:
+            ValidationError: If command validation fails.
+            DomainError: If business rules violated.
+        """
+        ...
+
+
+class IQueryHandler(Protocol[Q, R]):
+    """
+    Primary port for query handling.
+
+    Queries represent read operations that return data.
+    They must not modify state.
+    """
+
+    @abstractmethod
+    def handle(self, query: Q) -> R:
+        """
+        Execute the query.
+
+        Args:
+            query: The query to execute.
+
+        Returns:
+            Query result (DTO, not domain entity).
+
+        Raises:
+            NotFoundError: If requested entity not found.
+        """
+        ...
+
+
+class IEventDispatcher(Protocol):
+    """
+    Primary port for event dispatch.
+
+    Routes domain events to registered handlers.
+    """
+
+    def dispatch(self, event: CloudEventEnvelope) -> None:
+        """
+        Dispatch an event to all registered handlers.
+
+        Args:
+            event: The event to dispatch.
+        """
+        ...
+
+    def register(
+        self,
+        event_type: str,
+        handler: callable
+    ) -> None:
+        """
+        Register a handler for an event type.
+
+        Args:
+            event_type: Event type to handle.
+            handler: Callback function.
+        """
+        ...
+
+    def unregister(
+        self,
+        event_type: str,
+        handler: callable
+    ) -> None:
+        """
+        Unregister a handler.
+
+        Args:
+            event_type: Event type.
+            handler: Previously registered callback.
+        """
+        ...
+```
+
+---
+
+## 6. CQRS Operations
+
+### 6.1 Work Tracker Commands
+
+| Command | Purpose | Input Parameters | Output | Events |
+|---------|---------|------------------|--------|--------|
+| CreateTaskCommand | Create new task | title: str, description: str?, priority: Priority, tags: list[str] | TaskId | TaskCreated |
+| UpdateTaskCommand | Update task details | task_id: TaskId, title: str?, description: str?, priority: Priority? | None | TaskUpdated |
+| TransitionTaskCommand | Change task status | task_id: TaskId, new_status: TaskStatus | None | TaskStatusChanged |
+| CompleteTaskCommand | Mark task complete | task_id: TaskId, completion_notes: str? | None | TaskCompleted |
+| AssignTaskToPhaseCommand | Assign task to phase | task_id: TaskId, phase_id: PhaseId | None | TaskAssigned |
+| AddTaskTagCommand | Add tag to task | task_id: TaskId, tag: str | None | TaskTagAdded |
+| DeleteTaskCommand | Delete a task | task_id: TaskId | bool | TaskDeleted |
+| CreatePhaseCommand | Create new phase | name: str, description: str?, plan_id: PlanId? | PhaseId | PhaseCreated |
+| CompletePhaseCommand | Mark phase complete | phase_id: PhaseId | None | PhaseCompleted |
+| ReorderPhasesCommand | Change phase order | plan_id: PlanId, phase_ids: list[PhaseId] | None | PhasesReordered |
+| CreatePlanCommand | Create new plan | name: str, description: str? | PlanId | PlanCreated |
+| ActivatePlanCommand | Activate a plan | plan_id: PlanId | None | PlanActivated |
+| CompletePlanCommand | Mark plan complete | plan_id: PlanId | None | PlanCompleted |
+| ArchivePlanCommand | Archive a plan | plan_id: PlanId | None | PlanArchived |
+| TrackAssumptionCommand | Link assumption to plan | plan_id: PlanId, assumption_id: KnowledgeId | None | AssumptionTracked |
+
+### 6.2 Work Tracker Queries
+
+| Query | Purpose | Input Parameters | Output |
+|-------|---------|------------------|--------|
+| GetTaskQuery | Get task by ID | task_id: TaskId | TaskDTO |
+| ListTasksQuery | List tasks with filters | phase_id: PhaseId?, status: TaskStatus?, tags: list[str]?, page: int, page_size: int | PagedResult[TaskDTO] |
+| GetPhaseQuery | Get phase by ID | phase_id: PhaseId | PhaseDTO |
+| ListPhasesQuery | List phases with filters | plan_id: PlanId?, status: PhaseStatus?, page: int, page_size: int | PagedResult[PhaseDTO] |
+| GetPhaseProgressQuery | Get phase completion % | phase_id: PhaseId | PhaseProgressDTO |
+| GetPlanQuery | Get plan by ID | plan_id: PlanId | PlanDTO |
+| ListPlansQuery | List plans with filters | status: PlanStatus?, page: int, page_size: int | PagedResult[PlanDTO] |
+| GetPlanProgressQuery | Get plan completion % | plan_id: PlanId | PlanProgressDTO |
+| GetTaskHistoryQuery | Get task event history | task_id: TaskId | list[TaskEventDTO] |
+| SearchTasksQuery | Full-text search | query: str, filters: dict?, page: int, page_size: int | PagedResult[TaskDTO] |
+
+### 6.3 Knowledge Management Commands
+
+| Command | Purpose | Input Parameters | Output | Events |
+|---------|---------|------------------|--------|--------|
+| CreatePatternCommand | Create pattern | title: str, problem: str, solution: str, context: str, consequences: str, tags: list[str] | KnowledgeId | PatternCreated |
+| UpdatePatternCommand | Update pattern | pattern_id: KnowledgeId, title: str?, problem: str?, solution: str? | None | PatternUpdated |
+| CreateLessonCommand | Create lesson | title: str, situation: str, action: str, result: str, reflection: str, source_task_id: TaskId?, tags: list[str] | KnowledgeId | LessonCreated |
+| UpdateLessonCommand | Update lesson | lesson_id: KnowledgeId, title: str?, reflection: str? | None | LessonUpdated |
+| CreateAssumptionCommand | Create assumption | title: str, statement: str, rationale: str, risk_if_wrong: str, validation_criteria: str | KnowledgeId | AssumptionCreated |
+| ValidateAssumptionCommand | Mark validated/invalidated | assumption_id: KnowledgeId, validated: bool, evidence: Evidence | None | AssumptionValidated |
+| AddEvidenceCommand | Add evidence | knowledge_id: KnowledgeId, evidence: Evidence | None | EvidenceAdded |
+| AddKnowledgeTagCommand | Add tag | knowledge_id: KnowledgeId, tag: str | None | KnowledgeTagAdded |
+| DeleteKnowledgeCommand | Delete knowledge item | knowledge_id: KnowledgeId | bool | KnowledgeDeleted |
+| LinkKnowledgeCommand | Create relationship | from_id: KnowledgeId, to_id: KnowledgeId, relationship: str | None | KnowledgeLinked |
+| ApplyPatternCommand | Record pattern usage | pattern_id: KnowledgeId, task_id: TaskId, outcome: str? | None | PatternApplied |
+
+### 6.4 Knowledge Management Queries
+
+| Query | Purpose | Input Parameters | Output |
+|-------|---------|------------------|--------|
+| GetKnowledgeQuery | Get by ID | knowledge_id: KnowledgeId | KnowledgeDTO |
+| ListPatternsQuery | List patterns | tags: list[str]?, page: int, page_size: int | PagedResult[PatternDTO] |
+| ListLessonsQuery | List lessons | source_task_id: TaskId?, tags: list[str]?, page: int, page_size: int | PagedResult[LessonDTO] |
+| ListAssumptionsQuery | List assumptions | status: AssumptionStatus?, plan_id: PlanId?, page: int, page_size: int | PagedResult[AssumptionDTO] |
+| SearchKnowledgeQuery | Semantic search | query: str, types: list[KnowledgeType]?, k: int, threshold: float | list[KnowledgeSearchResultDTO] |
+| GetRelatedKnowledgeQuery | Graph traversal | knowledge_id: KnowledgeId, relationship: str?, max_depth: int | list[KnowledgeDTO] |
+| GetPatternApplicationsQuery | Pattern usage history | pattern_id: KnowledgeId, page: int, page_size: int | PagedResult[PatternApplicationDTO] |
+| GetKnowledgeHistoryQuery | Event history | knowledge_id: KnowledgeId | list[KnowledgeEventDTO] |
+| ExportKnowledgeQuery | RDF export | format: str, types: list[KnowledgeType]? | str |
+
+### 6.5 Cross-Domain Commands
+
+| Command | Purpose | Input Parameters | Output | Events |
+|---------|---------|------------------|--------|--------|
+| MaterializeLessonCommand | Task → Lesson | task_id: TaskId, aar_response: AARResponse | KnowledgeId | LessonMaterialized |
+| DiscoverPatternCommand | Phase → Pattern | phase_id: PhaseId, pattern_candidate: PatternCandidate | KnowledgeId | PatternDiscovered |
+| RecordPatternUsageCommand | Track pattern application | task_id: TaskId, pattern_id: KnowledgeId, outcome: str | None | PatternUsageRecorded |
+| ValidateAssumptionFromTaskCommand | Task validates assumption | task_id: TaskId, assumption_id: KnowledgeId, validated: bool | None | AssumptionValidatedByTask |
+
+---
+
+## 7. Use Case Specifications
+
+### 7.1 UC-001: Create and Track Task
+
+| Field | Value |
+|-------|-------|
+| **ID** | UC-001 |
+| **Name** | Create and Track Task |
+| **Primary Actor** | User |
+| **Preconditions** | User has CLI/Skill access |
+| **Postconditions** | Task exists in Work Tracker, graph vertex created |
+
+**Main Success Scenario:**
+
+1. User issues task creation command with title and optional parameters
+2. System validates input (title required, non-empty)
+3. System generates unique TaskId (WORK-NNN format)
+4. System creates Task aggregate with PENDING status
+5. System persists Task to repository
+6. System creates graph vertex for Task
+7. System emits TaskCreated event
+8. System returns TaskId to user
+
+**Alternative Flows:**
+
+- 2a. Validation fails:
+  - 2a1. System returns ValidationError with details
+  - 2a2. Use case ends
+
+- 6a. Graph store unavailable:
+  - 6a1. System logs warning but continues (graph is eventually consistent)
+  - 6a2. Task is marked for graph sync retry
+
+**Events Emitted:**
+- TaskCreated (type: "work-tracker/TaskCreated")
+
+### 7.2 UC-002: Complete Task with AAR
+
+| Field | Value |
+|-------|-------|
+| **ID** | UC-002 |
+| **Name** | Complete Task with After Action Review |
+| **Primary Actor** | User |
+| **Preconditions** | Task exists with IN_PROGRESS status |
+| **Postconditions** | Task marked complete, optional Lesson created |
+
+**Main Success Scenario:**
+
+1. User issues complete command for TaskId
+2. System retrieves Task from repository
+3. System validates status transition (IN_PROGRESS → COMPLETED allowed)
+4. System updates Task status to COMPLETED
+5. System persists updated Task
+6. System emits TaskCompleted event
+7. AAR handler receives event
+8. System prompts user for AAR (situation, action, result, reflection)
+9. User provides AAR response
+10. System creates Lesson from AAR
+11. System creates LEARNED_FROM edge: Task → Lesson
+12. System emits LessonMaterialized event
+13. System returns success to user
+
+**Alternative Flows:**
+
+- 3a. Invalid transition (e.g., PENDING → COMPLETED):
+  - 3a1. System returns InvalidStateError
+  - 3a2. Use case ends
+
+- 8a. User declines AAR:
+  - 8a1. System skips Lesson creation
+  - 8a2. Task is still marked complete
+  - 8a3. Use case ends at step 7
+
+- 9a. AAR response validation fails:
+  - 9a1. System prompts for correction
+  - 9a2. Return to step 9
+
+**Events Emitted:**
+- TaskCompleted
+- LessonMaterialized (if AAR provided)
+
+### 7.3 UC-003: Semantic Knowledge Search
+
+| Field | Value |
+|-------|-------|
+| **ID** | UC-003 |
+| **Name** | Semantic Knowledge Search |
+| **Primary Actor** | User, ps-* Agents |
+| **Preconditions** | Knowledge items exist with embeddings |
+| **Postconditions** | Relevant knowledge returned to actor |
+
+**Main Success Scenario:**
+
+1. Actor issues search query with natural language text
+2. System generates embedding for query text
+3. System queries semantic index for k-nearest neighbors
+4. System filters results by optional type and threshold
+5. System retrieves full KnowledgeItem for each result
+6. System enriches results with graph context (related items)
+7. System returns ranked results with similarity scores
+
+**Alternative Flows:**
+
+- 2a. Embedding generation fails:
+  - 2a1. System falls back to keyword search
+  - 2a2. Continue from step 4 with keyword matches
+
+- 3a. No results above threshold:
+  - 3a1. System returns empty result with suggestion to lower threshold
+  - 3a2. Use case ends
+
+- 6a. Graph traversal times out:
+  - 6a1. System returns results without enrichment
+  - 6a2. Results flagged as "partial"
+
+**Events Emitted:**
+- (Query - no events)
+
+### 7.4 UC-004: Pattern Discovery from Phase
+
+| Field | Value |
+|-------|-------|
+| **ID** | UC-004 |
+| **Name** | Pattern Discovery from Completed Phase |
+| **Primary Actor** | System (automated) |
+| **Preconditions** | Phase completed with 3+ tasks |
+| **Postconditions** | Pattern candidates identified, user notified |
+
+**Main Success Scenario:**
+
+1. PhaseCompleted event triggers handler
+2. System retrieves all tasks from completed phase
+3. System retrieves Lessons linked to those tasks
+4. System analyzes Lessons for common themes (embedding clustering)
+5. System identifies pattern candidates with confidence scores
+6. For each candidate above threshold:
+   - 6a. System creates PatternCandidate record
+   - 6b. System notifies user of discovery
+7. User reviews and optionally confirms pattern
+8. If confirmed:
+   - 8a. System creates Pattern knowledge item
+   - 8b. System creates EMERGED_PATTERN edge: Phase → Pattern
+   - 8c. System emits PatternDiscovered event
+
+**Alternative Flows:**
+
+- 3a. No Lessons linked to tasks:
+  - 3a1. System skips pattern analysis
+  - 3a2. Use case ends
+
+- 5a. No candidates above threshold:
+  - 5a1. System logs analysis result
+  - 5a2. Use case ends without notification
+
+- 7a. User rejects all candidates:
+  - 7a1. Candidates marked as rejected
+  - 7a2. Use case ends
+
+**Events Emitted:**
+- PatternDiscovered (for each confirmed pattern)
+
+### 7.5 UC-005: Apply Pattern to Task
+
+| Field | Value |
+|-------|-------|
+| **ID** | UC-005 |
+| **Name** | Apply Pattern to Task |
+| **Primary Actor** | User |
+| **Preconditions** | Task exists, Pattern exists |
+| **Postconditions** | Pattern application recorded, success rate updated |
+
+**Main Success Scenario:**
+
+1. User indicates pattern application for task
+2. System retrieves Pattern by ID
+3. System retrieves Task by ID
+4. System creates APPLIED_PATTERN edge: Task → Pattern
+5. System increments pattern application count
+6. System emits PatternApplied event
+7. System returns success
+
+**Alternative Flows:**
+
+- 2a. Pattern not found:
+  - 2a1. System suggests similar patterns via semantic search
+  - 2a2. User selects alternative or cancels
+  - 2a3. If selected, continue from step 2
+
+- 3a. Task not found:
+  - 3a1. System returns NotFoundError
+  - 3a2. Use case ends
+
+**Post-Task Update (After Task Completion):**
+- When task completes, system prompts for outcome
+- Outcome updates pattern success rate
+- LessonMaterialized event may reference applied pattern
+
+**Events Emitted:**
+- PatternApplied
+
+---
+
+## 8. Sequence Diagrams
+
+### 8.1 Task Creation Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI Adapter
+    participant CH as CreateTaskHandler
+    participant TR as TaskRepository
+    participant GS as GraphStore
+    participant ES as EventStore
+    participant ED as EventDispatcher
+
+    U->>CLI: create task "Fix bug"
+    CLI->>CLI: Parse and validate input
+    CLI->>CH: CreateTaskCommand(title="Fix bug")
+    CH->>CH: Generate TaskId (WORK-042)
+    CH->>CH: Create Task aggregate
+    CH->>TR: save(task)
+    TR->>TR: Persist to SQLite
+    TR-->>CH: success
+    CH->>GS: add_vertex(TaskId, "Task", props)
+    GS-->>CH: success
+    CH->>CH: Create TaskCreated event
+    CH->>ES: append(event)
+    ES-->>CH: event_id
+    CH->>ED: dispatch(event)
+    ED-->>CH: (async handlers notified)
+    CH-->>CLI: TaskId(WORK-042)
+    CLI-->>U: Created task WORK-042
+```
+
+### 8.2 Task Completion with Lesson Materialization
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI Adapter
+    participant CTH as CompleteTaskHandler
+    participant TR as TaskRepository
+    participant ES as EventStore
+    participant ED as EventDispatcher
+    participant AAR as AARPromptHandler
+    participant MLH as MaterializeLessonHandler
+    participant KR as KnowledgeRepository
+    participant GS as GraphStore
+
+    U->>CLI: complete task WORK-042
+    CLI->>CTH: CompleteTaskCommand(WORK-042)
+    CTH->>TR: get(WORK-042)
+    TR-->>CTH: Task
+    CTH->>CTH: Validate transition
+    CTH->>CTH: task.complete()
+    CTH->>TR: save(task)
+    TR-->>CTH: success
+    CTH->>ES: append(TaskCompleted)
+    CTH->>ED: dispatch(TaskCompleted)
+    ED->>AAR: handle(TaskCompleted)
+
+    AAR->>U: Prompt for AAR
+    U-->>AAR: AARResponse
+    AAR->>MLH: MaterializeLessonCommand
+    MLH->>MLH: Create Lesson from AAR
+    MLH->>KR: save(lesson)
+    KR-->>MLH: success
+    MLH->>GS: add_edge(WORK-042, LES-042, LEARNED_FROM)
+    GS-->>MLH: Edge
+    MLH->>ES: append(LessonMaterialized)
+    MLH->>ED: dispatch(LessonMaterialized)
+    MLH-->>AAR: LES-042
+
+    AAR-->>ED: complete
+    CTH-->>CLI: success
+    CLI-->>U: Task completed, Lesson LES-042 created
+```
+
+### 8.3 Semantic Search Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI Adapter
+    participant QH as SearchKnowledgeHandler
+    participant SI as SemanticIndex
+    participant KR as KnowledgeRepository
+    participant GS as GraphStore
+
+    U->>CLI: search "handling API errors"
+    CLI->>QH: SearchKnowledgeQuery(query="handling API errors", k=5)
+    QH->>SI: search_by_text(query, k=5)
+    SI->>SI: Generate embedding
+    SI->>SI: FAISS kNN search
+    SI-->>QH: [SearchResult(PAT-001, 0.92), SearchResult(LES-015, 0.87), ...]
+
+    loop For each result
+        QH->>KR: get(knowledge_id)
+        KR-->>QH: KnowledgeItem
+        QH->>GS: traverse(knowledge_id, max_depth=1)
+        GS-->>QH: related_ids[]
+    end
+
+    QH->>QH: Build enriched results
+    QH-->>CLI: [KnowledgeSearchResultDTO, ...]
+    CLI-->>U: Display results with scores
+```
+
+### 8.4 Knowledge Graph Traversal
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI Adapter
+    participant QH as GetRelatedKnowledgeHandler
+    participant GS as GraphStore
+    participant KR as KnowledgeRepository
+
+    U->>CLI: related PAT-001 --depth 2
+    CLI->>QH: GetRelatedKnowledgeQuery(PAT-001, max_depth=2)
+    QH->>GS: traverse(PAT-001, max_depth=2)
+    GS->>GS: BFS from PAT-001
+    GS-->>QH: [LES-015, LES-023, ASM-007, WORK-042]
+
+    loop For each vertex_id
+        QH->>KR: get(vertex_id)
+        KR-->>QH: KnowledgeItem | Task
+    end
+
+    QH->>GS: get_edges(from=PAT-001)
+    GS-->>QH: [Edge(PAT-001, LES-015, RELATED_TO), ...]
+
+    QH->>QH: Build graph response
+    QH-->>CLI: RelatedKnowledgeDTO
+    CLI-->>U: Display graph visualization
+```
+
+---
+
+## 9. CloudEvents Schemas
+
+### 9.1 TaskCreated
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "specversion": { "const": "1.0" },
+    "type": { "const": "work-tracker/TaskCreated" },
+    "source": {
+      "type": "string",
+      "pattern": "^jer:jer:work-tracker:system$"
+    },
+    "subject": {
+      "type": "string",
+      "pattern": "^jer:jer:work-tracker:task:WORK-\\d+$"
+    },
+    "id": { "type": "string", "format": "uuid" },
+    "time": { "type": "string", "format": "date-time" },
+    "datacontenttype": { "const": "application/json" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "task_id": { "type": "string", "pattern": "^WORK-\\d+$" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": ["string", "null"] },
+        "status": { "const": "PENDING" },
+        "priority": { "enum": ["LOW", "NORMAL", "HIGH", "CRITICAL"] },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "phase_id": { "type": ["string", "null"] },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["task_id", "title", "status", "priority", "created_at"]
+    }
+  },
+  "required": ["specversion", "type", "source", "subject", "id", "time", "data"]
+}
+```
+
+### 9.2 TaskCompleted
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "specversion": { "const": "1.0" },
+    "type": { "const": "work-tracker/TaskCompleted" },
+    "source": {
+      "type": "string",
+      "pattern": "^jer:jer:work-tracker:system$"
+    },
+    "subject": {
+      "type": "string",
+      "pattern": "^jer:jer:work-tracker:task:WORK-\\d+$"
+    },
+    "id": { "type": "string", "format": "uuid" },
+    "time": { "type": "string", "format": "date-time" },
+    "datacontenttype": { "const": "application/json" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "task_id": { "type": "string", "pattern": "^WORK-\\d+$" },
+        "title": { "type": "string" },
+        "previous_status": { "type": "string" },
+        "completion_notes": { "type": ["string", "null"] },
+        "completed_at": { "type": "string", "format": "date-time" },
+        "duration_hours": { "type": "number" },
+        "phase_id": { "type": ["string", "null"] }
+      },
+      "required": ["task_id", "title", "previous_status", "completed_at"]
+    }
+  },
+  "required": ["specversion", "type", "source", "subject", "id", "time", "data"]
+}
+```
+
+### 9.3 LessonMaterialized
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "specversion": { "const": "1.0" },
+    "type": { "const": "knowledge/LessonMaterialized" },
+    "source": {
+      "type": "string",
+      "pattern": "^jer:jer:knowledge:system$"
+    },
+    "subject": {
+      "type": "string",
+      "pattern": "^jer:jer:knowledge:les:LES-\\d+$"
+    },
+    "id": { "type": "string", "format": "uuid" },
+    "time": { "type": "string", "format": "date-time" },
+    "datacontenttype": { "const": "application/json" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "lesson_id": { "type": "string", "pattern": "^LES-\\d+$" },
+        "title": { "type": "string" },
+        "source_task_id": { "type": "string", "pattern": "^WORK-\\d+$" },
+        "situation": { "type": "string" },
+        "action": { "type": "string" },
+        "result": { "type": "string" },
+        "reflection": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["lesson_id", "title", "source_task_id", "situation", "action", "result", "reflection", "created_at"]
+    }
+  },
+  "required": ["specversion", "type", "source", "subject", "id", "time", "data"]
+}
+```
+
+### 9.4 PatternDiscovered
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "specversion": { "const": "1.0" },
+    "type": { "const": "knowledge/PatternDiscovered" },
+    "source": {
+      "type": "string",
+      "pattern": "^jer:jer:knowledge:system$"
+    },
+    "subject": {
+      "type": "string",
+      "pattern": "^jer:jer:knowledge:pat:PAT-\\d+$"
+    },
+    "id": { "type": "string", "format": "uuid" },
+    "time": { "type": "string", "format": "date-time" },
+    "datacontenttype": { "const": "application/json" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "pattern_id": { "type": "string", "pattern": "^PAT-\\d+$" },
+        "title": { "type": "string" },
+        "problem": { "type": "string" },
+        "solution": { "type": "string" },
+        "context": { "type": "string" },
+        "consequences": { "type": "string" },
+        "source_phase_id": { "type": ["string", "null"] },
+        "source_lessons": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^LES-\\d+$" }
+        },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "discovery_method": { "enum": ["MANUAL", "AUTOMATED_CLUSTERING", "USER_SUGGESTION"] },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["pattern_id", "title", "problem", "solution", "discovery_method", "created_at"]
+    }
+  },
+  "required": ["specversion", "type", "source", "subject", "id", "time", "data"]
+}
+```
+
+---
+
+## 10. BDD Test Specifications
+
+### 10.1 Task Aggregate
+
+```gherkin
+Feature: Task Lifecycle Management
+  As a Jerry Framework user
+  I want to create and manage tasks
+  So that I can track work across Claude Code sessions
+
+  Background:
+    Given the Work Tracker system is initialized
+    And no tasks exist
+
+  Scenario: Create a new task with minimum required fields
+    When I create a task with title "Fix authentication bug"
+    Then a task should be created with ID matching "WORK-\\d+"
+    And the task status should be "PENDING"
+    And the task priority should be "NORMAL"
+    And a TaskCreated event should be emitted
+
+  Scenario: Create a task with all optional fields
+    When I create a task with:
+      | field       | value                    |
+      | title       | Implement user dashboard |
+      | description | Build the main dashboard |
+      | priority    | HIGH                     |
+      | tags        | frontend, ui, sprint-1   |
+    Then a task should be created
+    And the task description should be "Build the main dashboard"
+    And the task priority should be "HIGH"
+    And the task should have 3 tags
+
+  Scenario: Transition task from PENDING to IN_PROGRESS
+    Given a task exists with status "PENDING"
+    When I transition the task to "IN_PROGRESS"
+    Then the task status should be "IN_PROGRESS"
+    And a TaskStatusChanged event should be emitted
+
+  Scenario: Complete a task from IN_PROGRESS
+    Given a task exists with status "IN_PROGRESS"
+    When I complete the task
+    Then the task status should be "COMPLETED"
+    And the task completed_at should be set
+    And a TaskCompleted event should be emitted
+
+  Scenario: Cannot complete task from PENDING status
+    Given a task exists with status "PENDING"
+    When I attempt to complete the task
+    Then an InvalidStateError should be raised
+    And the task status should remain "PENDING"
+
+  Scenario: Cannot transition completed task
+    Given a task exists with status "COMPLETED"
+    When I attempt to transition the task to "IN_PROGRESS"
+    Then an InvalidStateError should be raised
+    And the task status should remain "COMPLETED"
+
+  Scenario: Add tags to existing task
+    Given a task exists with tags "bug"
+    When I add tag "critical" to the task
+    Then the task should have tags "bug, critical"
+    And a TaskTagAdded event should be emitted
+
+  Scenario: Delete a task
+    Given a task exists with ID "WORK-001"
+    When I delete the task
+    Then no task should exist with ID "WORK-001"
+    And a TaskDeleted event should be emitted
+```
+
+### 10.2 Phase Aggregate
+
+```gherkin
+Feature: Phase Lifecycle Management
+  As a Jerry Framework user
+  I want to organize tasks into phases
+  So that I can manage work in logical groups
+
+  Background:
+    Given the Work Tracker system is initialized
+
+  Scenario: Create a phase
+    When I create a phase with name "Implementation"
+    Then a phase should be created with ID matching "PHASE-\\d+"
+    And the phase status should be "PENDING"
+    And a PhaseCreated event should be emitted
+
+  Scenario: Add task to phase
+    Given a phase exists with ID "PHASE-001"
+    And a task exists with ID "WORK-001"
+    When I add task "WORK-001" to phase "PHASE-001"
+    Then the task should be assigned to the phase
+    And a TaskAssigned event should be emitted
+
+  Scenario: Complete phase with all tasks completed
+    Given a phase exists with ID "PHASE-001"
+    And the phase has tasks:
+      | task_id  | status    |
+      | WORK-001 | COMPLETED |
+      | WORK-002 | COMPLETED |
+    When I complete the phase
+    Then the phase status should be "COMPLETED"
+    And a PhaseCompleted event should be emitted
+
+  Scenario: Cannot complete phase with pending tasks
+    Given a phase exists with ID "PHASE-001"
+    And the phase has tasks:
+      | task_id  | status      |
+      | WORK-001 | COMPLETED   |
+      | WORK-002 | IN_PROGRESS |
+    When I attempt to complete the phase
+    Then an InvalidStateError should be raised
+    And the error message should contain "pending tasks"
+
+  Scenario: Phase completion triggers pattern analysis
+    Given a phase exists with 5 completed tasks
+    And 3 tasks have linked lessons
+    When I complete the phase
+    Then pattern analysis should be triggered
+    And the user should be notified of any pattern candidates
+```
+
+### 10.3 KnowledgeItem Aggregate
+
+```gherkin
+Feature: Knowledge Item Management
+  As a Jerry Framework user
+  I want to capture and retrieve knowledge
+  So that I can learn from past experiences
+
+  Background:
+    Given the Knowledge Management system is initialized
+
+  Scenario: Create a lesson from task completion
+    Given a task "WORK-042" was just completed
+    When I provide AAR response:
+      | field      | value                                |
+      | situation  | API was returning 500 errors         |
+      | action     | Added retry logic with backoff       |
+      | result     | Error rate dropped from 5% to 0.1%   |
+      | reflection | Retry patterns should be standard    |
+    Then a lesson should be created with ID matching "LES-\\d+"
+    And a LEARNED_FROM edge should exist from "WORK-042" to the lesson
+    And a LessonMaterialized event should be emitted
+
+  Scenario: Create a pattern manually
+    When I create a pattern with:
+      | field        | value                              |
+      | title        | Retry with Exponential Backoff     |
+      | problem      | Transient failures cause cascading |
+      | solution     | Implement retry with backoff       |
+      | context      | Distributed systems, API calls     |
+      | consequences | Increased latency on failures      |
+    Then a pattern should be created with ID matching "PAT-\\d+"
+    And a PatternCreated event should be emitted
+
+  Scenario: Add evidence to knowledge item
+    Given a lesson exists with ID "LES-001"
+    And confidence is 0.6
+    When I add evidence:
+      | type              | confidence |
+      | TASK_COMPLETION   | 0.8        |
+    Then the evidence should be added
+    And the lesson confidence should be recalculated
+    And an EvidenceAdded event should be emitted
+
+  Scenario: Validate an assumption
+    Given an assumption exists with status "UNTESTED"
+    And validation criteria "API handles 1000 RPS"
+    When I mark the assumption as validated with evidence from "WORK-050"
+    Then the assumption status should be "VALIDATED"
+    And an AssumptionValidated event should be emitted
+
+  Scenario: Semantic search returns relevant results
+    Given knowledge items exist:
+      | id      | type    | content                          |
+      | PAT-001 | PATTERN | Retry with exponential backoff   |
+      | PAT-002 | PATTERN | Circuit breaker pattern          |
+      | LES-001 | LESSON  | Learned about API error handling |
+    When I search for "handling API failures"
+    Then the results should include "PAT-001"
+    And the results should include "LES-001"
+    And results should be ordered by relevance score
+
+  Scenario: Graph traversal finds related knowledge
+    Given knowledge relationships:
+      | from    | to      | relationship |
+      | PAT-001 | LES-001 | RELATED_TO   |
+      | LES-001 | WORK-042| SOURCE_TASK  |
+    When I traverse from "PAT-001" with depth 2
+    Then the results should include "LES-001"
+    And the results should include "WORK-042"
+```
+
+### 10.4 Cross-Domain Integration
+
+```gherkin
+Feature: Cross-Domain Knowledge Flow
+  As a Jerry Framework user
+  I want knowledge to flow between Work Tracker and KM
+  So that completed work automatically enriches the knowledge base
+
+  Background:
+    Given both Work Tracker and KM systems are initialized
+
+  Scenario: Task completion prompts for lesson capture
+    Given a task exists with ID "WORK-042"
+    And the task status is "IN_PROGRESS"
+    When I complete the task
+    Then I should be prompted for After Action Review
+    And the AAR prompt should include task details
+
+  Scenario: Declining AAR still completes task
+    Given a task exists in progress
+    When I complete the task
+    And I decline the AAR prompt
+    Then the task should be marked completed
+    And no lesson should be created
+
+  Scenario: Pattern application is tracked
+    Given a pattern exists with ID "PAT-001"
+    And a task exists with ID "WORK-050"
+    When I record that "PAT-001" was applied to "WORK-050"
+    Then an APPLIED_PATTERN edge should exist
+    And the pattern application count should increment
+    And a PatternApplied event should be emitted
+
+  Scenario: Pattern success rate updates on task completion
+    Given pattern "PAT-001" was applied to task "WORK-050"
+    When I complete task "WORK-050" with outcome "SUCCESS"
+    Then the pattern success rate should be recalculated
+    And the success should be recorded as evidence
+
+  Scenario: Phase completion triggers pattern discovery
+    Given a phase with 5 completed tasks
+    And 4 tasks have lessons with similar themes
+    When the phase is completed
+    Then pattern candidates should be identified
+    And candidates with score > 0.7 should be surfaced
+    And the user should be notified
+
+  Scenario: Plan tracks assumption validation
+    Given a plan exists with tracked assumption "ASM-001"
+    And "ASM-001" has status "UNTESTED"
+    When task "WORK-060" completes and validates "ASM-001"
+    Then the assumption status should be "VALIDATED"
+    And the plan should show updated assumption status
+```
+
+---
+
+## 11. Implementation Plan
+
+### Phase 1: Work Tracker Foundation (Weeks 1-8)
+
+**Deliverables:**
+
+| Week | Deliverable | Files | Acceptance Criteria |
+|------|-------------|-------|---------------------|
+| 1-2 | Domain entities | `src/domain/aggregates/task.py`, `phase.py`, `plan.py` | All BDD scenarios pass |
+| 1-2 | Value objects | `src/domain/value_objects/*.py` | Immutable, validated |
+| 3-4 | Repository port | `src/domain/ports/work_item_repository.py` | Interface complete |
+| 3-4 | SQLite adapter | `src/infrastructure/persistence/sqlite_work_item_repo.py` | CRUD operations work |
+| 5-6 | CQRS commands | `src/application/commands/work_tracker/*.py` | Commands emit events |
+| 5-6 | CQRS queries | `src/application/queries/work_tracker/*.py` | Queries return DTOs |
+| 7-8 | CLI adapter | `src/interface/cli/work_tracker_cli.py` | Full CRUD via CLI |
+| 7-8 | BDD tests | `tests/bdd/work_tracker/*.py` | 100% scenario coverage |
+
+**Dependencies:**
+- Python 3.11+ runtime
+- pytest for testing
+- SQLite (stdlib)
+
+**Risks:**
+- Scope creep into KM features
+- Event schema evolution during development
+
+### Phase 2: Shared Infrastructure (Weeks 9-16)
+
+**Deliverables:**
+
+| Week | Deliverable | Files | Acceptance Criteria |
+|------|-------------|-------|---------------------|
+| 9-10 | Event store port | `src/domain/ports/event_store.py` | CloudEvents 1.0 compliant |
+| 9-10 | SQLite event store | `src/infrastructure/event_store/sqlite_event_store.py` | Append-only, queryable |
+| 11-12 | Graph store port | `src/domain/ports/graph_store.py` | Traversal operations |
+| 11-12 | NetworkX adapter | `src/infrastructure/graph/networkx_graph_store.py` | All port methods implemented |
+| 13-14 | Semantic index port | `src/domain/ports/semantic_index.py` | kNN search |
+| 13-14 | FAISS adapter | `src/infrastructure/search/faiss_semantic_index.py` | Embedding storage/search |
+| 15-16 | RDF serializer port | `src/domain/ports/rdf_serializer.py` | Export to Turtle/JSON-LD |
+| 15-16 | RDFLib adapter | `src/infrastructure/rdf/rdflib_serializer.py` | SPARQL queries |
+
+**Dependencies:**
+- NetworkX 3.2.1
+- FAISS 1.7.4
+- RDFLib 7.0.0
+
+**Risks:**
+- Library compatibility issues
+- Performance not meeting targets
+
+### Phase 3: Knowledge Management Integration (Weeks 17-24)
+
+**Deliverables:**
+
+| Week | Deliverable | Files | Acceptance Criteria |
+|------|-------------|-------|---------------------|
+| 17-18 | KM domain entities | `src/domain/aggregates/knowledge_item.py` | Pattern/Lesson/Assumption types |
+| 17-18 | KM value objects | `src/domain/value_objects/knowledge/*.py` | Evidence, EvidenceType |
+| 19-20 | KM repository | `src/domain/ports/knowledge_repository.py` | Full interface |
+| 19-20 | KM SQLite adapter | `src/infrastructure/persistence/sqlite_knowledge_repo.py` | All operations |
+| 21-22 | KM CQRS | `src/application/commands/km/*.py`, `queries/km/*.py` | All commands/queries |
+| 21-22 | KM event handlers | `src/application/event_handlers/km/*.py` | AAR, pattern analysis |
+| 23-24 | KM CLI | `src/interface/cli/km_cli.py` | Full KM operations |
+| 23-24 | KM SKILL.md | `skills/km/SKILL.md` | Natural language interface |
+
+**Dependencies:**
+- Phase 1 & 2 complete
+- Embedding model selection
+
+**Risks:**
+- AAR adoption rate
+- Pattern detection accuracy
+
+### Phase 4: Advanced Features (Weeks 25-32)
+
+**Deliverables:**
+
+| Week | Deliverable | Files | Acceptance Criteria |
+|------|-------------|-------|---------------------|
+| 25-26 | Cross-domain handlers | `src/application/event_handlers/cross_domain/*.py` | Task→Lesson flow |
+| 25-26 | Graph integration | Enhanced traversal, enriched queries | Performance targets met |
+| 27-28 | HybridRAG | `src/application/services/hybrid_rag.py` | Semantic + graph retrieval |
+| 27-28 | Pattern discovery | `src/application/services/pattern_discovery.py` | Clustering, candidates |
+| 29-30 | SPARQL endpoint | `src/interface/api/sparql_endpoint.py` | External queries |
+| 29-30 | Export/import | `src/application/commands/export.py`, `import.py` | RDF interchange |
+| 31-32 | Integration tests | `tests/integration/*.py` | Full system validation |
+| 31-32 | Documentation | `docs/user-guide/*.md` | Complete user docs |
+
+**Dependencies:**
+- Phase 1-3 complete
+
+**Risks:**
+- HybridRAG complexity
+- SPARQL security
+
+---
+
+## 12. Risk Analysis
+
+### 12.1 Risk Register
+
+| ID | Risk | Probability | Impact | Score | Mitigation |
+|----|------|-------------|--------|-------|------------|
+| R-001 | Performance degradation at scale | Medium | High | 6 | Validate at WT scale first; establish baselines |
+| R-002 | Supernode formation in graph | Medium | High | 6 | Edge count validator; alert at 100 edges |
+| R-003 | Event store scaling limits | Low | Medium | 3 | Measure throughput on WT workload; snapshot strategy |
+| R-004 | User AAR adoption | Medium | Medium | 4 | Track completion rate; streamline UX |
+| R-005 | Schema evolution complexity | Medium | High | 6 | Version envelope pattern; migration scripts |
+| R-006 | Library dependency conflicts | Low | Medium | 3 | Pin versions; isolation testing |
+| R-007 | Pattern detection false positives | Medium | Low | 3 | User confirmation required; confidence thresholds |
+| R-008 | Embedding model quality | Low | High | 4 | Benchmark multiple models; allow swapping |
+| R-009 | Graph query performance | Medium | Medium | 4 | Index hot paths; query caching |
+| R-010 | Cross-context transaction failures | Low | High | 4 | Saga pattern; compensating transactions |
+
+### 12.2 Risk Matrix
+
+```
+Impact
+  ^
+  |
+High   | R-006   R-001   |
+       |   R-008  R-002   |
+       |          R-005   |
+       |          R-010   |
+Medium | R-003   R-004   |
+       |          R-009   |
+       |                  |
+Low    |         R-007   |
+       |                  |
+       +-------------------> Probability
+         Low    Medium  High
+```
+
+### 12.3 Risk Mitigation Strategies
+
+**R-001 Performance Degradation:**
+- Phase 1-2 establishes performance baselines at WT scale (~500 nodes)
+- Performance regression tests in CI
+- Profile and optimize hot paths before KM scale-up
+- Acceptance criteria: <100ms p95 for common operations
+
+**R-002 Supernode Formation:**
+- Implement edge count validator in domain layer
+- Alert when vertex approaches 100 edges
+- Document edge creation guidelines
+- Consider edge bucketing for hot vertices
+
+**R-005 Schema Evolution:**
+- CloudEvents envelope provides version insulation
+- Data payload versioned separately
+- Migration scripts for breaking changes
+- Never delete fields, only deprecate
+
+**R-010 Cross-Context Transactions:**
+- Implement Saga pattern for multi-aggregate operations
+- Each step has compensating action
+- Event-driven coordination (no distributed transactions)
+- Idempotent handlers with deduplication
+
+---
+
+## Appendix A: Technology Stack Reference
+
+| Category | Technology | Version | Purpose | License |
+|----------|------------|---------|---------|---------|
+| Runtime | Python | 3.11+ | Core language | PSF |
+| Graph Store | NetworkX | 3.2.1 | Property graph | BSD |
+| Vector Search | FAISS | 1.7.4 | Semantic index | MIT |
+| RDF | RDFLib | 7.0.0 | Knowledge export | BSD |
+| Persistence | SQLite | 3.x | Relational store | Public Domain |
+| Testing | pytest | 8.x | Test framework | MIT |
+| BDD | pytest-bdd | 7.x | BDD scenarios | MIT |
+| CLI | argparse | stdlib | Command line | PSF |
+| Logging | logging | stdlib | Diagnostics | PSF |
+| JSON | json | stdlib | Serialization | PSF |
+
+## Appendix B: Jerry URI Specification
+
+```
+jerry://{partition}:{tenant}:{domain}:{resource_type}:{resource_id}[/{version}]
+
+Components:
+- partition: Logical partition (default: "jer")
+- tenant: Tenant identifier (default: "jer" for single-tenant)
+- domain: Bounded context name
+- resource_type: Entity type identifier
+- resource_id: Unique identifier within type
+- version: Optional version suffix
+
+Examples:
+- jer:jer:work-tracker:task:WORK-042
+- jer:jer:work-tracker:phase:PHASE-001
+- jer:jer:work-tracker:plan:PLAN-001
+- jer:jer:knowledge:pat:PAT-001
+- jer:jer:knowledge:les:LES-042
+- jer:jer:knowledge:asm:ASM-007
+- jer:jer:governance:agent:orchestrator
+
+Short Form (within same tenant):
+- wt:task:WORK-042
+- km:pat:PAT-001
+```
+
+## Appendix C: CloudEvents Extensions
+
+```json
+{
+  "jerry_extensions": {
+    "x-jerry-correlation-id": {
+      "type": "string",
+      "description": "Correlation ID for distributed tracing"
+    },
+    "x-jerry-causation-id": {
+      "type": "string",
+      "description": "ID of event that caused this event"
+    },
+    "x-jerry-session-id": {
+      "type": "string",
+      "description": "Claude Code session identifier"
+    },
+    "x-jerry-actor": {
+      "type": "string",
+      "description": "Actor that triggered the event (user, agent, system)"
+    },
+    "x-jerry-domain-version": {
+      "type": "string",
+      "description": "Domain model version for schema evolution"
+    }
+  }
+}
+```
+
+## Appendix D: Graph Schema Reference
+
+### Vertex Labels
+
+| Label | Domain | Description | Properties |
+|-------|--------|-------------|------------|
+| Task | Work Tracker | Work item | title, status, priority, created_at |
+| Phase | Work Tracker | Task grouping | name, status, order |
+| Plan | Work Tracker | Phase container | name, status |
+| Pattern | KM | Reusable solution | problem, solution, context, success_rate |
+| Lesson | KM | Learned insight | situation, action, result, reflection |
+| Assumption | KM | Tracked belief | statement, status, risk |
+
+### Edge Labels
+
+| Label | From | To | Description |
+|-------|------|-----|-------------|
+| CONTAINS | Phase | Task | Phase contains task |
+| CONTAINS | Plan | Phase | Plan contains phase |
+| LEARNED_FROM | Lesson | Task | Lesson derived from task |
+| APPLIED_PATTERN | Task | Pattern | Task used pattern |
+| VALIDATED_ASSUMPTION | Task | Assumption | Task validated assumption |
+| EMERGED_PATTERN | Phase | Pattern | Pattern discovered in phase |
+| DEPENDS_ON_ASSUMPTION | Plan | Assumption | Plan depends on assumption |
+| RELATED_TO | Knowledge | Knowledge | Generic relationship |
+| SUPERSEDES | Knowledge | Knowledge | Newer knowledge replaces older |
+
+### Index Definitions
+
+| Index | Vertex/Edge | Properties | Purpose |
+|-------|-------------|------------|---------|
+| idx_task_status | Task | status | Filter by status |
+| idx_task_phase | Task | phase_id | Tasks in phase |
+| idx_phase_plan | Phase | plan_id | Phases in plan |
+| idx_knowledge_type | Pattern/Lesson/Assumption | type | Filter by type |
+| idx_knowledge_tags | Pattern/Lesson/Assumption | tags | Tag-based retrieval |
+| idx_edge_label | All edges | label | Traversal optimization |
+
+---
+
+**Document End**
+
+*Generated by ps-architect v2.0.0 for WORK-034 Entry e-003*

--- a/docs/archive/projects-archive/plans/AGENT_REORGANIZATION_PLAN.md
+++ b/docs/archive/projects-archive/plans/AGENT_REORGANIZATION_PLAN.md
@@ -1,0 +1,331 @@
+# Agent Reorganization Plan - ps-*.md Agents and Enforcement
+
+> **Status:** DRAFT - AWAITING APPROVAL
+> **Created:** 2026-01-08
+> **Author:** Claude (Distinguished Systems Engineer persona)
+> **Related Research:** `docs/research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md`
+
+---
+
+## Executive Summary
+
+This plan reorganizes Jerry's `ps-*.md` agents to implement a **4-tier progressive enforcement model** focusing on **Advisory, Soft, and Medium enforcement** (deferring Hard enforcement). Based on comprehensive research from Anthropic, OpenAI, Google DeepMind, and academic sources.
+
+### Key Design Decisions
+
+| Decision | Choice | Evidence |
+|----------|--------|----------|
+| **Enforcement Model** | 4-Tier Progressive (Advisory → Soft → Medium → Hard) | Industry consensus; AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md |
+| **Primary Emphasis** | Advisory + Soft (75%) | Constitutional AI research; OpenAI Model Spec |
+| **Agent Location** | `.claude/agents/` + `skills/*/agents/` | Claude Code conventions |
+| **Self-Monitoring** | Enable skill-level metrics | DeepMind amplified oversight patterns |
+| **Constitutional Principles** | Create Jerry Constitution | Anthropic Constitutional AI |
+
+---
+
+## 1. Problem Statement (5W1H Analysis)
+
+### WHO is affected?
+- Jerry framework users deploying ps-*.md agents
+- Agent orchestration workflows
+- Future skill developers
+
+### WHAT problem are we solving?
+- Current agents have Hard enforcement references that aren't fully implemented
+- Need working agents with Advisory + Soft + Medium enforcement
+- Architecture skill needs cleanup
+- ps-*.md agents reference non-existent infrastructure
+
+### WHERE does the problem manifest?
+- `skills/problem-solving/agents/ps-*.md` - 8 agent definitions
+- `skills/architecture/SKILL.md` - Hard enforcement references
+- `.claude/agents/` - orchestration layer
+
+### WHEN does it occur?
+- When attempting to invoke ps-* agents via Task tool
+- When agents reference c-009 persistence enforcement that isn't implemented
+- When trying to use Context7 MCP tools that may not be configured
+
+### WHY does it matter?
+- Non-functional agents reduce trust and productivity
+- Missing enforcement creates inconsistent behavior
+- Hard enforcement adds complexity without established soft foundations
+
+### HOW will we solve it?
+1. Implement Jerry Constitution for Advisory principles
+2. Add self-monitoring and reflection to agents
+3. Simplify agents to work without Hard enforcement
+4. Create Medium enforcement via tool restrictions
+5. Defer Hard enforcement until Advisory/Soft/Medium are proven
+
+---
+
+## 2. Current State Analysis
+
+### 2.1 Existing ps-*.md Agents (8 total)
+
+| Agent | Purpose | Current Issues |
+|-------|---------|----------------|
+| `ps-researcher` | Deep research with Context7 | References c-009 hard enforcement, link-artifact CLI |
+| `ps-analyst` | Root cause, trade-offs, FMEA | References non-existent templates |
+| `ps-architect` | ADR creation (Nygard format) | CLI paths hardcoded to ECW |
+| `ps-validator` | Constraint validation | References problem-statement skill |
+| `ps-synthesizer` | ? | Need to analyze |
+| `ps-reviewer` | ? | Need to analyze |
+| `ps-investigator` | ? | Need to analyze |
+| `ps-reporter` | ? | Need to analyze |
+
+### 2.2 Enforcement Tier Analysis
+
+Current state references 4 tiers but only Advisory is partially implemented:
+
+| Tier | Current State | Target State |
+|------|---------------|--------------|
+| **Advisory** | Partial (CLAUDE.md, SKILL.md) | Full constitutional principles |
+| **Soft** | Not implemented | Self-monitoring, warnings, reflection |
+| **Medium** | Not implemented | Tool restrictions, escalation triggers |
+| **Hard** | Referenced but not built | Deferred (not focus of this plan) |
+
+---
+
+## 3. Target Architecture
+
+### 3.1 4-Tier Progressive Enforcement Model
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     JERRY 4-TIER ENFORCEMENT MODEL                           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │  TIER 1: ADVISORY (60% of enforcement)                                  │ │
+│  │  ─────────────────────────────────────────────────────────────────────  │ │
+│  │  • Jerry Constitution (principles)                                      │ │
+│  │  • CLAUDE.md / SKILL.md instructions                                    │ │
+│  │  • Agent persona definitions                                            │ │
+│  │  • Best practice reminders                                              │ │
+│  │  Mechanism: System prompts, skill frontmatter                           │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                    ↓                                         │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │  TIER 2: SOFT (30% of enforcement)                                      │ │
+│  │  ─────────────────────────────────────────────────────────────────────  │ │
+│  │  • Self-monitoring metrics                                              │ │
+│  │  • Reflection prompts before destructive actions                        │ │
+│  │  • Warning messages (non-blocking)                                      │ │
+│  │  • Consent prompts for consequential operations                         │ │
+│  │  Mechanism: Agent self-checks, SKILL.md consent patterns                │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                    ↓                                         │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │  TIER 3: MEDIUM (8% of enforcement)                                     │ │
+│  │  ─────────────────────────────────────────────────────────────────────  │ │
+│  │  • Tool restrictions (allowed-tools in frontmatter)                     │ │
+│  │  • Escalation triggers                                                  │ │
+│  │  • Action logging                                                       │ │
+│  │  • Agent trust levels                                                   │ │
+│  │  Mechanism: Frontmatter tool lists, escalation protocols                │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                    ↓                                         │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │  TIER 4: HARD (2% of enforcement) - DEFERRED                            │ │
+│  │  ─────────────────────────────────────────────────────────────────────  │ │
+│  │  • PreToolUse hooks that block                                          │ │
+│  │  • PostToolUse validation                                               │ │
+│  │  • Forced escalation                                                    │ │
+│  │  • Session termination                                                  │ │
+│  │  Mechanism: Python hooks (NOT IMPLEMENTED YET)                          │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Jerry Constitution v1.0
+
+Create `/docs/governance/JERRY_CONSTITUTION.md` with principles:
+
+**General Principles:**
+1. Maximize user productivity and learning
+2. Respect user autonomy - guide don't control
+3. Persist state to survive context compaction
+4. Ask when uncertain, escalate when consequential
+5. Provide evidence for claims and decisions
+
+**Operational Principles:**
+1. Use filesystem as infinite memory (not context)
+2. Track work in WORKTRACKER.md
+3. Create artifacts, not transient responses
+4. Follow BDD Red/Green/Refactor cycle
+5. Cite authoritative sources
+
+**Agent Principles:**
+1. Agents complete their designated task
+2. Agents persist outputs to filesystem
+3. Agents self-monitor for quality
+4. Agents escalate failures, don't hide them
+5. Agents respect tool restrictions
+
+### 3.3 Simplified Agent Structure
+
+New agent template without hard enforcement dependencies:
+
+```yaml
+---
+name: ps-{function}
+description: {purpose}
+version: "2.0.0"
+enforcement-tier: advisory  # or soft, medium
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  # ... tool list
+output:
+  required: true
+  location: "docs/{category}/{topic-slug}.md"
+self-monitoring:
+  enabled: true
+  metrics: [completion, quality, persistence]
+---
+```
+
+---
+
+## 4. Implementation Phases
+
+### Phase 1: Foundation (AGT-001 to AGT-005)
+
+| ID | Task | Description | BDD |
+|----|------|-------------|-----|
+| AGT-001 | Create Jerry Constitution | `/docs/governance/JERRY_CONSTITUTION.md` | RED: Test principles exist, GREEN: Create file |
+| AGT-002 | Update CLAUDE.md with constitution reference | Add Advisory principles | RED: Check reference, GREEN: Add reference |
+| AGT-003 | Create simplified agent template | Remove hard enforcement references | RED: Template test, GREEN: Create template |
+| AGT-004 | Audit all ps-*.md agents | Document current state vs target | Analysis task |
+| AGT-005 | Define tool restriction matrix | Which agents get which tools | Analysis task |
+
+### Phase 2: Agent Refactoring (AGT-010 to AGT-018)
+
+| ID | Task | Description | BDD |
+|----|------|-------------|-----|
+| AGT-010 | Refactor ps-researcher | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-011 | Refactor ps-analyst | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-012 | Refactor ps-architect | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-013 | Refactor ps-validator | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-014 | Refactor ps-synthesizer | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-015 | Refactor ps-reviewer | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-016 | Refactor ps-investigator | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-017 | Refactor ps-reporter | Simplify to Advisory + Soft + Medium | RED: Invocation test, GREEN: Implement |
+| AGT-018 | Clean up architecture SKILL.md | Remove hard enforcement references | Edit task |
+
+### Phase 3: Soft Enforcement (AGT-020 to AGT-025)
+
+| ID | Task | Description | BDD |
+|----|------|-------------|-----|
+| AGT-020 | Implement self-monitoring interface | Metrics collection for agents | RED: Interface test, GREEN: Implement |
+| AGT-021 | Add reflection prompts | Pre-action self-assessment | RED: Prompt test, GREEN: Implement |
+| AGT-022 | Create warning message patterns | Non-blocking alerts | Design task |
+| AGT-023 | Implement consent request pattern | For consequential operations | RED: Consent test, GREEN: Implement |
+| AGT-024 | Add quality self-assessment | Agents grade their outputs | Design task |
+| AGT-025 | Document soft enforcement patterns | Best practices guide | Documentation |
+
+### Phase 4: Medium Enforcement (AGT-030 to AGT-035)
+
+| ID | Task | Description | BDD |
+|----|------|-------------|-----|
+| AGT-030 | Define trust levels | Agent privilege matrix | Analysis task |
+| AGT-031 | Implement tool restriction enforcement | Validate allowed-tools | RED: Restriction test, GREEN: Implement |
+| AGT-032 | Create escalation trigger patterns | When to escalate to user | Design task |
+| AGT-033 | Add action logging | Audit trail for agent actions | RED: Logging test, GREEN: Implement |
+| AGT-034 | Test trust-based restrictions | Verify enforcement works | Integration test |
+| AGT-035 | Document medium enforcement patterns | Best practices guide | Documentation |
+
+---
+
+## 5. File Structure
+
+### Target Directory Structure
+
+```
+jerry/
+├── docs/
+│   ├── governance/
+│   │   └── JERRY_CONSTITUTION.md           # NEW: Constitutional principles
+│   ├── plans/
+│   │   └── AGENT_REORGANIZATION_PLAN.md    # THIS FILE
+│   └── research/
+│       └── AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md  # EXISTS
+├── .claude/
+│   ├── agents/
+│   │   ├── orchestrator.md                 # EXISTS
+│   │   ├── qa-engineer.md                  # EXISTS
+│   │   └── security-auditor.md             # EXISTS
+│   └── templates/
+│       └── agent-template.md               # NEW: Simplified template
+└── skills/
+    ├── problem-solving/
+    │   ├── SKILL.md                        # UPDATE: Simplify
+    │   └── agents/
+    │       ├── ps-researcher.md            # REFACTOR
+    │       ├── ps-analyst.md               # REFACTOR
+    │       ├── ps-architect.md             # REFACTOR
+    │       ├── ps-validator.md             # REFACTOR
+    │       ├── ps-synthesizer.md           # REFACTOR
+    │       ├── ps-reviewer.md              # REFACTOR
+    │       ├── ps-investigator.md          # REFACTOR
+    │       └── ps-reporter.md              # REFACTOR
+    └── architecture/
+        └── SKILL.md                        # UPDATE: Remove hard enforcement
+```
+
+---
+
+## 6. Success Criteria
+
+### Phase 1 Exit Criteria
+- [ ] Jerry Constitution v1.0 exists and is referenced in CLAUDE.md
+- [ ] Simplified agent template created
+- [ ] All ps-*.md agents audited
+
+### Phase 2 Exit Criteria
+- [ ] All 8 ps-*.md agents refactored to new template
+- [ ] Agents invoke successfully via Task tool
+- [ ] Hard enforcement references removed
+
+### Phase 3 Exit Criteria
+- [ ] Self-monitoring interface implemented
+- [ ] Reflection prompts documented
+- [ ] Soft enforcement patterns guide published
+
+### Phase 4 Exit Criteria
+- [ ] Trust levels defined and documented
+- [ ] Tool restrictions enforced via frontmatter
+- [ ] Escalation patterns documented
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Agents break during refactor | Medium | High | Incremental changes, test each agent |
+| Over-simplification | Low | Medium | Keep core functionality, remove complexity |
+| Missing enforcement gaps | Medium | Medium | Document exceptions, plan for iteration |
+| Context7 MCP unavailable | High | Low | Make Context7 optional, not required |
+
+---
+
+## 8. References
+
+- [AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md](../research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md)
+- [Constitutional AI: Harmlessness from AI Feedback](https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback)
+- [OpenAI Model Spec (2025)](https://model-spec.openai.com/2025-12-18.html)
+- [Google DeepMind Frontier Safety Framework](https://deepmind.google/discover/blog/introducing-the-frontier-safety-framework/)
+
+---
+
+## Document History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-08 | Claude | Initial creation |

--- a/docs/archive/projects-archive/plans/WORKTRACKER_PROPOSAL.md
+++ b/docs/archive/projects-archive/plans/WORKTRACKER_PROPOSAL.md
@@ -1,0 +1,2131 @@
+# Jerry Framework - Implementation Work Tracker (Proposed)
+
+> Granular implementation plan derived from ADR-034 unified design.
+> **Source**: [ADR-034](../decisions/ADR-034-unified-wt-km-implementation.md) | [Unified Design](../design/work-034-e-003-unified-design.md)
+
+**Created**: 2026-01-09
+**Revised**: 2026-01-09
+**Status**: PROPOSED (awaiting approval)
+**Total Duration**: 32 weeks (4 phases)
+**Branch**: TBD (implementation branch)
+
+---
+
+## Architecture & Testing Principles
+
+> **MANDATORY**: All implementation MUST adhere to these principles.
+
+### Architecture Pure Best Practices
+
+| Pattern | Enforcement | Validation |
+|---------|-------------|------------|
+| DDD | Hard | Architecture tests verify bounded contexts |
+| Hexagonal Architecture | Hard | No adapter imports in domain |
+| Event Sourcing | Hard | Events immutable, append-only |
+| CQRS | Hard | Commands return events, queries return DTOs |
+| Repository Pattern | Hard | All data access via ports |
+| Dispatcher Pattern | Hard | Events dispatched, not directly handled |
+| Dependency Injection | Hard | No `new` in domain/application |
+
+### Test Pyramid (Per Feature)
+
+| Level | Count | Focus | Real Data |
+|-------|-------|-------|-----------|
+| Unit | Many | Single class/function | Mocked dependencies |
+| Integration | Medium | Multiple components | Real SQLite |
+| Contract | Few | Port compliance | Interface verification |
+| System | Few | Multi-operation workflows | Full stack |
+| E2E | Few | CLI to persistence | Real everything |
+| Architecture | Always | Layer dependencies | Static analysis |
+
+### BDD Red/Green/Refactor Protocol
+
+```
+1. RED: Write failing test with REAL assertions (no placeholders)
+2. GREEN: Implement MINIMUM code to pass
+3. REFACTOR: Clean up while maintaining GREEN
+4. REPEAT: Until acceptance criteria met
+```
+
+### Test Coverage Requirements
+
+| Scenario Type | Coverage |
+|--------------|----------|
+| Happy path | 100% of use cases |
+| Edge cases | Boundary conditions, empty/max values |
+| Failure scenarios | NotFound, InvalidState, Concurrent |
+| Negative tests | Invalid input, malformed data |
+
+---
+
+## Quick Status
+
+| Phase | Status | Progress |
+|-------|--------|----------|
+| Phase 1: Work Tracker Foundation | PENDING | 0% |
+| Phase 2: Shared Infrastructure | PENDING | 0% |
+| Phase 3: KM Integration | PENDING | 0% |
+| Phase 4: Advanced Features | PENDING | 0% |
+
+---
+
+## Implementation Work Items
+
+| Work Item | Status | Artifacts | Duration | Dependencies |
+|-----------|--------|-----------|----------|--------------|
+| WORK-101 | PENDING | Domain entities, VOs, events | Weeks 1-2 | None |
+| WORK-102 | PENDING | Repository ports & adapters | Weeks 3-4 | WORK-101 |
+| WORK-103 | PENDING | CQRS commands & queries | Weeks 5-6 | WORK-101, WORK-102 |
+| WORK-104 | PENDING | CLI interface, BDD tests | Weeks 7-8 | WORK-103 |
+| WORK-201 | PENDING | Event store port & adapter | Weeks 9-10 | Phase 1 |
+| WORK-202 | PENDING | Graph store (NetworkX) | Weeks 11-12 | WORK-201 |
+| WORK-203 | PENDING | Semantic index (FAISS) | Weeks 13-14 | WORK-202 |
+| WORK-204 | PENDING | RDF serializer (RDFLib) | Weeks 15-16 | WORK-202, WORK-203 |
+| WORK-301 | PENDING | KM domain entities | Weeks 17-18 | Phase 2 |
+| WORK-302 | PENDING | KM repository layer | Weeks 19-20 | WORK-301 |
+| WORK-303 | PENDING | KM CQRS & AAR handlers | Weeks 21-22 | WORK-301, WORK-302 |
+| WORK-304 | PENDING | KM CLI & SKILL.md | Weeks 23-24 | WORK-303 |
+| WORK-401 | PENDING | Cross-domain handlers | Weeks 25-26 | Phase 3 |
+| WORK-402 | PENDING | HybridRAG & pattern discovery | Weeks 27-28 | WORK-401 |
+| WORK-403 | PENDING | SPARQL endpoint & export | Weeks 29-30 | WORK-401 |
+| WORK-404 | PENDING | Documentation & final tests | Weeks 31-32 | All |
+
+---
+
+## Phase 1: Work Tracker Foundation (Weeks 1-8)
+
+> **Goal**: Establish Work Tracker domain with full CQRS, proving hexagonal architecture patterns.
+> **Reference**: [Unified Design 11 Phase 1](../design/work-034-e-003-unified-design.md#phase-1-work-tracker-foundation-weeks-1-8)
+
+### WORK-101: Domain Layer - Shared Kernel & Work Tracker Entities
+
+- **Status**: PENDING
+- **Duration**: Weeks 1-2
+- **Dependencies**: None
+- **Acceptance**: All BDD scenarios pass, architecture tests pass, 95%+ unit coverage
+- **Reference**: [Unified Design 10.1](../design/work-034-e-003-unified-design.md#101-task-aggregate)
+
+#### 101.1: Shared Kernel Value Objects
+
+**Files**: `src/domain/value_objects/`
+
+- [ ] **101.1.1: VertexId Base Class**
+  - [ ] RED: Write failing tests for VertexId
+    - [ ] `tests/unit/domain/value_objects/test_vertex_id.py`
+    - [ ] Test: Valid UUID creation
+    - [ ] Test: Invalid format raises ValueError
+    - [ ] Test: Equality by value (not identity)
+    - [ ] Test: Immutability (frozen dataclass)
+    - [ ] Edge: Empty string raises ValueError
+    - [ ] Edge: Whitespace-only raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/vertex_id.py`
+  - [ ] REFACTOR: Ensure `@dataclass(frozen=True)`, `__hash__` works
+
+- [ ] **101.1.2: Domain-Specific IDs**
+  - [ ] RED: Write failing tests for each ID type
+    - [ ] `tests/unit/domain/value_objects/test_ids.py`
+    - [ ] Test: TaskId creation with valid UUID
+    - [ ] Test: PhaseId creation with valid UUID
+    - [ ] Test: PlanId creation with valid UUID
+    - [ ] Test: KnowledgeId creation with valid UUID
+    - [ ] Test: Each ID type is distinct (TaskId != PhaseId)
+    - [ ] Edge: None value raises TypeError
+    - [ ] Negative: Non-UUID string raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/ids.py`
+  - [ ] REFACTOR: Extract common validation to base class
+
+- [ ] **101.1.3: JerryURI Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_jerry_uri.py`
+    - [ ] Test: Parse `jerry://task/abc-123` correctly
+    - [ ] Test: Parse `jerry://plan/xyz/phase/001` correctly
+    - [ ] Test: Serialize back to string
+    - [ ] Edge: Missing scheme raises ValueError
+    - [ ] Edge: Unknown entity type raises ValueError
+    - [ ] Negative: Malformed URI raises ValueError
+    - [ ] Negative: Empty string raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/jerry_uri.py`
+  - [ ] REFACTOR: Use regex pattern, cache parsed results
+
+- [ ] **101.1.4: Priority Enum**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_priority.py`
+    - [ ] Test: Priority.LOW, MEDIUM, HIGH, CRITICAL exist
+    - [ ] Test: Ordering comparison works (LOW < HIGH)
+    - [ ] Test: From string parsing works
+    - [ ] Edge: Case-insensitive parsing
+    - [ ] Negative: Invalid string raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/priority.py`
+  - [ ] REFACTOR: Implement `__lt__`, `__le__` for comparison
+
+- [ ] **101.1.5: Status Enums**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_status.py`
+    - [ ] Test: TaskStatus states (PENDING, IN_PROGRESS, BLOCKED, COMPLETED, CANCELLED)
+    - [ ] Test: PhaseStatus states (NOT_STARTED, ACTIVE, COMPLETED)
+    - [ ] Test: PlanStatus states (DRAFT, ACTIVE, COMPLETED, ARCHIVED)
+    - [ ] Test: Valid transitions defined
+    - [ ] Negative: Invalid transition raises InvalidStateTransition
+  - [ ] GREEN: Implement `src/domain/value_objects/status.py`
+  - [ ] REFACTOR: Add `can_transition_to()` method
+
+- [ ] **101.1.6: Tag Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_tag.py`
+    - [ ] Test: Valid tag creation
+    - [ ] Test: Normalized to lowercase
+    - [ ] Test: Whitespace trimmed
+    - [ ] Edge: Max length (50 chars) enforced
+    - [ ] Negative: Empty tag raises ValueError
+    - [ ] Negative: Special characters raise ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/tag.py`
+  - [ ] REFACTOR: Add validation regex
+
+- [ ] **101.1.7: Architecture Tests for Value Objects**
+  - [ ] `tests/architecture/test_value_objects_architecture.py`
+  - [ ] Test: All VOs are frozen dataclasses
+  - [ ] Test: No external imports in value_objects/
+  - [ ] Test: All VOs implement `__hash__`
+  - [ ] Test: All VOs implement `__eq__`
+
+#### 101.2: Task Aggregate Root
+
+**Files**: `src/domain/aggregates/task.py`
+
+- [ ] **101.2.1: Task Entity Core**
+  - [ ] RED: Write failing tests for Task creation
+    - [ ] `tests/unit/domain/aggregates/test_task.py`
+    - [ ] Test: Create task with title, description
+    - [ ] Test: Task has auto-generated TaskId
+    - [ ] Test: Task starts in PENDING status
+    - [ ] Test: Task has created_at timestamp
+    - [ ] Test: Task has version=1 (optimistic concurrency)
+    - [ ] Edge: Empty title raises ValueError
+    - [ ] Edge: Title > 200 chars raises ValueError
+    - [ ] Negative: None title raises TypeError
+  - [ ] GREEN: Implement Task.__init__() and Task.create()
+  - [ ] REFACTOR: Extract validation to private methods
+
+- [ ] **101.2.2: Task State Transitions**
+  - [ ] RED: Write failing tests for transitions
+    - [ ] Test: PENDING -> IN_PROGRESS valid
+    - [ ] Test: IN_PROGRESS -> COMPLETED valid
+    - [ ] Test: IN_PROGRESS -> BLOCKED valid
+    - [ ] Test: BLOCKED -> IN_PROGRESS valid
+    - [ ] Test: PENDING -> CANCELLED valid
+    - [ ] Test: transition emits TaskTransitioned event
+    - [ ] Edge: Same state transition is no-op
+    - [ ] Negative: COMPLETED -> IN_PROGRESS raises InvalidStateTransition
+    - [ ] Negative: CANCELLED -> any raises InvalidStateTransition
+  - [ ] GREEN: Implement Task.transition_to()
+  - [ ] REFACTOR: Use state machine pattern
+
+- [ ] **101.2.3: Task Completion**
+  - [ ] RED: Write failing tests for completion
+    - [ ] Test: complete() sets status=COMPLETED
+    - [ ] Test: complete() sets completed_at timestamp
+    - [ ] Test: complete() emits TaskCompleted event
+    - [ ] Test: complete() requires IN_PROGRESS status
+    - [ ] Edge: complete() with notes adds completion notes
+    - [ ] Negative: complete() on PENDING raises InvalidStateTransition
+  - [ ] GREEN: Implement Task.complete()
+  - [ ] REFACTOR: Ensure immutable event creation
+
+- [ ] **101.2.4: Task Phase Assignment**
+  - [ ] RED: Write failing tests for phase assignment
+    - [ ] Test: assign_to_phase() sets phase_id
+    - [ ] Test: assign_to_phase() emits TaskAssignedToPhase event
+    - [ ] Test: assign_to_phase() clears previous assignment
+    - [ ] Edge: Assign to None removes from phase
+    - [ ] Negative: Assign COMPLETED task raises InvalidStateError
+  - [ ] GREEN: Implement Task.assign_to_phase()
+  - [ ] REFACTOR: Add phase validation
+
+- [ ] **101.2.5: Task Update Operations**
+  - [ ] RED: Write failing tests for updates
+    - [ ] Test: update_title() changes title
+    - [ ] Test: update_description() changes description
+    - [ ] Test: set_priority() changes priority
+    - [ ] Test: add_tag() adds tag to set
+    - [ ] Test: remove_tag() removes tag
+    - [ ] Test: Each update increments version
+    - [ ] Test: Each update emits TaskUpdated event
+    - [ ] Edge: Add duplicate tag is no-op
+    - [ ] Negative: Update COMPLETED task raises InvalidStateError
+  - [ ] GREEN: Implement update methods
+  - [ ] REFACTOR: Extract common update pattern
+
+- [ ] **101.2.6: Task Invariant Enforcement**
+  - [ ] RED: Write tests for business invariants
+    - [ ] Test: Task with BLOCKED status must have blocker_reason
+    - [ ] Test: Task with due_date in past raises ValidationError on create
+    - [ ] Test: Completed task has completed_at <= updated_at
+    - [ ] Negative: Clear blocker_reason while BLOCKED raises InvariantViolation
+  - [ ] GREEN: Implement invariant checks
+  - [ ] REFACTOR: Add `_validate_invariants()` method
+
+- [ ] **101.2.7: Task Domain Events**
+  - [ ] RED: Write tests for event structure
+    - [ ] `tests/unit/domain/events/test_task_events.py`
+    - [ ] Test: TaskCreated has task_id, title, created_at
+    - [ ] Test: TaskTransitioned has from_status, to_status
+    - [ ] Test: TaskCompleted has completed_at
+    - [ ] Test: All events are CloudEvents 1.0 compliant
+    - [ ] Test: Events are immutable (frozen)
+  - [ ] GREEN: Implement `src/domain/events/work_tracker.py`
+  - [ ] REFACTOR: Extract CloudEventEnvelope base class
+
+#### 101.3: Phase Aggregate Root
+
+**Files**: `src/domain/aggregates/phase.py`
+
+- [ ] **101.3.1: Phase Entity Core**
+  - [ ] RED: Write failing tests for Phase creation
+    - [ ] `tests/unit/domain/aggregates/test_phase.py`
+    - [ ] Test: Create phase with name, description
+    - [ ] Test: Phase has auto-generated PhaseId
+    - [ ] Test: Phase starts in NOT_STARTED status
+    - [ ] Test: Phase has order_index for sequencing
+    - [ ] Test: Phase has empty task_ids set initially
+    - [ ] Edge: Empty name raises ValueError
+    - [ ] Negative: Duplicate order_index in same plan (handled by Plan AR)
+  - [ ] GREEN: Implement Phase.__init__() and Phase.create()
+  - [ ] REFACTOR: Add validation methods
+
+- [ ] **101.3.2: Phase Task Management**
+  - [ ] RED: Write failing tests for task management
+    - [ ] Test: add_task() adds TaskId to set
+    - [ ] Test: add_task() emits TaskAddedToPhase event
+    - [ ] Test: remove_task() removes TaskId from set
+    - [ ] Test: remove_task() emits TaskRemovedFromPhase event
+    - [ ] Edge: Add already-present task is no-op
+    - [ ] Edge: Remove non-present task is no-op
+    - [ ] Negative: Add task to COMPLETED phase raises InvalidStateError
+  - [ ] GREEN: Implement add_task(), remove_task()
+  - [ ] REFACTOR: Use set operations
+
+- [ ] **101.3.3: Phase Completion Logic**
+  - [ ] RED: Write failing tests for completion
+    - [ ] Test: complete() sets status=COMPLETED
+    - [ ] Test: complete() emits PhaseCompleted event
+    - [ ] Test: complete() requires ACTIVE status
+    - [ ] Test: complete() requires all tasks completed (or validates via callback)
+    - [ ] Edge: complete(force=True) completes regardless of tasks
+    - [ ] Negative: complete() with incomplete tasks raises PhaseNotCompletable
+  - [ ] GREEN: Implement Phase.complete()
+  - [ ] REFACTOR: Add task completion callback
+
+- [ ] **101.3.4: Phase State Transitions**
+  - [ ] RED: Write failing tests for phase transitions
+    - [ ] Test: NOT_STARTED -> ACTIVE valid
+    - [ ] Test: ACTIVE -> COMPLETED valid (via complete())
+    - [ ] Test: activate() emits PhaseActivated event
+    - [ ] Negative: NOT_STARTED -> COMPLETED raises InvalidStateTransition
+    - [ ] Negative: COMPLETED -> ACTIVE raises InvalidStateTransition
+  - [ ] GREEN: Implement Phase.activate()
+  - [ ] REFACTOR: Add state machine
+
+#### 101.4: Plan Aggregate Root
+
+**Files**: `src/domain/aggregates/plan.py`
+
+- [ ] **101.4.1: Plan Entity Core**
+  - [ ] RED: Write failing tests for Plan creation
+    - [ ] `tests/unit/domain/aggregates/test_plan.py`
+    - [ ] Test: Create plan with name, description
+    - [ ] Test: Plan has auto-generated PlanId
+    - [ ] Test: Plan starts in DRAFT status
+    - [ ] Test: Plan has empty phases list initially
+    - [ ] Test: Plan has empty assumptions set
+    - [ ] Edge: Empty name raises ValueError
+    - [ ] Edge: Name > 100 chars raises ValueError
+  - [ ] GREEN: Implement Plan.__init__() and Plan.create()
+  - [ ] REFACTOR: Add metadata fields
+
+- [ ] **101.4.2: Plan Phase Management**
+  - [ ] RED: Write failing tests for phase management
+    - [ ] Test: add_phase() adds PhaseId with order
+    - [ ] Test: add_phase() emits PhaseAddedToPlan event
+    - [ ] Test: remove_phase() removes PhaseId
+    - [ ] Test: reorder_phases() updates order_index values
+    - [ ] Test: get_phases() returns sorted by order_index
+    - [ ] Edge: Add phase at specific position shifts others
+    - [ ] Negative: Add phase to COMPLETED plan raises InvalidStateError
+    - [ ] Negative: Remove last phase raises PlanRequiresPhase
+  - [ ] GREEN: Implement add_phase(), remove_phase(), reorder_phases()
+  - [ ] REFACTOR: Use OrderedDict or sorted list
+
+- [ ] **101.4.3: Plan Assumption Tracking**
+  - [ ] RED: Write failing tests for assumptions
+    - [ ] Test: track_assumption() adds assumption text
+    - [ ] Test: track_assumption() emits AssumptionTracked event
+    - [ ] Test: get_assumptions() returns all assumptions
+    - [ ] Test: validate_assumption() marks as validated/invalidated
+    - [ ] Edge: Duplicate assumption text is no-op
+    - [ ] Negative: Empty assumption text raises ValueError
+  - [ ] GREEN: Implement assumption methods
+  - [ ] REFACTOR: Create Assumption value object
+
+- [ ] **101.4.4: Plan State Transitions**
+  - [ ] RED: Write failing tests for plan transitions
+    - [ ] Test: DRAFT -> ACTIVE valid (via activate())
+    - [ ] Test: ACTIVE -> COMPLETED valid (via complete())
+    - [ ] Test: ACTIVE -> ARCHIVED valid (via archive())
+    - [ ] Test: activate() emits PlanActivated event
+    - [ ] Test: complete() requires all phases completed
+    - [ ] Negative: DRAFT -> COMPLETED raises InvalidStateTransition
+    - [ ] Negative: ARCHIVED -> any raises InvalidStateTransition
+  - [ ] GREEN: Implement activate(), complete(), archive()
+  - [ ] REFACTOR: Add state machine
+
+#### 101.5: Domain Events (CloudEvents 1.0)
+
+**Files**: `src/domain/events/`
+
+- [ ] **101.5.1: CloudEventEnvelope Base**
+  - [ ] RED: Write failing tests for envelope
+    - [ ] `tests/unit/domain/events/test_cloud_event_envelope.py`
+    - [ ] Test: Envelope has specversion="1.0"
+    - [ ] Test: Envelope has type (e.g., "jerry.task.created")
+    - [ ] Test: Envelope has source (e.g., "jerry://worktracker")
+    - [ ] Test: Envelope has id (UUID)
+    - [ ] Test: Envelope has time (ISO 8601)
+    - [ ] Test: Envelope has data (event payload)
+    - [ ] Test: Envelope serializes to JSON
+    - [ ] Edge: Missing required field raises ValidationError
+  - [ ] GREEN: Implement `src/domain/events/base.py`
+  - [ ] REFACTOR: Add JSON schema validation
+
+- [ ] **101.5.2: Work Tracker Events**
+  - [ ] RED: Write failing tests for each event
+    - [ ] `tests/unit/domain/events/test_work_tracker_events.py`
+    - [ ] Test: TaskCreated, TaskUpdated, TaskTransitioned, TaskCompleted
+    - [ ] Test: PhaseCreated, PhaseActivated, PhaseCompleted
+    - [ ] Test: PlanCreated, PlanActivated, PlanCompleted, PlanArchived
+    - [ ] Test: TaskAssignedToPhase, TaskRemovedFromPhase
+    - [ ] Test: Each event wraps in CloudEventEnvelope
+    - [ ] Test: Events are immutable
+  - [ ] GREEN: Implement `src/domain/events/work_tracker.py`
+  - [ ] REFACTOR: Add factory methods
+
+- [ ] **101.5.3: Contract Tests for Events**
+  - [ ] `tests/contract/events/test_event_schema.py`
+  - [ ] Test: All events validate against JSON schema
+  - [ ] Test: Events can be serialized/deserialized
+  - [ ] Test: Event versioning (v1 schema)
+
+#### 101.6: Domain Exceptions
+
+**Files**: `src/domain/exceptions.py`
+
+- [ ] **101.6.1: Exception Hierarchy**
+  - [ ] RED: Write failing tests for exceptions
+    - [ ] `tests/unit/domain/test_exceptions.py`
+    - [ ] Test: DomainError is base class
+    - [ ] Test: NotFoundError has entity_type, entity_id
+    - [ ] Test: InvalidStateError has current_state, attempted_action
+    - [ ] Test: InvalidStateTransition has from_state, to_state
+    - [ ] Test: InvariantViolation has invariant_name, details
+    - [ ] Test: ConcurrencyError has expected_version, actual_version
+    - [ ] Test: ValidationError has field_name, message
+  - [ ] GREEN: Implement exception classes
+  - [ ] REFACTOR: Add error codes for machine-readable handling
+
+#### 101.7: Architecture Tests for Domain Layer
+
+**Files**: `tests/architecture/`
+
+- [ ] **101.7.1: Layer Dependency Tests**
+  - [ ] `tests/architecture/test_domain_architecture.py`
+  - [ ] Test: domain/ has NO imports from application/
+  - [ ] Test: domain/ has NO imports from infrastructure/
+  - [ ] Test: domain/ has NO imports from interface/
+  - [ ] Test: domain/ only uses stdlib imports
+  - [ ] Test: All aggregates extend AggregateRoot base
+  - [ ] Test: All value objects are frozen dataclasses
+
+- [ ] **101.7.2: DDD Pattern Compliance**
+  - [ ] `tests/architecture/test_ddd_patterns.py`
+  - [ ] Test: Aggregates have private setters
+  - [ ] Test: Aggregates expose behavior methods, not data
+  - [ ] Test: Value objects are immutable
+  - [ ] Test: Domain events are past-tense named
+
+---
+
+### WORK-102: Repository Layer - Ports & SQLite Adapters
+
+- **Status**: PENDING
+- **Duration**: Weeks 3-4
+- **Dependencies**: WORK-101
+- **Acceptance**: All CRUD operations work, integration tests pass, 95%+ coverage
+- **Reference**: [Unified Design 5.1](../design/work-034-e-003-unified-design.md#51-iworkitemrepository)
+
+#### 102.1: Repository Port Definitions
+
+**Files**: `src/domain/ports/`
+
+- [ ] **102.1.1: IWorkItemRepository Port**
+  - [ ] RED: Write failing tests for port interface
+    - [ ] `tests/unit/domain/ports/test_work_item_repository.py`
+    - [ ] Test: Interface defines get_task(id) -> Task | None
+    - [ ] Test: Interface defines save_task(task) -> None
+    - [ ] Test: Interface defines delete_task(id) -> bool
+    - [ ] Test: Interface defines list_tasks(filters) -> List[Task]
+    - [ ] Test: Same methods for Phase and Plan
+    - [ ] Contract: Port is abstract (ABC)
+  - [ ] GREEN: Implement `src/domain/ports/work_item_repository.py`
+  - [ ] REFACTOR: Add type hints, docstrings
+
+- [ ] **102.1.2: IUnitOfWork Port**
+  - [ ] RED: Write failing tests for UoW interface
+    - [ ] `tests/unit/domain/ports/test_unit_of_work.py`
+    - [ ] Test: Interface defines begin() context manager
+    - [ ] Test: Interface defines commit()
+    - [ ] Test: Interface defines rollback()
+    - [ ] Test: Interface provides repository property
+    - [ ] Contract: Commit on exit, rollback on exception
+  - [ ] GREEN: Implement `src/domain/ports/unit_of_work.py`
+  - [ ] REFACTOR: Add async support preparation
+
+#### 102.2: SQLite Repository Adapter
+
+**Files**: `src/infrastructure/persistence/`
+
+- [ ] **102.2.1: Database Schema Migration**
+  - [ ] RED: Write failing migration tests
+    - [ ] `tests/integration/persistence/test_migrations.py`
+    - [ ] Test: Migration creates tasks table
+    - [ ] Test: Migration creates phases table
+    - [ ] Test: Migration creates plans table
+    - [ ] Test: Migration creates task_tags junction table
+    - [ ] Test: Migration is idempotent
+    - [ ] Edge: Run migration on existing DB does nothing
+    - [ ] Negative: Invalid migration raises MigrationError
+  - [ ] GREEN: Implement `migrations/001_work_tracker_schema.sql`
+  - [ ] REFACTOR: Add migration versioning
+
+- [ ] **102.2.2: Task Repository CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/persistence/test_sqlite_task_repo.py`
+    - [ ] Test: save_task() inserts new task
+    - [ ] Test: save_task() updates existing task
+    - [ ] Test: get_task() returns task by ID
+    - [ ] Test: get_task() returns None for missing ID
+    - [ ] Test: delete_task() removes task
+    - [ ] Test: delete_task() returns False for missing ID
+    - [ ] Test: list_tasks() returns all tasks
+    - [ ] Test: list_tasks(status=) filters by status
+    - [ ] Test: list_tasks(priority=) filters by priority
+    - [ ] Test: list_tasks(tags=) filters by tags
+    - [ ] Edge: Concurrent update detected (version mismatch)
+    - [ ] Negative: Save with stale version raises ConcurrencyError
+  - [ ] GREEN: Implement SQLite adapter task methods
+  - [ ] REFACTOR: Extract SQL to constants, add parameterization
+
+- [ ] **102.2.3: Phase Repository CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/persistence/test_sqlite_phase_repo.py`
+    - [ ] Test: save_phase() inserts/updates
+    - [ ] Test: get_phase() returns phase
+    - [ ] Test: delete_phase() removes phase
+    - [ ] Test: list_phases() returns phases
+    - [ ] Test: list_phases(plan_id=) filters by plan
+    - [ ] Test: Cascade: delete phase removes task associations
+    - [ ] Edge: Get phase with many tasks is performant
+    - [ ] Negative: Delete phase with orphan tasks option
+  - [ ] GREEN: Implement SQLite adapter phase methods
+  - [ ] REFACTOR: Add indexing for plan_id
+
+- [ ] **102.2.4: Plan Repository CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/persistence/test_sqlite_plan_repo.py`
+    - [ ] Test: save_plan() inserts/updates
+    - [ ] Test: get_plan() returns plan with phases
+    - [ ] Test: delete_plan() removes plan
+    - [ ] Test: list_plans() returns plans
+    - [ ] Test: list_plans(status=) filters by status
+    - [ ] Test: Cascade: delete plan deletes phases
+    - [ ] Edge: Get plan with nested structure
+    - [ ] Negative: Delete active plan raises ActivePlanError
+  - [ ] GREEN: Implement SQLite adapter plan methods
+  - [ ] REFACTOR: Add eager loading for phases
+
+- [ ] **102.2.5: Optimistic Concurrency**
+  - [ ] RED: Write failing tests for concurrency
+    - [ ] `tests/integration/persistence/test_concurrency.py`
+    - [ ] Test: Save increments version
+    - [ ] Test: Save with outdated version fails
+    - [ ] Test: Error includes expected vs actual version
+    - [ ] Negative: Concurrent updates detected
+  - [ ] GREEN: Implement version checking in save methods
+  - [ ] REFACTOR: Add retry logic option
+
+#### 102.3: Unit of Work Implementation
+
+**Files**: `src/infrastructure/persistence/sqlite_unit_of_work.py`
+
+- [ ] **102.3.1: Transaction Management**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/persistence/test_sqlite_unit_of_work.py`
+    - [ ] Test: Begin starts transaction
+    - [ ] Test: Commit persists all changes
+    - [ ] Test: Rollback reverts all changes
+    - [ ] Test: Context manager auto-commits on success
+    - [ ] Test: Context manager auto-rollbacks on exception
+    - [ ] Edge: Nested transactions (savepoints)
+    - [ ] Negative: Commit on failed UoW raises UnitOfWorkError
+  - [ ] GREEN: Implement SQLiteUnitOfWork
+  - [ ] REFACTOR: Add connection pooling
+
+#### 102.4: Contract Tests for Repository
+
+**Files**: `tests/contract/`
+
+- [ ] **102.4.1: Repository Port Compliance**
+  - [ ] `tests/contract/persistence/test_repository_contract.py`
+  - [ ] Test: SQLite adapter implements all IWorkItemRepository methods
+  - [ ] Test: Return types match port signatures
+  - [ ] Test: Exceptions match port specifications
+  - [ ] Run contract against in-memory and file SQLite
+
+---
+
+### WORK-103: CQRS Implementation - Commands & Queries
+
+- **Status**: PENDING
+- **Duration**: Weeks 5-6
+- **Dependencies**: WORK-101, WORK-102
+- **Acceptance**: All commands emit events, queries return DTOs, handlers tested
+- **Reference**: [Unified Design 6.1-6.2](../design/work-034-e-003-unified-design.md#61-work-tracker-commands)
+
+#### 103.1: Command Definitions
+
+**Files**: `src/application/commands/work_tracker/`
+
+- [ ] **103.1.1: Task Commands**
+  - [ ] RED: Write failing tests for command structures
+    - [ ] `tests/unit/application/commands/test_task_commands.py`
+    - [ ] Test: CreateTaskCommand has title, description, priority
+    - [ ] Test: UpdateTaskCommand has task_id, optional fields
+    - [ ] Test: TransitionTaskCommand has task_id, target_status
+    - [ ] Test: CompleteTaskCommand has task_id, optional notes
+    - [ ] Test: AssignTaskToPhaseCommand has task_id, phase_id
+    - [ ] Test: Commands are immutable (frozen dataclass)
+    - [ ] Negative: Invalid command data raises ValidationError
+  - [ ] GREEN: Implement command classes
+  - [ ] REFACTOR: Add validation decorators
+
+- [ ] **103.1.2: Phase Commands**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/commands/test_phase_commands.py`
+    - [ ] Test: CreatePhaseCommand has name, plan_id, order
+    - [ ] Test: CompletePhaseCommand has phase_id
+    - [ ] Test: ActivatePhaseCommand has phase_id
+  - [ ] GREEN: Implement command classes
+  - [ ] REFACTOR: Ensure consistency
+
+- [ ] **103.1.3: Plan Commands**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/commands/test_plan_commands.py`
+    - [ ] Test: CreatePlanCommand has name, description
+    - [ ] Test: ActivatePlanCommand has plan_id
+    - [ ] Test: CompletePlanCommand has plan_id
+  - [ ] GREEN: Implement command classes
+  - [ ] REFACTOR: Add builder pattern option
+
+#### 103.2: Command Handlers
+
+**Files**: `src/application/handlers/commands/work_tracker/`
+
+- [ ] **103.2.1: CreateTaskHandler**
+  - [ ] RED: Write failing unit tests (mocked repo)
+    - [ ] `tests/unit/application/handlers/test_create_task_handler.py`
+    - [ ] Test: Handler creates Task via factory
+    - [ ] Test: Handler saves Task via repository
+    - [ ] Test: Handler dispatches TaskCreated event
+    - [ ] Test: Handler returns TaskId
+    - [ ] Edge: Handler rolls back on dispatch failure
+    - [ ] Negative: Duplicate task title handling
+  - [ ] GREEN: Implement CreateTaskCommandHandler
+  - [ ] REFACTOR: Extract common handler pattern
+
+- [ ] **103.2.2: UpdateTaskHandler**
+  - [ ] RED: Write failing unit tests
+    - [ ] `tests/unit/application/handlers/test_update_task_handler.py`
+    - [ ] Test: Handler fetches existing Task
+    - [ ] Test: Handler applies updates
+    - [ ] Test: Handler saves updated Task
+    - [ ] Test: Handler dispatches TaskUpdated event
+    - [ ] Negative: Task not found raises NotFoundError
+    - [ ] Negative: Stale version raises ConcurrencyError
+  - [ ] GREEN: Implement UpdateTaskCommandHandler
+  - [ ] REFACTOR: Use apply pattern
+
+- [ ] **103.2.3: TransitionTaskHandler**
+  - [ ] RED: Write failing unit tests
+    - [ ] `tests/unit/application/handlers/test_transition_task_handler.py`
+    - [ ] Test: Handler transitions task status
+    - [ ] Test: Handler dispatches TaskTransitioned event
+    - [ ] Negative: Invalid transition raises InvalidStateTransition
+    - [ ] Negative: Task not found raises NotFoundError
+  - [ ] GREEN: Implement TransitionTaskCommandHandler
+  - [ ] REFACTOR: Add transition validation
+
+- [ ] **103.2.4: CompleteTaskHandler**
+  - [ ] RED: Write failing unit tests
+    - [ ] `tests/unit/application/handlers/test_complete_task_handler.py`
+    - [ ] Test: Handler completes task
+    - [ ] Test: Handler dispatches TaskCompleted event
+    - [ ] Negative: Complete non-IN_PROGRESS raises InvalidStateError
+  - [ ] GREEN: Implement CompleteTaskCommandHandler
+  - [ ] REFACTOR: Add completion notes handling
+
+- [ ] **103.2.5: Phase and Plan Handlers**
+  - [ ] RED: Write failing unit tests for each handler
+    - [ ] CreatePhaseHandler, CompletePhaseHandler
+    - [ ] CreatePlanHandler, ActivatePlanHandler, CompletePlanHandler
+    - [ ] Tests follow same pattern as task handlers
+  - [ ] GREEN: Implement all handlers
+  - [ ] REFACTOR: Extract base handler class
+
+#### 103.3: Query Definitions and Handlers
+
+**Files**: `src/application/queries/work_tracker/`, `src/application/dtos/`
+
+- [ ] **103.3.1: DTOs**
+  - [ ] RED: Write failing tests for DTOs
+    - [ ] `tests/unit/application/dtos/test_work_tracker_dtos.py`
+    - [ ] Test: TaskDTO has all display fields
+    - [ ] Test: PhaseDTO has phase fields + task count
+    - [ ] Test: PlanDTO has plan fields + phase list
+    - [ ] Test: DTOs are immutable
+    - [ ] Test: DTOs have from_entity() factory
+  - [ ] GREEN: Implement `src/application/dtos/work_tracker.py`
+  - [ ] REFACTOR: Add serialization methods
+
+- [ ] **103.3.2: Task Queries**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/queries/test_task_queries.py`
+    - [ ] Test: GetTaskQuery has task_id
+    - [ ] Test: ListTasksQuery has filters (status, priority, tags)
+    - [ ] Test: GetTaskHistoryQuery has task_id
+  - [ ] GREEN: Implement query classes
+  - [ ] REFACTOR: Add pagination to list queries
+
+- [ ] **103.3.3: Query Handlers**
+  - [ ] RED: Write failing unit tests (mocked repo)
+    - [ ] `tests/unit/application/handlers/queries/test_task_query_handlers.py`
+    - [ ] Test: GetTaskQueryHandler returns TaskDTO
+    - [ ] Test: GetTaskQueryHandler returns None for missing
+    - [ ] Test: ListTasksQueryHandler returns List[TaskDTO]
+    - [ ] Test: ListTasksQueryHandler applies filters
+    - [ ] Test: GetTaskHistoryQueryHandler returns events
+    - [ ] Edge: Empty list returned for no matches
+  - [ ] GREEN: Implement query handlers
+  - [ ] REFACTOR: Add caching layer preparation
+
+#### 103.4: Event Dispatcher
+
+**Files**: `src/domain/ports/event_dispatcher.py`, `src/infrastructure/messaging/`
+
+- [ ] **103.4.1: Event Dispatcher Port**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_event_dispatcher.py`
+    - [ ] Test: Interface defines dispatch(event) -> None
+    - [ ] Test: Interface defines dispatch_all(events) -> None
+    - [ ] Test: Interface defines subscribe(event_type, handler)
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement `src/domain/ports/event_dispatcher.py`
+  - [ ] REFACTOR: Add type constraints
+
+- [ ] **103.4.2: In-Memory Dispatcher Adapter**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/messaging/test_in_memory_dispatcher.py`
+    - [ ] Test: dispatch() calls registered handlers
+    - [ ] Test: Multiple handlers for same event type
+    - [ ] Test: No handler is no-op (or configurable)
+    - [ ] Test: Handler exception doesn't stop other handlers
+    - [ ] Edge: Async handler support
+    - [ ] Negative: Handler timeout handling
+  - [ ] GREEN: Implement `src/infrastructure/messaging/in_memory_dispatcher.py`
+  - [ ] REFACTOR: Add logging, retry logic
+
+#### 103.5: Integration Tests for CQRS
+
+**Files**: `tests/integration/application/`
+
+- [ ] **103.5.1: Command-Query Round Trip**
+  - [ ] `tests/integration/application/test_cqrs_integration.py`
+  - [ ] Test: Create task -> Query task returns it
+  - [ ] Test: Update task -> Query shows updates
+  - [ ] Test: Complete task -> Query shows completed
+  - [ ] Test: Events are dispatched during commands
+  - [ ] Test: Full task lifecycle CRUD
+
+---
+
+### WORK-104: CLI Interface & BDD Tests
+
+- **Status**: PENDING
+- **Duration**: Weeks 7-8
+- **Dependencies**: WORK-103
+- **Acceptance**: Full CRUD via CLI, 100% BDD scenario coverage, <100ms p95
+- **Reference**: [Unified Design 7](../design/work-034-e-003-unified-design.md#7-interface-specifications)
+
+#### 104.1: CLI Adapter
+
+**Files**: `src/interface/cli/`
+
+- [ ] **104.1.1: CLI Entry Point**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_work_tracker_cli.py`
+    - [ ] Test: `wt --help` shows usage
+    - [ ] Test: `wt --version` shows version
+    - [ ] Test: Exit code 0 on success
+    - [ ] Test: Exit code 1 on error
+    - [ ] Negative: Unknown command shows error
+  - [ ] GREEN: Implement `src/interface/cli/work_tracker_cli.py`
+  - [ ] REFACTOR: Add rich output formatting
+
+- [ ] **104.1.2: Task Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_task_cli.py`
+    - [ ] Test: `wt task create "Title"` creates task
+    - [ ] Test: `wt task list` lists tasks
+    - [ ] Test: `wt task show <id>` shows task details
+    - [ ] Test: `wt task update <id> --title "New"` updates
+    - [ ] Test: `wt task complete <id>` completes task
+    - [ ] Test: `wt task delete <id>` deletes task
+    - [ ] Test: Output is valid JSON with `--json` flag
+    - [ ] Edge: Create with all optional fields
+    - [ ] Negative: Show non-existent task shows error
+  - [ ] GREEN: Implement task subcommand
+  - [ ] REFACTOR: Add confirmation prompts
+
+- [ ] **104.1.3: Phase Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_phase_cli.py`
+    - [ ] Test: `wt phase create "Name" --plan <id>` creates phase
+    - [ ] Test: `wt phase list --plan <id>` lists phases
+    - [ ] Test: `wt phase show <id>` shows phase
+    - [ ] Test: `wt phase complete <id>` completes phase
+    - [ ] Negative: Create phase without plan fails
+  - [ ] GREEN: Implement phase subcommand
+  - [ ] REFACTOR: Add progress indicator
+
+- [ ] **104.1.4: Plan Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_plan_cli.py`
+    - [ ] Test: `wt plan create "Name"` creates plan
+    - [ ] Test: `wt plan list` lists plans
+    - [ ] Test: `wt plan show <id>` shows plan with phases
+    - [ ] Test: `wt plan activate <id>` activates plan
+    - [ ] Test: `wt plan complete <id>` completes plan
+    - [ ] Negative: Complete plan with incomplete phases fails
+  - [ ] GREEN: Implement plan subcommand
+  - [ ] REFACTOR: Add tree view for plan structure
+
+- [ ] **104.1.5: CLI Error Handling**
+  - [ ] RED: Write failing tests for error scenarios
+    - [ ] `tests/e2e/cli/test_cli_errors.py`
+    - [ ] Test: Invalid ID format shows helpful error
+    - [ ] Test: Database error shows user-friendly message
+    - [ ] Test: Validation error shows field and message
+    - [ ] Test: Concurrent modification shows retry suggestion
+  - [ ] GREEN: Implement error handling
+  - [ ] REFACTOR: Add error codes for scripting
+
+#### 104.2: Work Tracker SKILL.md
+
+**Files**: `skills/work-tracker/SKILL.md`
+
+- [ ] **104.2.1: Skill Documentation**
+  - [ ] Create `skills/work-tracker/SKILL.md`
+  - [ ] Document all commands with examples
+  - [ ] Include natural language patterns
+  - [ ] Add troubleshooting section
+  - [ ] Add quick reference card
+
+#### 104.3: BDD Test Suite
+
+**Files**: `tests/bdd/work_tracker/`
+
+- [ ] **104.3.1: Task Feature File**
+  - [ ] `tests/bdd/work_tracker/features/task.feature`
+  - [ ] Scenario: Create task with title and description
+  - [ ] Scenario: Create task with priority and tags
+  - [ ] Scenario: Transition task through states
+  - [ ] Scenario: Complete task records completion time
+  - [ ] Scenario: Assign task to phase
+  - [ ] Scenario: Block task with reason
+  - [ ] Scenario: Cancel pending task
+  - [ ] Edge Scenario: Create task with max-length title
+  - [ ] Negative Scenario: Create task with empty title fails
+  - [ ] Negative Scenario: Complete task not in progress fails
+
+- [ ] **104.3.2: Phase Feature File**
+  - [ ] `tests/bdd/work_tracker/features/phase.feature`
+  - [ ] Scenario: Create phase in plan
+  - [ ] Scenario: Add tasks to phase
+  - [ ] Scenario: Remove task from phase
+  - [ ] Scenario: Complete phase when all tasks done
+  - [ ] Negative Scenario: Complete phase with incomplete tasks fails
+
+- [ ] **104.3.3: Plan Feature File**
+  - [ ] `tests/bdd/work_tracker/features/plan.feature`
+  - [ ] Scenario: Create plan with phases
+  - [ ] Scenario: Activate draft plan
+  - [ ] Scenario: Complete plan when all phases done
+  - [ ] Scenario: Track assumptions on plan
+  - [ ] Negative Scenario: Complete active plan with incomplete phases fails
+
+- [ ] **104.3.4: Step Definitions**
+  - [ ] `tests/bdd/work_tracker/steps/task_steps.py`
+  - [ ] `tests/bdd/work_tracker/steps/phase_steps.py`
+  - [ ] `tests/bdd/work_tracker/steps/plan_steps.py`
+  - [ ] All steps use REAL implementations (no mocks)
+
+#### 104.4: System Tests
+
+**Files**: `tests/system/work_tracker/`
+
+- [ ] **104.4.1: Multi-Operation Workflows**
+  - [ ] `tests/system/work_tracker/test_full_workflow.py`
+  - [ ] Test: Create plan -> Add phases -> Add tasks -> Complete all
+  - [ ] Test: Create multiple plans, interleave operations
+  - [ ] Test: Database persists across CLI invocations
+  - [ ] Test: Concurrent CLI operations don't corrupt data
+
+- [ ] **104.4.2: Performance Tests**
+  - [ ] `tests/system/work_tracker/test_performance.py`
+  - [ ] Test: Create 1000 tasks in < 10s
+  - [ ] Test: List 1000 tasks in < 1s
+  - [ ] Test: Single operation p95 < 100ms
+  - [ ] Test: Memory usage stays bounded
+
+#### 104.5: Phase 1 Go/No-Go Gate
+
+- [ ] **104.5.1: Quality Gates**
+  - [ ] All unit tests pass (target: 95%+ coverage)
+  - [ ] All integration tests pass
+  - [ ] All BDD scenarios pass
+  - [ ] All E2E tests pass
+  - [ ] All architecture tests pass
+  - [ ] All contract tests pass
+  - [ ] CLI operations < 100ms p95
+  - [ ] Code review approved
+  - [ ] No critical/high security issues
+
+---
+
+## Phase 2: Shared Infrastructure (Weeks 9-16)
+
+> **Goal**: Build shared infrastructure components (Event Store, Graph, Search, RDF).
+> **Reference**: [Unified Design 11 Phase 2](../design/work-034-e-003-unified-design.md#phase-2-shared-infrastructure-weeks-9-16)
+
+### WORK-201: Event Store Implementation
+
+- **Status**: PENDING
+- **Duration**: Weeks 9-10
+- **Dependencies**: Phase 1 complete
+- **Acceptance**: CloudEvents 1.0 compliant, append-only semantics, replay works
+- **Reference**: [Unified Design 5.5](../design/work-034-e-003-unified-design.md#55-ieventstore)
+
+#### 201.1: Event Store Port
+
+**Files**: `src/domain/ports/event_store.py`
+
+- [ ] **201.1.1: IEventStore Interface**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_event_store.py`
+    - [ ] Test: append(event) adds event to stream
+    - [ ] Test: get(event_id) returns single event
+    - [ ] Test: get_by_subject(subject_id) returns events for entity
+    - [ ] Test: get_by_type(event_type) returns events by type
+    - [ ] Test: replay(from_position) returns ordered events
+    - [ ] Test: get_snapshot(subject_id) returns latest snapshot
+    - [ ] Test: save_snapshot(snapshot) persists snapshot
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement port interface
+  - [ ] REFACTOR: Add type hints for CloudEventEnvelope
+
+#### 201.2: SQLite Event Store Adapter
+
+**Files**: `src/infrastructure/event_store/`
+
+- [ ] **201.2.1: Event Store Schema**
+  - [ ] RED: Write failing migration tests
+    - [ ] `tests/integration/event_store/test_migrations.py`
+    - [ ] Test: Creates events table (id, type, subject, time, data)
+    - [ ] Test: Creates snapshots table
+    - [ ] Test: Creates indexes for subject, type, time
+    - [ ] Test: Events table is append-only (no UPDATE/DELETE triggers)
+  - [ ] GREEN: Implement `migrations/002_event_store_schema.sql`
+  - [ ] REFACTOR: Add partitioning preparation
+
+- [ ] **201.2.2: Event Store CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/event_store/test_sqlite_event_store.py`
+    - [ ] Test: append() inserts event with auto-increment position
+    - [ ] Test: get() returns event by ID
+    - [ ] Test: get_by_subject() returns all events for subject
+    - [ ] Test: get_by_type() returns events of type
+    - [ ] Test: Events ordered by position
+    - [ ] Edge: get() for non-existent returns None
+    - [ ] Edge: get_by_subject() for new entity returns empty
+    - [ ] Negative: Modifying event raises ImmutableEventError
+  - [ ] GREEN: Implement `src/infrastructure/event_store/sqlite_event_store.py`
+  - [ ] REFACTOR: Add batch insert
+
+- [ ] **201.2.3: Event Replay**
+  - [ ] RED: Write failing tests for replay
+    - [ ] `tests/integration/event_store/test_event_replay.py`
+    - [ ] Test: replay() returns all events from position 0
+    - [ ] Test: replay(from_position=N) skips first N events
+    - [ ] Test: replay(to_position=M) stops at M
+    - [ ] Test: replay() handles large event counts (1000+)
+    - [ ] Test: replay() maintains exact ordering
+    - [ ] Edge: replay() on empty store returns empty
+  - [ ] GREEN: Implement replay functionality
+  - [ ] REFACTOR: Add streaming/generator support
+
+- [ ] **201.2.4: Snapshot Management**
+  - [ ] RED: Write failing tests for snapshots
+    - [ ] `tests/integration/event_store/test_snapshots.py`
+    - [ ] Test: save_snapshot() persists aggregate state
+    - [ ] Test: get_snapshot() returns latest for subject
+    - [ ] Test: Snapshot includes version/position
+    - [ ] Test: Multiple snapshots, latest returned
+    - [ ] Edge: No snapshot returns None
+  - [ ] GREEN: Implement snapshot methods
+  - [ ] REFACTOR: Add snapshot frequency configuration
+
+#### 201.3: Contract Tests for Event Store
+
+- [ ] `tests/contract/event_store/test_event_store_contract.py`
+- [ ] Test: Adapter implements all IEventStore methods
+- [ ] Test: CloudEvents 1.0 compliance for stored events
+- [ ] Test: Immutability guarantees
+
+---
+
+### WORK-202: Graph Store Implementation
+
+- **Status**: PENDING
+- **Duration**: Weeks 11-12
+- **Dependencies**: WORK-201
+- **Acceptance**: Traversal operations work, persistence to disk, performance baseline met
+- **Reference**: [Unified Design 5.3](../design/work-034-e-003-unified-design.md#53-igraphstore)
+
+#### 202.1: Graph Store Port
+
+**Files**: `src/domain/ports/graph_store.py`
+
+- [ ] **202.1.1: IGraphStore Interface**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_graph_store.py`
+    - [ ] Test: add_vertex(vertex) adds node to graph
+    - [ ] Test: get_vertex(id) returns vertex
+    - [ ] Test: update_vertex(vertex) updates properties
+    - [ ] Test: remove_vertex(id) removes node and edges
+    - [ ] Test: add_edge(source, target, relation) adds edge
+    - [ ] Test: get_edges(vertex_id, direction) returns edges
+    - [ ] Test: remove_edge(source, target, relation) removes edge
+    - [ ] Test: traverse(start, depth, direction) returns subgraph
+    - [ ] Test: shortest_path(start, end) returns path
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement port interface
+  - [ ] REFACTOR: Add Vertex, Edge value objects
+
+- [ ] **202.1.2: Graph Value Objects**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_graph.py`
+    - [ ] Test: Vertex has id, type, properties
+    - [ ] Test: Edge has source_id, target_id, relation, properties
+    - [ ] Test: Both are immutable
+  - [ ] GREEN: Implement `src/domain/value_objects/graph.py`
+  - [ ] REFACTOR: Add validation
+
+#### 202.2: NetworkX Graph Adapter
+
+**Files**: `src/infrastructure/graph/`
+
+- [ ] **202.2.1: Graph CRUD Operations**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/graph/test_networkx_graph_store.py`
+    - [ ] Test: add_vertex() creates node
+    - [ ] Test: get_vertex() returns node data
+    - [ ] Test: update_vertex() modifies properties
+    - [ ] Test: remove_vertex() deletes node and edges
+    - [ ] Test: add_edge() creates directed edge
+    - [ ] Test: get_edges() returns incoming/outgoing/both
+    - [ ] Test: remove_edge() deletes edge
+    - [ ] Edge: Add duplicate vertex updates properties
+    - [ ] Edge: Remove non-existent vertex is no-op
+    - [ ] Negative: Invalid vertex type raises ValidationError
+  - [ ] GREEN: Implement `src/infrastructure/graph/networkx_graph_store.py`
+  - [ ] REFACTOR: Add property indexing
+
+- [ ] **202.2.2: Graph Traversal**
+  - [ ] RED: Write failing tests for traversal
+    - [ ] `tests/integration/graph/test_graph_traversal.py`
+    - [ ] Test: traverse(depth=1) returns immediate neighbors
+    - [ ] Test: traverse(depth=2) returns 2-hop neighbors
+    - [ ] Test: traverse(direction=OUTGOING) follows outbound
+    - [ ] Test: traverse(direction=INCOMING) follows inbound
+    - [ ] Test: traverse() respects edge type filters
+    - [ ] Test: shortest_path() returns path if exists
+    - [ ] Test: shortest_path() returns None if no path
+    - [ ] Edge: traverse() on isolated node returns just node
+    - [ ] Edge: traverse(depth=0) returns start node only
+  - [ ] GREEN: Implement traversal methods
+  - [ ] REFACTOR: Use BFS algorithm
+
+- [ ] **202.2.3: Graph Persistence**
+  - [ ] RED: Write failing tests for persistence
+    - [ ] `tests/integration/graph/test_graph_persistence.py`
+    - [ ] Test: save() writes graph to file
+    - [ ] Test: load() restores graph from file
+    - [ ] Test: Round-trip preserves all data
+    - [ ] Test: Load non-existent file returns empty graph
+    - [ ] Edge: Large graph (1000 vertices) save/load
+    - [ ] Negative: Corrupted file raises GraphCorruptionError
+  - [ ] GREEN: Implement save/load with gpickle
+  - [ ] REFACTOR: Add file locking
+
+#### 202.3: Performance Baseline
+
+- [ ] **202.3.1: Graph Performance Tests**
+  - [ ] `tests/performance/graph/test_graph_performance.py`
+  - [ ] Benchmark: Add 500 vertices < 1s
+  - [ ] Benchmark: 2-hop traversal from any node < 100ms
+  - [ ] Benchmark: Save/load 500-node graph < 500ms
+  - [ ] Document baseline metrics in `docs/performance/graph-baseline.md`
+
+---
+
+### WORK-203: Semantic Index Implementation
+
+- **Status**: PENDING
+- **Duration**: Weeks 13-14
+- **Dependencies**: WORK-202
+- **Acceptance**: kNN search functional, persistence to disk, performance baseline met
+- **Reference**: [Unified Design 5.4](../design/work-034-e-003-unified-design.md#54-isemanticindex)
+
+#### 203.1: Semantic Index Port
+
+**Files**: `src/domain/ports/semantic_index.py`
+
+- [ ] **203.1.1: ISemanticIndex Interface**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_semantic_index.py`
+    - [ ] Test: add(id, embedding) adds vector
+    - [ ] Test: update(id, embedding) updates vector
+    - [ ] Test: remove(id) removes vector
+    - [ ] Test: search(query_embedding, k) returns k nearest
+    - [ ] Test: search_by_text(text, k) embeds and searches
+    - [ ] Test: save(path) persists index
+    - [ ] Test: load(path) restores index
+    - [ ] Test: rebuild() rebuilds index from source
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement port interface
+  - [ ] REFACTOR: Add SearchResult value object
+
+- [ ] **203.1.2: SearchResult Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_search_result.py`
+    - [ ] Test: SearchResult has id, score, metadata
+    - [ ] Test: SearchResult is immutable
+    - [ ] Test: SearchResult comparable by score
+  - [ ] GREEN: Implement `src/domain/value_objects/search_result.py`
+  - [ ] REFACTOR: Add ranking helpers
+
+#### 203.2: FAISS Semantic Index Adapter
+
+**Files**: `src/infrastructure/search/`
+
+- [ ] **203.2.1: FAISS Index CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/search/test_faiss_semantic_index.py`
+    - [ ] Test: add() inserts embedding with ID
+    - [ ] Test: update() replaces embedding
+    - [ ] Test: remove() deletes embedding
+    - [ ] Test: ID mapping maintained correctly
+    - [ ] Edge: Add with existing ID updates
+    - [ ] Edge: Remove non-existent ID is no-op
+    - [ ] Negative: Mismatched embedding dimension raises DimensionError
+  - [ ] GREEN: Implement `src/infrastructure/search/faiss_semantic_index.py`
+  - [ ] REFACTOR: Add batch operations
+
+- [ ] **203.2.2: FAISS Search**
+  - [ ] RED: Write failing tests for search
+    - [ ] `tests/integration/search/test_faiss_search.py`
+    - [ ] Test: search(embedding, k=5) returns 5 nearest
+    - [ ] Test: Results ordered by similarity (closest first)
+    - [ ] Test: search() with k > count returns all
+    - [ ] Test: search() on empty index returns empty
+    - [ ] Edge: Search with exact match returns score ~1.0
+    - [ ] Edge: Search with k=0 returns empty
+  - [ ] GREEN: Implement search functionality
+  - [ ] REFACTOR: Add score normalization
+
+- [ ] **203.2.3: FAISS Persistence**
+  - [ ] RED: Write failing tests for persistence
+    - [ ] `tests/integration/search/test_faiss_persistence.py`
+    - [ ] Test: save() writes index to file
+    - [ ] Test: load() restores index from file
+    - [ ] Test: Round-trip preserves embeddings and IDs
+    - [ ] Test: Load non-existent file returns empty index
+    - [ ] Edge: Large index (1000 embeddings) save/load
+    - [ ] Negative: Corrupted file raises IndexCorruptionError
+  - [ ] GREEN: Implement save/load with faiss.write_index
+  - [ ] REFACTOR: Add index metadata
+
+- [ ] **203.2.4: Embedding Provider**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/search/test_embedding_provider.py`
+    - [ ] Test: embed_text() returns fixed-dimension vector
+    - [ ] Test: Consistent embeddings for same text
+    - [ ] Test: Different texts have different embeddings
+    - [ ] Edge: Empty text handling
+    - [ ] Edge: Very long text handling
+  - [ ] GREEN: Implement `src/infrastructure/search/embedding_provider.py`
+  - [ ] REFACTOR: Add caching
+
+#### 203.3: Performance Baseline
+
+- [ ] **203.3.1: Semantic Index Performance Tests**
+  - [ ] `tests/performance/search/test_faiss_performance.py`
+  - [ ] Benchmark: Add 1000 embeddings < 1s
+  - [ ] Benchmark: kNN search (k=10) < 50ms
+  - [ ] Benchmark: Save/load 1000 embeddings < 500ms
+  - [ ] Document baseline metrics in `docs/performance/search-baseline.md`
+
+---
+
+### WORK-204: RDF Serialization Implementation
+
+- **Status**: PENDING
+- **Duration**: Weeks 15-16
+- **Dependencies**: WORK-202, WORK-203
+- **Acceptance**: Export to Turtle/JSON-LD, SPARQL queries work
+- **Reference**: [Unified Design 5.6](../design/work-034-e-003-unified-design.md#56-irdfserializer)
+
+#### 204.1: RDF Serializer Port
+
+**Files**: `src/domain/ports/rdf_serializer.py`
+
+- [ ] **204.1.1: IRDFSerializer Interface**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_rdf_serializer.py`
+    - [ ] Test: add_triple(s, p, o) adds RDF triple
+    - [ ] Test: add_entity(entity) converts to triples
+    - [ ] Test: serialize(format) returns string (turtle, xml, json-ld, n3)
+    - [ ] Test: save(path, format) writes to file
+    - [ ] Test: load(path) reads from file
+    - [ ] Test: query(sparql) executes SPARQL query
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement port interface
+  - [ ] REFACTOR: Add namespace management
+
+#### 204.2: RDFLib Serializer Adapter
+
+**Files**: `src/infrastructure/rdf/`
+
+- [ ] **204.2.1: RDF Graph Operations**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/rdf/test_rdflib_serializer.py`
+    - [ ] Test: add_triple() adds to graph
+    - [ ] Test: add_entity() creates multiple triples
+    - [ ] Test: Graph uses Jerry namespace
+    - [ ] Edge: Add duplicate triple is no-op
+    - [ ] Negative: Invalid URI raises URIError
+  - [ ] GREEN: Implement `src/infrastructure/rdf/rdflib_serializer.py`
+  - [ ] REFACTOR: Add namespace prefix management
+
+- [ ] **204.2.2: RDF Serialization**
+  - [ ] RED: Write failing tests for serialization
+    - [ ] `tests/integration/rdf/test_rdf_serialization.py`
+    - [ ] Test: serialize("turtle") returns valid Turtle
+    - [ ] Test: serialize("xml") returns valid RDF/XML
+    - [ ] Test: serialize("json-ld") returns valid JSON-LD
+    - [ ] Test: serialize("n3") returns valid N3
+    - [ ] Test: save() writes to file
+    - [ ] Test: load() reads from file
+    - [ ] Test: Round-trip preserves data
+    - [ ] Edge: Empty graph serializes to minimal output
+  - [ ] GREEN: Implement serialization methods
+  - [ ] REFACTOR: Add format validation
+
+- [ ] **204.2.3: SPARQL Query**
+  - [ ] RED: Write failing tests for SPARQL
+    - [ ] `tests/integration/rdf/test_sparql_query.py`
+    - [ ] Test: Simple SELECT query returns results
+    - [ ] Test: FILTER query works
+    - [ ] Test: ASK query returns boolean
+    - [ ] Test: CONSTRUCT query returns graph
+    - [ ] Edge: Query on empty graph returns empty
+    - [ ] Negative: Invalid SPARQL raises QuerySyntaxError
+  - [ ] GREEN: Implement query method
+  - [ ] REFACTOR: Add query caching
+
+- [ ] **204.2.4: Jerry Ontology**
+  - [ ] `src/infrastructure/rdf/jerry_ontology.py`
+  - [ ] Define Jerry namespace
+  - [ ] Define Task, Phase, Plan classes
+  - [ ] Define relationships (hasTask, belongsToPhase, etc.)
+  - [ ] Define KnowledgeItem, Pattern, Lesson classes
+  - [ ] Write ontology tests
+
+#### 204.3: Phase 2 Go/No-Go Gate
+
+- [ ] **204.3.1: Quality Gates**
+  - [ ] All Phase 2 unit tests pass
+  - [ ] All integration tests pass
+  - [ ] All contract tests pass
+  - [ ] Performance baselines documented
+  - [ ] Work Tracker entities stored in graph
+  - [ ] Events stored in event store
+  - [ ] Code review approved
+  - [ ] No critical/high security issues
+
+---
+
+## Phase 3: Knowledge Management Integration (Weeks 17-24)
+
+> **Goal**: Implement KM domain entities and integrate with Work Tracker.
+> **Reference**: [Unified Design 11 Phase 3](../design/work-034-e-003-unified-design.md#phase-3-knowledge-management-integration-weeks-17-24)
+
+### WORK-301: KM Domain Layer
+
+- **Status**: PENDING
+- **Duration**: Weeks 17-18
+- **Dependencies**: Phase 2 complete
+- **Acceptance**: Pattern, Lesson, Assumption entities with BDD scenarios pass
+- **Reference**: [Unified Design 4.3](../design/work-034-e-003-unified-design.md#43-knowledge-management-domain)
+
+#### 301.1: KM Value Objects
+
+**Files**: `src/domain/value_objects/knowledge/`
+
+- [ ] **301.1.1: KnowledgeType Enum**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/knowledge/test_knowledge_type.py`
+    - [ ] Test: KnowledgeType.PATTERN, LESSON, ASSUMPTION exist
+    - [ ] Test: From string parsing works
+    - [ ] Negative: Invalid type raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/knowledge/knowledge_type.py`
+  - [ ] REFACTOR: Add descriptions
+
+- [ ] **301.1.2: Evidence Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/knowledge/test_evidence.py`
+    - [ ] Test: Evidence has type, source, content, timestamp
+    - [ ] Test: Evidence is immutable
+    - [ ] Test: Evidence types (OBSERVATION, OUTCOME, REFERENCE, METRIC)
+    - [ ] Edge: Empty content raises ValueError
+  - [ ] GREEN: Implement `src/domain/value_objects/knowledge/evidence.py`
+  - [ ] REFACTOR: Add validation
+
+- [ ] **301.1.3: Confidence Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/knowledge/test_confidence.py`
+    - [ ] Test: Confidence has score (0.0-1.0)
+    - [ ] Test: Confidence has justification
+    - [ ] Test: Confidence comparable
+    - [ ] Edge: Score < 0 raises ValueError
+    - [ ] Edge: Score > 1 raises ValueError
+  - [ ] GREEN: Implement confidence value object
+  - [ ] REFACTOR: Add level helpers (HIGH, MEDIUM, LOW)
+
+#### 301.2: KnowledgeItem Aggregate
+
+**Files**: `src/domain/aggregates/knowledge/`
+
+- [ ] **301.2.1: KnowledgeItem Base**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/aggregates/knowledge/test_knowledge_item.py`
+    - [ ] Test: KnowledgeItem has id, title, description
+    - [ ] Test: KnowledgeItem has knowledge_type
+    - [ ] Test: KnowledgeItem has tags set
+    - [ ] Test: KnowledgeItem has source_uri (optional)
+    - [ ] Test: KnowledgeItem has created_at, updated_at
+    - [ ] Test: add_evidence() adds evidence
+    - [ ] Test: link_to() creates relationship
+    - [ ] Edge: Empty title raises ValueError
+  - [ ] GREEN: Implement `src/domain/aggregates/knowledge/knowledge_item.py`
+  - [ ] REFACTOR: Extract common behavior
+
+- [ ] **301.2.2: Pattern Entity**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/aggregates/knowledge/test_pattern.py`
+    - [ ] Test: Pattern extends KnowledgeItem
+    - [ ] Test: Pattern has context, problem, solution, consequences
+    - [ ] Test: Pattern has applicability_conditions
+    - [ ] Test: Pattern tracks application_count
+    - [ ] Test: apply() increments count, emits PatternApplied
+    - [ ] Edge: Pattern without solution raises ValidationError
+  - [ ] GREEN: Implement `src/domain/aggregates/knowledge/pattern.py`
+  - [ ] REFACTOR: Add pattern template
+
+- [ ] **301.2.3: Lesson Entity**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/aggregates/knowledge/test_lesson.py`
+    - [ ] Test: Lesson extends KnowledgeItem
+    - [ ] Test: Lesson has observation, reflection, action
+    - [ ] Test: Lesson has source_task_id (optional)
+    - [ ] Test: Lesson can be materialized to Pattern
+    - [ ] Test: materialize() emits LessonMaterialized
+    - [ ] Edge: Lesson without observation raises ValidationError
+  - [ ] GREEN: Implement `src/domain/aggregates/knowledge/lesson.py`
+  - [ ] REFACTOR: Add AAR prompts
+
+- [ ] **301.2.4: Assumption Entity**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/aggregates/knowledge/test_assumption.py`
+    - [ ] Test: Assumption extends KnowledgeItem
+    - [ ] Test: Assumption has hypothesis, validation_criteria
+    - [ ] Test: Assumption has status (UNTESTED, VALIDATED, INVALIDATED)
+    - [ ] Test: validate() sets status, adds evidence
+    - [ ] Test: invalidate() sets status, adds evidence
+    - [ ] Test: validate() emits AssumptionValidated
+    - [ ] Negative: Validate without evidence raises ValidationError
+  - [ ] GREEN: Implement `src/domain/aggregates/knowledge/assumption.py`
+  - [ ] REFACTOR: Add validation workflow
+
+#### 301.3: KM Domain Events
+
+**Files**: `src/domain/events/knowledge.py`
+
+- [ ] **301.3.1: Knowledge Events**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/events/test_knowledge_events.py`
+    - [ ] Test: PatternCreated, PatternUpdated, PatternApplied
+    - [ ] Test: LessonCreated, LessonUpdated, LessonMaterialized
+    - [ ] Test: AssumptionCreated, AssumptionValidated, AssumptionInvalidated
+    - [ ] Test: EvidenceAdded, KnowledgeLinked
+    - [ ] Test: All events CloudEvents 1.0 compliant
+  - [ ] GREEN: Implement events
+  - [ ] REFACTOR: Ensure consistency with WT events
+
+---
+
+### WORK-302: KM Repository Layer
+
+- **Status**: PENDING
+- **Duration**: Weeks 19-20
+- **Dependencies**: WORK-301
+- **Acceptance**: Full CRUD for knowledge items, integration tests pass
+- **Reference**: [Unified Design 5.2](../design/work-034-e-003-unified-design.md#52-iknowledgerepository)
+
+#### 302.1: Knowledge Repository Port
+
+**Files**: `src/domain/ports/knowledge_repository.py`
+
+- [ ] **302.1.1: IKnowledgeRepository Interface**
+  - [ ] RED: Write failing tests for port
+    - [ ] `tests/unit/domain/ports/test_knowledge_repository.py`
+    - [ ] Test: get(id) returns KnowledgeItem
+    - [ ] Test: save(item) persists item
+    - [ ] Test: delete(id) removes item
+    - [ ] Test: list_by_type(type) returns items of type
+    - [ ] Test: list_by_tags(tags) returns items with tags
+    - [ ] Test: get_by_source(source_uri) returns items from source
+    - [ ] Contract: Port is abstract
+  - [ ] GREEN: Implement port interface
+  - [ ] REFACTOR: Add pagination
+
+#### 302.2: SQLite Knowledge Repository
+
+**Files**: `src/infrastructure/persistence/sqlite_knowledge_repo.py`
+
+- [ ] **302.2.1: Knowledge Schema**
+  - [ ] RED: Write failing migration tests
+    - [ ] `tests/integration/persistence/test_km_migrations.py`
+    - [ ] Test: Creates knowledge_items table
+    - [ ] Test: Creates evidence table (1:N)
+    - [ ] Test: Creates knowledge_tags junction table
+    - [ ] Test: Creates knowledge_links table
+  - [ ] GREEN: Implement `migrations/003_knowledge_schema.sql`
+  - [ ] REFACTOR: Add indexes
+
+- [ ] **302.2.2: Knowledge CRUD**
+  - [ ] RED: Write failing integration tests
+    - [ ] `tests/integration/persistence/test_sqlite_knowledge_repo.py`
+    - [ ] Test: save() inserts Pattern
+    - [ ] Test: save() inserts Lesson
+    - [ ] Test: save() inserts Assumption
+    - [ ] Test: get() returns correct subtype
+    - [ ] Test: delete() removes item and evidence
+    - [ ] Test: list_by_type() filters correctly
+    - [ ] Test: list_by_tags() filters correctly
+    - [ ] Test: get_by_source() finds items
+    - [ ] Edge: Update existing item
+    - [ ] Negative: Get non-existent returns None
+  - [ ] GREEN: Implement repository adapter
+  - [ ] REFACTOR: Add polymorphic loading
+
+---
+
+### WORK-303: KM CQRS Implementation
+
+- **Status**: PENDING
+- **Duration**: Weeks 21-22
+- **Dependencies**: WORK-301, WORK-302
+- **Acceptance**: All commands/queries functional, AAR handler working
+- **Reference**: [Unified Design 6.3-6.4](../design/work-034-e-003-unified-design.md#63-knowledge-management-commands)
+
+#### 303.1: KM Commands
+
+**Files**: `src/application/commands/km/`
+
+- [ ] **303.1.1: Pattern Commands**
+  - [ ] RED: Write failing tests
+    - [ ] CreatePatternCommand, UpdatePatternCommand, ApplyPatternCommand
+    - [ ] Tests follow WORK-103 pattern
+  - [ ] GREEN: Implement commands
+  - [ ] REFACTOR: Add validation
+
+- [ ] **303.1.2: Lesson Commands**
+  - [ ] RED: Write failing tests
+    - [ ] CreateLessonCommand, UpdateLessonCommand, MaterializeLessonCommand
+    - [ ] Tests follow WORK-103 pattern
+  - [ ] GREEN: Implement commands
+  - [ ] REFACTOR: Add validation
+
+- [ ] **303.1.3: Assumption Commands**
+  - [ ] RED: Write failing tests
+    - [ ] CreateAssumptionCommand, ValidateAssumptionCommand, InvalidateAssumptionCommand
+    - [ ] Tests follow WORK-103 pattern
+  - [ ] GREEN: Implement commands
+  - [ ] REFACTOR: Add validation
+
+- [ ] **303.1.4: Cross-Cutting Commands**
+  - [ ] RED: Write failing tests
+    - [ ] AddEvidenceCommand, LinkKnowledgeCommand
+    - [ ] Tests for linking across types
+  - [ ] GREEN: Implement commands
+  - [ ] REFACTOR: Add bidirectional linking
+
+#### 303.2: KM Command Handlers
+
+**Files**: `src/application/handlers/commands/km/`
+
+- [ ] **303.2.1: Pattern Handlers**
+  - [ ] RED: Write failing unit tests (mocked repo)
+    - [ ] CreatePatternHandler, UpdatePatternHandler, ApplyPatternHandler
+    - [ ] Tests follow WORK-103 handler pattern
+    - [ ] Test event emission
+  - [ ] GREEN: Implement handlers
+  - [ ] REFACTOR: Extract common behavior
+
+- [ ] **303.2.2: Lesson Handlers**
+  - [ ] RED: Write failing unit tests
+    - [ ] CreateLessonHandler, UpdateLessonHandler, MaterializeLessonHandler
+    - [ ] MaterializeLessonHandler creates Pattern from Lesson
+    - [ ] Test graph edge creation
+  - [ ] GREEN: Implement handlers
+  - [ ] REFACTOR: Add materialization workflow
+
+- [ ] **303.2.3: Assumption Handlers**
+  - [ ] RED: Write failing unit tests
+    - [ ] CreateAssumptionHandler, ValidateAssumptionHandler, InvalidateAssumptionHandler
+    - [ ] Test evidence requirement for validation
+  - [ ] GREEN: Implement handlers
+  - [ ] REFACTOR: Add notification
+
+#### 303.3: KM Queries
+
+**Files**: `src/application/queries/km/`
+
+- [ ] **303.3.1: KM DTOs**
+  - [ ] RED: Write failing tests
+    - [ ] PatternDTO, LessonDTO, AssumptionDTO, EvidenceDTO
+    - [ ] Tests for from_entity() factories
+  - [ ] GREEN: Implement `src/application/dtos/knowledge.py`
+  - [ ] REFACTOR: Add serialization
+
+- [ ] **303.3.2: Query Definitions**
+  - [ ] RED: Write failing tests
+    - [ ] GetKnowledgeQuery, ListPatternsQuery, ListLessonsQuery, ListAssumptionsQuery
+    - [ ] SearchKnowledgeQuery (semantic), GetRelatedKnowledgeQuery (graph)
+  - [ ] GREEN: Implement queries
+  - [ ] REFACTOR: Add pagination
+
+- [ ] **303.3.3: Query Handlers**
+  - [ ] RED: Write failing unit tests
+    - [ ] Handler for each query type
+    - [ ] Semantic search uses ISemanticIndex
+    - [ ] Related query uses IGraphStore traversal
+  - [ ] GREEN: Implement handlers
+  - [ ] REFACTOR: Add caching
+
+#### 303.4: AAR Event Handler
+
+**Files**: `src/application/event_handlers/km/`
+
+- [ ] **303.4.1: AAR Prompt Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/test_aar_prompt_handler.py`
+    - [ ] Test: TaskCompleted triggers AAR prompt
+    - [ ] Test: PhaseCompleted triggers AAR prompt
+    - [ ] Test: Handler creates pending AAR
+    - [ ] Test: AAR has what_happened, what_learned, what_next
+    - [ ] Edge: Skip AAR for trivial tasks (configurable)
+  - [ ] GREEN: Implement `src/application/event_handlers/km/aar_prompt_handler.py`
+  - [ ] REFACTOR: Add prompt templates
+
+- [ ] **303.4.2: Materialize Lesson Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/test_materialize_lesson_handler.py`
+    - [ ] Test: AARCompleted triggers lesson creation
+    - [ ] Test: Lesson links to source task
+    - [ ] Test: Lesson added to graph
+    - [ ] Test: Lesson embedded in semantic index
+  - [ ] GREEN: Implement `src/application/event_handlers/km/materialize_lesson_handler.py`
+  - [ ] REFACTOR: Add batching
+
+---
+
+### WORK-304: KM Interface Layer
+
+- **Status**: PENDING
+- **Duration**: Weeks 23-24
+- **Dependencies**: WORK-303
+- **Acceptance**: Full KM operations via CLI and SKILL, cross-domain BDD passes
+- **Reference**: [Unified Design 7](../design/work-034-e-003-unified-design.md#7-interface-specifications)
+
+#### 304.1: KM CLI Adapter
+
+**Files**: `src/interface/cli/km_cli.py`
+
+- [ ] **304.1.1: Pattern Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_pattern_cli.py`
+    - [ ] Test: `km pattern create` creates pattern
+    - [ ] Test: `km pattern list` lists patterns
+    - [ ] Test: `km pattern show <id>` shows details
+    - [ ] Test: `km pattern apply <id> --task <task_id>` applies pattern
+    - [ ] Negative: Create without required fields fails
+  - [ ] GREEN: Implement pattern subcommand
+  - [ ] REFACTOR: Add interactive mode
+
+- [ ] **304.1.2: Lesson Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_lesson_cli.py`
+    - [ ] Test: `km lesson create` creates lesson
+    - [ ] Test: `km lesson list` lists lessons
+    - [ ] Test: `km lesson show <id>` shows details
+    - [ ] Test: `km lesson materialize <id>` creates pattern
+    - [ ] Negative: Materialize without observation fails
+  - [ ] GREEN: Implement lesson subcommand
+  - [ ] REFACTOR: Add AAR wizard
+
+- [ ] **304.1.3: Assumption Subcommand**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_assumption_cli.py`
+    - [ ] Test: `km assumption create` creates assumption
+    - [ ] Test: `km assumption list` lists assumptions
+    - [ ] Test: `km assumption validate <id> --evidence "..."` validates
+    - [ ] Test: `km assumption invalidate <id> --evidence "..."` invalidates
+    - [ ] Negative: Validate without evidence fails
+  - [ ] GREEN: Implement assumption subcommand
+  - [ ] REFACTOR: Add evidence attachment
+
+- [ ] **304.1.4: Search and Related Commands**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_km_search_cli.py`
+    - [ ] Test: `km search "query"` returns semantic results
+    - [ ] Test: `km related <id>` returns graph neighbors
+    - [ ] Test: Output formats (table, json)
+    - [ ] Edge: Empty results handled
+  - [ ] GREEN: Implement search commands
+  - [ ] REFACTOR: Add result highlighting
+
+#### 304.2: KM SKILL.md
+
+**Files**: `skills/km/SKILL.md`
+
+- [ ] **304.2.1: Skill Documentation**
+  - [ ] Create `skills/km/SKILL.md`
+  - [ ] Document pattern commands
+  - [ ] Document lesson commands
+  - [ ] Document assumption commands
+  - [ ] Document search and related commands
+  - [ ] Add natural language examples
+  - [ ] Add quick reference
+
+#### 304.3: Cross-Domain BDD Tests
+
+**Files**: `tests/bdd/cross_domain/`
+
+- [ ] **304.3.1: Task to Lesson Flow**
+  - [ ] `tests/bdd/cross_domain/features/task_to_lesson.feature`
+  - [ ] Scenario: Complete task triggers AAR prompt
+  - [ ] Scenario: Submit AAR creates lesson
+  - [ ] Scenario: Lesson links to source task
+  - [ ] Scenario: Lesson searchable by task content
+  - [ ] Negative Scenario: Skip AAR for cancelled task
+
+- [ ] **304.3.2: Pattern Application Flow**
+  - [ ] `tests/bdd/cross_domain/features/pattern_application.feature`
+  - [ ] Scenario: Search patterns by problem
+  - [ ] Scenario: Apply pattern to task
+  - [ ] Scenario: Pattern application_count incremented
+  - [ ] Scenario: Applied pattern linked to task
+  - [ ] Negative Scenario: Apply inapplicable pattern fails
+
+- [ ] **304.3.3: Assumption Validation Flow**
+  - [ ] `tests/bdd/cross_domain/features/assumption_validation.feature`
+  - [ ] Scenario: Track assumption on plan
+  - [ ] Scenario: Link task to validate assumption
+  - [ ] Scenario: Task completion validates assumption
+  - [ ] Scenario: Task failure invalidates assumption
+  - [ ] Negative Scenario: Validate without task link
+
+#### 304.4: Phase 3 Go/No-Go Gate
+
+- [ ] **304.4.1: Quality Gates**
+  - [ ] KM entity CRUD working
+  - [ ] AAR prompt flow functional
+  - [ ] Semantic search returning results
+  - [ ] Graph traversal working
+  - [ ] Cross-domain BDD scenarios pass
+  - [ ] All unit tests pass (95%+ coverage)
+  - [ ] All integration tests pass
+  - [ ] Code review approved
+  - [ ] No critical/high security issues
+
+---
+
+## Phase 4: Advanced Features (Weeks 25-32)
+
+> **Goal**: Complete cross-domain integration, HybridRAG, and external APIs.
+> **Reference**: [Unified Design 11 Phase 4](../design/work-034-e-003-unified-design.md#phase-4-advanced-features-weeks-25-32)
+
+### WORK-401: Cross-Domain Integration
+
+- **Status**: PENDING
+- **Duration**: Weeks 25-26
+- **Dependencies**: Phase 3 complete
+- **Acceptance**: Task→Lesson, Phase→Pattern flows automated
+- **Reference**: [Unified Design 4.4](../design/work-034-e-003-unified-design.md#44-cross-domain-integration)
+
+#### 401.1: Cross-Domain Event Handlers
+
+**Files**: `src/application/event_handlers/cross_domain/`
+
+- [ ] **401.1.1: TaskCompleted Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/cross_domain/test_task_completed.py`
+    - [ ] Test: Handler triggers AAR prompt creation
+    - [ ] Test: Handler updates graph with completion
+    - [ ] Test: Handler updates semantic index
+    - [ ] Edge: Handler configurable by task type
+    - [ ] Negative: Handler failure doesn't block completion
+  - [ ] GREEN: Implement `src/application/event_handlers/cross_domain/task_completed_handler.py`
+  - [ ] REFACTOR: Add retry logic
+
+- [ ] **401.1.2: PhaseCompleted Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/cross_domain/test_phase_completed.py`
+    - [ ] Test: Handler triggers pattern candidate analysis
+    - [ ] Test: Handler aggregates lessons from phase
+    - [ ] Test: Handler updates graph
+  - [ ] GREEN: Implement `src/application/event_handlers/cross_domain/phase_completed_handler.py`
+  - [ ] REFACTOR: Add aggregation logic
+
+- [ ] **401.1.3: PatternApplied Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/cross_domain/test_pattern_applied.py`
+    - [ ] Test: Handler creates graph edge
+    - [ ] Test: Handler tracks application in task
+    - [ ] Test: Handler updates pattern stats
+  - [ ] GREEN: Implement `src/application/event_handlers/cross_domain/pattern_applied_handler.py`
+  - [ ] REFACTOR: Add bidirectional linking
+
+- [ ] **401.1.4: AssumptionValidation Handler**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/event_handlers/cross_domain/test_assumption_validation.py`
+    - [ ] Test: Handler updates linked plan
+    - [ ] Test: Handler updates graph
+    - [ ] Test: Handler triggers notifications
+    - [ ] Negative: Invalid assumption blocks related tasks
+  - [ ] GREEN: Implement `src/application/event_handlers/cross_domain/assumption_validation_handler.py`
+  - [ ] REFACTOR: Add plan impact analysis
+
+#### 401.2: Knowledge Materializer Service
+
+**Files**: `src/application/services/knowledge_materializer.py`
+
+- [ ] **401.2.1: Lesson Materialization**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/services/test_knowledge_materializer.py`
+    - [ ] Test: materialize_lesson() creates Pattern
+    - [ ] Test: Pattern inherits lesson metadata
+    - [ ] Test: Pattern linked to source lesson
+    - [ ] Test: Graph edge created
+    - [ ] Edge: Multiple lessons combine to pattern
+  - [ ] GREEN: Implement materialize_lesson()
+  - [ ] REFACTOR: Add template system
+
+- [ ] **401.2.2: Pattern Discovery**
+  - [ ] RED: Write failing tests
+    - [ ] Test: discover_patterns() finds recurring lessons
+    - [ ] Test: Clustering by semantic similarity
+    - [ ] Test: Candidate patterns have confidence scores
+    - [ ] Edge: No patterns found returns empty
+  - [ ] GREEN: Implement discover_patterns()
+  - [ ] REFACTOR: Add ML-based clustering
+
+#### 401.3: Graph Enrichment
+
+- [ ] **401.3.1: Auto-Graph Integration**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/integration/graph/test_auto_enrichment.py`
+    - [ ] Test: Task creation adds vertex
+    - [ ] Test: Task update updates vertex
+    - [ ] Test: Task completion adds edges
+    - [ ] Test: Phase creation adds vertex
+    - [ ] Test: Knowledge item creation adds vertex
+  - [ ] GREEN: Implement auto-enrichment
+  - [ ] REFACTOR: Add batch processing
+
+---
+
+### WORK-402: HybridRAG & Pattern Discovery
+
+- **Status**: PENDING
+- **Duration**: Weeks 27-28
+- **Dependencies**: WORK-401
+- **Acceptance**: Semantic + graph retrieval working, pattern candidates surfaced
+- **Reference**: [Unified Design 8](../design/work-034-e-003-unified-design.md#8-hybrid-rag-specification)
+
+#### 402.1: HybridRAG Service
+
+**Files**: `src/application/services/hybrid_rag.py`
+
+- [ ] **402.1.1: Hybrid Search**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/services/test_hybrid_rag.py`
+    - [ ] Test: search() combines semantic and graph results
+    - [ ] Test: Semantic results enriched with graph context
+    - [ ] Test: Graph traversal from semantic matches
+    - [ ] Test: Result fusion and deduplication
+    - [ ] Test: Ranking by relevance score
+    - [ ] Edge: Empty semantic results uses graph only
+    - [ ] Edge: Empty graph uses semantic only
+  - [ ] GREEN: Implement `src/application/services/hybrid_rag.py`
+  - [ ] REFACTOR: Add configurable weights
+
+- [ ] **402.1.2: Context Enrichment**
+  - [ ] RED: Write failing tests
+    - [ ] Test: enrich() adds related items to results
+    - [ ] Test: Depth-limited traversal
+    - [ ] Test: Filter by relationship type
+    - [ ] Edge: Cycle detection in graph
+  - [ ] GREEN: Implement enrichment
+  - [ ] REFACTOR: Add caching
+
+- [ ] **402.1.3: HybridRAG Query**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/queries/test_hybrid_search.py`
+    - [ ] Test: HybridSearchQuery has query text, filters
+    - [ ] Test: Handler uses HybridRAG service
+    - [ ] Test: Results include context
+  - [ ] GREEN: Implement `src/application/queries/hybrid_search.py`
+  - [ ] REFACTOR: Add result formatting
+
+#### 402.2: Pattern Discovery Service
+
+**Files**: `src/application/services/pattern_discovery.py`
+
+- [ ] **402.2.1: Lesson Clustering**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/services/test_pattern_discovery.py`
+    - [ ] Test: cluster_lessons() groups similar lessons
+    - [ ] Test: Clustering by semantic similarity
+    - [ ] Test: Minimum cluster size configurable
+    - [ ] Test: Clusters have centroid
+    - [ ] Edge: Single lesson returns no clusters
+  - [ ] GREEN: Implement lesson clustering
+  - [ ] REFACTOR: Add cluster quality metrics
+
+- [ ] **402.2.2: Pattern Candidate Generation**
+  - [ ] RED: Write failing tests
+    - [ ] Test: generate_candidates() creates PatternCandidate from cluster
+    - [ ] Test: Candidate has confidence score
+    - [ ] Test: Candidate has source lessons
+    - [ ] Test: Candidate has proposed context/problem/solution
+    - [ ] Edge: Low-confidence candidates filtered
+  - [ ] GREEN: Implement candidate generation
+  - [ ] REFACTOR: Add LLM-based synthesis option
+
+- [ ] **402.2.3: PatternCandidate Value Object**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/domain/value_objects/test_pattern_candidate.py`
+    - [ ] Test: PatternCandidate has title, confidence, source_lessons
+    - [ ] Test: PatternCandidate has proposed_pattern data
+    - [ ] Test: PatternCandidate is immutable
+  - [ ] GREEN: Implement `src/domain/value_objects/pattern_candidate.py`
+  - [ ] REFACTOR: Add validation
+
+---
+
+### WORK-403: External API & Export
+
+- **Status**: PENDING
+- **Duration**: Weeks 29-30
+- **Dependencies**: WORK-401
+- **Acceptance**: SPARQL endpoint functional, RDF export working
+- **Reference**: [Unified Design 9](../design/work-034-e-003-unified-design.md#9-external-api-specification)
+
+#### 403.1: SPARQL Endpoint
+
+**Files**: `src/interface/api/sparql_endpoint.py`
+
+- [ ] **403.1.1: Query Endpoint**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/integration/api/test_sparql_endpoint.py`
+    - [ ] Test: POST /sparql accepts query
+    - [ ] Test: SELECT returns results
+    - [ ] Test: ASK returns boolean
+    - [ ] Test: CONSTRUCT returns graph
+    - [ ] Test: Content negotiation (json, xml, turtle)
+    - [ ] Edge: Empty result set handled
+    - [ ] Negative: Invalid SPARQL returns 400
+    - [ ] Negative: Query timeout returns 408
+  - [ ] GREEN: Implement endpoint
+  - [ ] REFACTOR: Add rate limiting
+
+- [ ] **403.1.2: Query Validation**
+  - [ ] RED: Write failing tests
+    - [ ] Test: Validate query syntax
+    - [ ] Test: Reject UPDATE/DELETE queries
+    - [ ] Test: Reject CONSTRUCT with external sources
+    - [ ] Negative: Injection attempt blocked
+  - [ ] GREEN: Implement validation
+  - [ ] REFACTOR: Add query logging
+
+#### 403.2: Export/Import Commands
+
+**Files**: `src/application/commands/export.py`, `src/application/commands/import.py`
+
+- [ ] **403.2.1: Export Command**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/commands/test_export.py`
+    - [ ] Test: ExportCommand has format, path
+    - [ ] Test: Handler exports all entities
+    - [ ] Test: Handler exports to Turtle, JSON-LD, RDF/XML
+    - [ ] Test: Handler includes relationships
+    - [ ] Edge: Large export handled
+  - [ ] GREEN: Implement export command and handler
+  - [ ] REFACTOR: Add streaming
+
+- [ ] **403.2.2: Import Command**
+  - [ ] RED: Write failing tests
+    - [ ] `tests/unit/application/commands/test_import.py`
+    - [ ] Test: ImportCommand has path, merge_strategy
+    - [ ] Test: Handler imports entities
+    - [ ] Test: Handler resolves conflicts
+    - [ ] Test: Handler validates data
+    - [ ] Edge: Duplicate handling
+    - [ ] Negative: Invalid format rejected
+  - [ ] GREEN: Implement import command and handler
+  - [ ] REFACTOR: Add preview mode
+
+- [ ] **403.2.3: CLI Integration**
+  - [ ] RED: Write failing E2E tests
+    - [ ] `tests/e2e/cli/test_export_cli.py`
+    - [ ] Test: `jerry export --format turtle -o out.ttl`
+    - [ ] Test: `jerry import data.ttl`
+    - [ ] Test: Round-trip preserves data
+  - [ ] GREEN: Implement `src/interface/cli/export_cli.py`
+  - [ ] REFACTOR: Add progress indicator
+
+---
+
+### WORK-404: Documentation & Final Testing
+
+- **Status**: PENDING
+- **Duration**: Weeks 31-32
+- **Dependencies**: All
+- **Acceptance**: Full documentation, all tests pass, system validated
+- **Reference**: Final quality gates
+
+#### 404.1: Integration Test Suite
+
+**Files**: `tests/integration/`
+
+- [ ] **404.1.1: Full Workflow Tests**
+  - [ ] `tests/integration/test_full_workflow.py`
+  - [ ] Test: Create plan -> phases -> tasks -> complete all
+  - [ ] Test: Task completion -> AAR -> Lesson -> Pattern
+  - [ ] Test: Search patterns -> apply -> track
+  - [ ] Test: Assumption tracking and validation
+  - [ ] Test: Export -> delete -> import -> verify
+
+- [ ] **404.1.2: Performance Tests**
+  - [ ] `tests/integration/test_performance.py`
+  - [ ] Test: 1000 tasks CRUD < 30s
+  - [ ] Test: 1000 knowledge items CRUD < 30s
+  - [ ] Test: Semantic search (1000 items) < 1s
+  - [ ] Test: Graph traversal (1000 vertices, depth 3) < 1s
+  - [ ] Test: Memory usage bounded
+
+- [ ] **404.1.3: Data Integrity Tests**
+  - [ ] `tests/integration/test_data_integrity.py`
+  - [ ] Test: Concurrent operations don't corrupt
+  - [ ] Test: Transaction rollback works
+  - [ ] Test: Foreign key integrity
+  - [ ] Test: Event replay reconstructs state
+  - [ ] Test: Snapshot consistency
+
+#### 404.2: User Documentation
+
+**Files**: `docs/user-guide/`
+
+- [ ] **404.2.1: Getting Started Guide**
+  - [ ] `docs/user-guide/getting-started.md`
+  - [ ] Installation instructions
+  - [ ] First task creation
+  - [ ] First lesson capture
+  - [ ] Quick reference
+
+- [ ] **404.2.2: Work Tracker Guide**
+  - [ ] `docs/user-guide/work-tracker.md`
+  - [ ] Task management
+  - [ ] Phase and plan management
+  - [ ] Best practices
+  - [ ] Troubleshooting
+
+- [ ] **404.2.3: Knowledge Management Guide**
+  - [ ] `docs/user-guide/knowledge-management.md`
+  - [ ] Patterns, lessons, assumptions
+  - [ ] AAR workflow
+  - [ ] Search and discovery
+  - [ ] Best practices
+
+- [ ] **404.2.4: CLI Reference**
+  - [ ] `docs/user-guide/cli-reference.md`
+  - [ ] Complete command reference
+  - [ ] Options and flags
+  - [ ] Examples
+  - [ ] Exit codes
+
+#### 404.3: Developer Documentation
+
+**Files**: `docs/dev-guide/`
+
+- [ ] **404.3.1: Architecture Guide**
+  - [ ] `docs/dev-guide/architecture.md`
+  - [ ] Hexagonal architecture overview
+  - [ ] Domain model
+  - [ ] CQRS implementation
+  - [ ] Event sourcing
+  - [ ] Dependency injection
+
+- [ ] **404.3.2: Extension Guide**
+  - [ ] `docs/dev-guide/extending.md`
+  - [ ] Adding new entity types
+  - [ ] Adding new commands/queries
+  - [ ] Adding new adapters
+  - [ ] Plugin architecture
+
+- [ ] **404.3.3: Testing Guide**
+  - [ ] `docs/dev-guide/testing.md`
+  - [ ] Test pyramid
+  - [ ] Writing unit tests
+  - [ ] Writing integration tests
+  - [ ] Writing BDD scenarios
+  - [ ] Contract testing
+
+#### 404.4: Final Go/No-Go Gate
+
+- [ ] **404.4.1: Quality Gates**
+  - [ ] All unit tests pass (target: 95%+ coverage)
+  - [ ] All integration tests pass
+  - [ ] All BDD scenarios pass
+  - [ ] All E2E tests pass
+  - [ ] All contract tests pass
+  - [ ] All architecture tests pass
+  - [ ] All system tests pass
+  - [ ] Performance targets met (<100ms p95)
+  - [ ] Documentation complete
+  - [ ] Security review passed
+  - [ ] Final code review approved
+  - [ ] No critical/high issues open
+
+---
+
+## Technology Stack
+
+| Component | Technology | Version | Purpose |
+|-----------|------------|---------|---------|
+| Runtime | Python | 3.11+ | Zero-dependency core |
+| Graph | NetworkX | 3.2.1 | Property graph |
+| Vector Search | FAISS | 1.7.4 | Semantic similarity |
+| RDF | RDFLib | 7.0.0 | Knowledge export |
+| Persistence | SQLite | 3.x | Entity and event storage |
+| Testing | pytest | 8.x | All test types |
+| BDD | pytest-bdd | 7.x | BDD scenarios |
+
+---
+
+## Key Decisions (From ADR-034)
+
+| Decision | Score | Choice | Alternative |
+|----------|-------|--------|-------------|
+| Architecture | 8.4/10 | Hexagonal | Layered (7.0) |
+| Sequence | 8.65/10 | WT First | KM First (6.05) |
+| Graph DB | 8.5/10 | NetworkX | Neo4j (7.05) |
+| Vector Search | 8.1/10 | FAISS | Pinecone (7.25) |
+| Database | 9.0/10 | SQLite | PostgreSQL (6.35) |
+
+---
+
+## Risk Register Summary
+
+| ID | Risk | Probability | Impact | Mitigation |
+|----|------|-------------|--------|------------|
+| R-001 | Performance at scale | Medium | High | Validate at WT scale first |
+| R-002 | Supernode formation | Medium | High | Edge count validator |
+| R-003 | Test suite too slow | Medium | Medium | Parallel execution, test isolation |
+| R-004 | User AAR adoption | Medium | Medium | Track completion rate |
+| R-005 | Schema evolution | Medium | High | Version envelope pattern |
+| R-006 | Integration complexity | Medium | Medium | Feature flags, incremental rollout |
+
+---
+
+## Testing Summary by Type
+
+| Test Type | Count (Est.) | Purpose |
+|-----------|--------------|---------|
+| Unit | ~500 | Isolated component testing |
+| Integration | ~150 | Multi-component testing |
+| Contract | ~30 | Port compliance |
+| System | ~20 | Multi-operation workflows |
+| E2E | ~50 | CLI to persistence |
+| BDD | ~60 | Business scenarios |
+| Architecture | ~20 | Layer dependencies |
+| Performance | ~15 | Baseline validation |
+
+**Total Estimated Tests**: ~845
+
+---
+
+## References
+
+| Document | Size | Purpose |
+|----------|------|---------|
+| [ADR-034](../decisions/ADR-034-unified-wt-km-implementation.md) | 59KB | Architecture decision |
+| [Unified Design](../design/work-034-e-003-unified-design.md) | 87KB | Technical specifications |
+| [Trade-off Analysis](../analysis/work-034-e-004-tradeoff-analysis.md) | 39KB | Decision rationale |
+| [Domain Synthesis](../synthesis/work-034-e-002-domain-synthesis.md) | 54KB | Domain model |
+| [Domain Analysis](../research/work-034-e-001-domain-analysis.md) | 93KB | Research foundation |
+| [Validation Report](../validation/work-034-e-006-validation-report.md) | 17KB | Approval status |
+
+---
+
+*Revised from WORK-034 artifacts on 2026-01-09 with comprehensive Architecture Pure and BDD Red/Green/Refactor sub-tasks*

--- a/docs/archive/projects-archive/plans/WORK_TRACKER_PLAN.md
+++ b/docs/archive/projects-archive/plans/WORK_TRACKER_PLAN.md
@@ -1,0 +1,1458 @@
+# PLAN: Jerry Framework Phase 3 - Hexagonal Core Implementation
+
+**Plan ID**: PLAN-20260107-hexagonal-core
+**Status**: DRAFT - AWAITING APPROVAL
+**Author**: Claude (Distinguished Systems Engineering Persona)
+**Created**: 2026-01-07
+**Work Items**: WORK-010, WORK-011, WORK-012, WORK-013, WORK-014
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [5W1H Analysis](#2-5w1h-analysis)
+3. [Bounded Context Diagram](#3-bounded-context-diagram)
+4. [Package Diagram](#4-package-diagram)
+5. [Domain Model - Class Diagrams](#5-domain-model---class-diagrams)
+6. [Network/DTO Class Diagrams](#6-networkdto-class-diagrams)
+7. [Use Case Specifications](#7-use-case-specifications)
+8. [Sequence Diagrams](#8-sequence-diagrams)
+9. [Activity Diagrams](#9-activity-diagrams)
+10. [JSON Schemas](#10-json-schemas)
+11. [BDD Test Specifications](#11-bdd-test-specifications)
+12. [Implementation Plan](#12-implementation-plan)
+13. [Risk Analysis](#13-risk-analysis)
+14. [References](#14-references)
+
+---
+
+## 1. Executive Summary
+
+### 1.1 Purpose
+
+This plan defines the comprehensive design for the Jerry Framework's Hexagonal Core - a Python implementation following Domain-Driven Design (DDD), Hexagonal Architecture (Ports & Adapters), CQRS, and Event Sourcing patterns.
+
+### 1.2 Scope
+
+The Work Tracker bounded context - a local Azure DevOps/JIRA alternative that:
+- Persists task state across sessions (surviving context rot)
+- Implements CQRS with separate read/write models
+- Uses domain events for loose coupling
+- Follows pure BDD Red/Green/Refactor development
+
+### 1.3 Key Decisions
+
+| Decision | Choice | Rationale | Reference |
+|----------|--------|-----------|-----------|
+| Architecture | Hexagonal | Testability, framework independence | [Cockburn, 2005](https://alistair.cockburn.us/hexagonal-architecture/) |
+| Domain Pattern | DDD Tactical | Rich domain model, aggregates | [Evans, 2003](https://www.domainlanguage.com/ddd/) |
+| Data Pattern | CQRS + Events | Separate read/write, audit trail | [Cosmic Python](https://www.cosmicpython.com/book/chapter_12_cqrs.html) |
+| Persistence | SQLite + Event Store | Zero deps, event sourcing ready | [Microsoft](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing) |
+| Testing | BDD with pytest-bdd | Behavior-focused, collaboration | [pytest-bdd](https://pytest-bdd.readthedocs.io/) |
+
+---
+
+## 2. 5W1H Analysis
+
+### 2.1 WHO (Stakeholders)
+
+| Stakeholder | Role | Needs |
+|-------------|------|-------|
+| **Claude Code Agent** | Primary User | Track work across sessions, survive compaction |
+| **Human Developer** | Supervisor | Review progress, approve changes |
+| **QA Agent** | Quality Gate | Verify tests, validate behavior |
+| **Security Agent** | Security Gate | Review for vulnerabilities |
+
+### 2.2 WHAT (Deliverables)
+
+| Component | Description | Files |
+|-----------|-------------|-------|
+| **Domain Layer** | Pure business logic | `src/domain/` |
+| **Application Layer** | Use cases (CQRS) | `src/application/` |
+| **Infrastructure Layer** | Adapters | `src/infrastructure/` |
+| **Interface Layer** | CLI adapter | `src/interface/` |
+| **Test Suites** | BDD, Unit, Integration | `tests/` |
+
+### 2.3 WHEN (Timeline)
+
+| Phase | Components | Dependencies |
+|-------|------------|--------------|
+| 3.1 | Domain Layer | None |
+| 3.2 | Application Layer | 3.1 |
+| 3.3 | Infrastructure Layer | 3.1, 3.2 |
+| 3.4 | Interface Layer | 3.1, 3.2, 3.3 |
+| 3.5 | Integration Testing | All above |
+
+### 2.4 WHERE (Location)
+
+```
+jerry/
+├── src/
+│   ├── domain/           # WHERE: Business logic lives
+│   ├── application/      # WHERE: Use cases orchestrate
+│   ├── infrastructure/   # WHERE: Technical adapters live
+│   └── interface/        # WHERE: Entry points exist
+├── tests/
+│   ├── unit/             # WHERE: Unit tests
+│   ├── integration/      # WHERE: Integration tests
+│   ├── e2e/              # WHERE: End-to-end tests
+│   └── bdd/              # WHERE: BDD feature tests
+└── data/
+    └── worktracker/      # WHERE: Persistence storage
+```
+
+### 2.5 WHY (Justification)
+
+**Problem**: Context rot degrades LLM performance as context fills.
+
+> "The effective context window where models perform optimally is often <256k tokens"
+> — [Chroma Research](https://research.trychroma.com/context-rot)
+
+**Solution**: External memory via Work Tracker persists state outside context window.
+
+**Why These Patterns**:
+1. **Hexagonal**: Enables testing without infrastructure
+2. **DDD**: Rich domain model captures business rules
+3. **CQRS**: Optimized read/write paths
+4. **Events**: Audit trail, loose coupling
+
+### 2.6 HOW (Approach)
+
+**Development Methodology**: BDD Red/Green/Refactor
+
+```
+1. WRITE failing BDD scenario (RED)
+2. IMPLEMENT minimum code to pass (GREEN)
+3. REFACTOR for quality (REFACTOR)
+4. REPEAT
+```
+
+**Architecture Approach**: Outside-In
+
+```
+1. Define ports (interfaces) first
+2. Implement domain entities
+3. Create use cases
+4. Build adapters
+5. Wire together
+```
+
+---
+
+## 3. Bounded Context Diagram
+
+### 3.1 Context Map
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           JERRY FRAMEWORK                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    WORK TRACKER CONTEXT                           │  │
+│  │                    (Core Subdomain)                               │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │  WorkItem   │────▶│   Project   │     │   Sprint    │        │  │
+│  │  │ (Aggregate) │     │ (Aggregate) │     │ (Aggregate) │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  │         │                   │                   │                │  │
+│  │         ▼                   ▼                   ▼                │  │
+│  │  ┌─────────────────────────────────────────────────────┐        │  │
+│  │  │              Domain Events Bus                       │        │  │
+│  │  │  (WorkItemCreated, WorkItemCompleted, etc.)         │        │  │
+│  │  └─────────────────────────────────────────────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                   │                                      │
+│                                   │ Anti-Corruption Layer                │
+│                                   ▼                                      │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    KNOWLEDGE CONTEXT                              │  │
+│  │                    (Supporting Subdomain)                         │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │  Document   │     │  Decision   │     │  Learning   │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    GOVERNANCE CONTEXT                             │  │
+│  │                    (Generic Subdomain)                            │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │    Agent    │     │    Hook     │     │    Rule     │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Legend:
+  ─────▶  Uses/References
+  - - -▶  Publishes Events To
+```
+
+### 3.2 Context Relationships
+
+| Upstream | Downstream | Relationship | Pattern |
+|----------|------------|--------------|---------|
+| Work Tracker | Knowledge | Publisher-Subscriber | Domain Events |
+| Work Tracker | Governance | Conformist | Shared Kernel |
+| Governance | Work Tracker | Open Host Service | REST/CLI |
+
+---
+
+## 4. Package Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              src/                                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                        interface/                                │    │
+│  │  ┌─────────────┐    ┌─────────────┐                             │    │
+│  │  │    cli/     │    │    api/     │   (Primary Adapters)        │    │
+│  │  │  main.py    │    │ controllers │                             │    │
+│  │  │  formatter  │    │             │                             │    │
+│  │  └──────┬──────┘    └──────┬──────┘                             │    │
+│  └─────────┼──────────────────┼────────────────────────────────────┘    │
+│            │                  │                                          │
+│            ▼                  ▼                                          │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                       application/                               │    │
+│  │  ┌─────────────────────────────────────────────────────────┐    │    │
+│  │  │                    use_cases/                            │    │    │
+│  │  │  ┌──────────────┐         ┌──────────────┐              │    │    │
+│  │  │  │  commands/   │         │   queries/   │              │    │    │
+│  │  │  │              │         │              │              │    │    │
+│  │  │  │ CreateItem   │         │ GetItem      │              │    │    │
+│  │  │  │ UpdateItem   │         │ ListItems    │              │    │    │
+│  │  │  │ CompleteItem │         │ SearchItems  │              │    │    │
+│  │  │  └──────────────┘         └──────────────┘              │    │    │
+│  │  └─────────────────────────────────────────────────────────┘    │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │    dtos/     │    │ dispatcher/  │    │  services/   │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                 │                                        │
+│                                 ▼                                        │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                         domain/                                  │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │ aggregates/  │    │value_objects/│    │   events/    │       │    │
+│  │  │              │    │              │    │              │       │    │
+│  │  │ WorkItem     │    │ Status       │    │ ItemCreated  │       │    │
+│  │  │ Project      │    │ Priority     │    │ ItemCompleted│       │    │
+│  │  │              │    │ WorkItemId   │    │ ItemUpdated  │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  │  ┌──────────────┐    ┌──────────────┐                           │    │
+│  │  │   ports/     │    │ exceptions/  │   (NO EXTERNAL DEPS)      │    │
+│  │  │              │    │              │                           │    │
+│  │  │ IRepository  │    │ DomainError  │                           │    │
+│  │  │ IEventStore  │    │ NotFound     │                           │    │
+│  │  │ INotifier    │    │ InvalidState │                           │    │
+│  │  └──────┬───────┘    └──────────────┘                           │    │
+│  └─────────┼───────────────────────────────────────────────────────┘    │
+│            │                                                             │
+│            │ implements                                                  │
+│            ▼                                                             │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                      infrastructure/                             │    │
+│  │  ┌─────────────────────────────────────────────────────────┐    │    │
+│  │  │                    persistence/                          │    │    │
+│  │  │  ┌──────────────┐         ┌──────────────┐              │    │    │
+│  │  │  │   sqlite/    │         │     fs/      │              │    │    │
+│  │  │  │              │         │              │              │    │    │
+│  │  │  │ repository   │         │ md_adapter   │              │    │    │
+│  │  │  │ event_store  │         │              │              │    │    │
+│  │  │  └──────────────┘         └──────────────┘              │    │    │
+│  │  └─────────────────────────────────────────────────────────┘    │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │  messaging/  │    │   schemas/   │    │ dispatcher/  │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Dependency Rules:
+  interface/     → application/, infrastructure/, domain/
+  application/   → domain/ ONLY
+  infrastructure/→ domain/, application/
+  domain/        → NOTHING (stdlib only)
+```
+
+---
+
+## 5. Domain Model - Class Diagrams
+
+### 5.1 WorkItem Aggregate
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         <<Aggregate Root>>                               │
+│                            WorkItem                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ - _id: WorkItemId                                                        │
+│ - _title: str                                                            │
+│ - _description: str                                                      │
+│ - _type: WorkItemType                                                    │
+│ - _status: Status                                                        │
+│ - _priority: Priority                                                    │
+│ - _parent_id: WorkItemId | None                                          │
+│ - _created_at: datetime                                                  │
+│ - _updated_at: datetime                                                  │
+│ - _completed_at: datetime | None                                         │
+│ - _notes: list[Note]                                                     │
+│ - _tags: list[Tag]                                                       │
+│ - _events: list[DomainEvent]                                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<class methods>>                                                        │
+│ + create(title, type, priority, parent_id?) → WorkItem                   │
+│ + reconstitute(events: list[DomainEvent]) → WorkItem                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<properties>>                                                           │
+│ + id: WorkItemId {readonly}                                              │
+│ + title: str {readonly}                                                  │
+│ + status: Status {readonly}                                              │
+│ + priority: Priority {readonly}                                          │
+│ + is_completed: bool {readonly}                                          │
+│ + is_blocked: bool {readonly}                                            │
+│ + pending_events: list[DomainEvent] {readonly}                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<commands>>                                                             │
+│ + update_title(new_title: str) → None                                    │
+│ + update_description(desc: str) → None                                   │
+│ + change_priority(priority: Priority) → None                             │
+│ + start() → None                          # pending → in_progress        │
+│ + block(reason: str) → None               # → blocked                    │
+│ + unblock() → None                        # blocked → in_progress        │
+│ + complete(notes: str?) → None            # → completed                  │
+│ + reopen() → None                         # completed → pending          │
+│ + add_note(content: str) → None                                          │
+│ + add_tag(tag: Tag) → None                                               │
+│ + remove_tag(tag: Tag) → None                                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<internal>>                                                             │
+│ - _apply(event: DomainEvent) → None                                      │
+│ - _raise_event(event: DomainEvent) → None                                │
+│ - _validate_state_transition(from: Status, to: Status) → None            │
+└─────────────────────────────────────────────────────────────────────────┘
+           │
+           │ contains
+           ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                               Note                                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + content: str {readonly, frozen}                                        │
+│ + created_at: datetime {readonly, frozen}                                │
+│ + author: str {readonly, frozen}                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __eq__(other: Note) → bool                                             │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Value Objects
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                            WorkItemId                                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + value: str {readonly, frozen}                                          │
+│ + prefix: str = "WORK" {class attr}                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<class methods>>                                                        │
+│ + generate() → WorkItemId                                                │
+│ + from_string(value: str) → WorkItemId                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __str__() → str                         # "WORK-001"                   │
+│ + __eq__(other) → bool                                                   │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                              Status                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ PENDING = "pending"                                                      │
+│ IN_PROGRESS = "in_progress"                                              │
+│ BLOCKED = "blocked"                                                      │
+│ COMPLETED = "completed"                                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + can_transition_to(target: Status) → bool                               │
+│ + valid_transitions() → set[Status]                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                             Priority                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ CRITICAL = 1                                                             │
+│ HIGH = 2                                                                 │
+│ MEDIUM = 3                                                               │
+│ LOW = 4                                                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __lt__(other: Priority) → bool          # For sorting                  │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                           WorkItemType                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ EPIC = "epic"                                                            │
+│ FEATURE = "feature"                                                      │
+│ TASK = "task"                                                            │
+│ BUG = "bug"                                                              │
+│ SPIKE = "spike"                                                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + can_have_children() → bool              # epic, feature can            │
+│ + allowed_parent_types() → set[WorkItemType]                             │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                               Tag                                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + name: str {readonly, frozen}                                           │
+│ + color: str | None {readonly, frozen}                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __eq__(other: Tag) → bool                                              │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 Domain Events
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Abstract>>                                   │
+│                          DomainEvent                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + event_id: UUID {readonly}                                              │
+│ + event_type: str {readonly}                                             │
+│ + aggregate_id: str {readonly}                                           │
+│ + aggregate_type: str {readonly}                                         │
+│ + occurred_at: datetime {readonly}                                       │
+│ + version: int {readonly}                                                │
+│ + payload: dict {readonly}                                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + to_dict() → dict                                                       │
+│ + from_dict(data: dict) → DomainEvent {class method}                     │
+└─────────────────────────────────────────────────────────────────────────┘
+           △
+           │ extends
+           │
+     ┌─────┴─────┬─────────────┬──────────────┬──────────────┐
+     │           │             │              │              │
+┌────┴────┐ ┌────┴────┐ ┌──────┴──────┐ ┌─────┴─────┐ ┌──────┴──────┐
+│WorkItem │ │WorkItem │ │  WorkItem   │ │ WorkItem  │ │  WorkItem   │
+│Created  │ │Started  │ │  Completed  │ │  Blocked  │ │   Updated   │
+├─────────┤ ├─────────┤ ├─────────────┤ ├───────────┤ ├─────────────┤
+│+title   │ │         │ │+completed_at│ │+reason    │ │+field       │
+│+type    │ │         │ │+notes       │ │           │ │+old_value   │
+│+priority│ │         │ │             │ │           │ │+new_value   │
+└─────────┘ └─────────┘ └─────────────┘ └───────────┘ └─────────────┘
+```
+
+### 5.4 Port Interfaces
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                       IWorkItemRepository                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + save(item: WorkItem) → None                                            │
+│ + get(id: WorkItemId) → WorkItem | None                                  │
+│ + get_all() → list[WorkItem]                                             │
+│ + get_by_status(status: Status) → list[WorkItem]                         │
+│ + get_by_parent(parent_id: WorkItemId) → list[WorkItem]                  │
+│ + delete(id: WorkItemId) → None                                          │
+│ + exists(id: WorkItemId) → bool                                          │
+│ + next_id() → WorkItemId                                                 │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                          IEventStore                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + append(aggregate_id: str, events: list[DomainEvent]) → None            │
+│ + get_events(aggregate_id: str) → list[DomainEvent]                      │
+│ + get_events_since(aggregate_id: str, version: int) → list[DomainEvent]  │
+│ + get_all_events() → list[DomainEvent]                                   │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                         IEventDispatcher                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + dispatch(event: DomainEvent) → None                                    │
+│ + dispatch_all(events: list[DomainEvent]) → None                         │
+│ + subscribe(event_type: str, handler: Callable) → None                   │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                            IUnitOfWork                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + work_items: IWorkItemRepository {readonly}                             │
+│ + __enter__() → IUnitOfWork                                              │
+│ + __exit__(exc_type, exc_val, exc_tb) → None                             │
+│ + commit() → None                                                        │
+│ + rollback() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Network/DTO Class Diagrams
+
+### 6.1 Data Transfer Objects (Read Models)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                          WorkItemDTO                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                                                │
+│ + title: str                                                             │
+│ + description: str                                                       │
+│ + type: str                                                              │
+│ + status: str                                                            │
+│ + priority: str                                                          │
+│ + parent_id: str | None                                                  │
+│ + created_at: str                         # ISO 8601                     │
+│ + updated_at: str                         # ISO 8601                     │
+│ + completed_at: str | None                # ISO 8601                     │
+│ + notes: list[NoteDTO]                                                   │
+│ + tags: list[str]                                                        │
+│ + children_count: int                                                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + to_dict() → dict                                                       │
+│ + from_dict(data: dict) → WorkItemDTO {class method}                     │
+│ + from_entity(entity: WorkItem) → WorkItemDTO {class method}             │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                        WorkItemSummaryDTO                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                                                │
+│ + title: str                                                             │
+│ + status: str                                                            │
+│ + priority: str                                                          │
+│ + type: str                                                              │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                        WorkTrackerStatsDTO                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + total_items: int                                                       │
+│ + by_status: dict[str, int]                                              │
+│ + by_priority: dict[str, int]                                            │
+│ + by_type: dict[str, int]                                                │
+│ + completed_today: int                                                   │
+│ + created_today: int                                                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                             NoteDTO                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + content: str                                                           │
+│ + created_at: str                         # ISO 8601                     │
+│ + author: str                                                            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 6.2 Command Objects (Write Models)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                       CreateWorkItemCommand                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + title: str                              # required                     │
+│ + description: str = ""                   # optional                     │
+│ + type: str = "task"                      # optional                     │
+│ + priority: str = "medium"                # optional                     │
+│ + parent_id: str | None = None            # optional                     │
+│ + tags: list[str] = []                    # optional                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                       # raises ValidationError       │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                       UpdateWorkItemCommand                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+│ + title: str | None = None                # optional                     │
+│ + description: str | None = None          # optional                     │
+│ + priority: str | None = None             # optional                     │
+│ + status: str | None = None               # optional                     │
+│ + notes: str | None = None                # optional (adds note)         │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                      CompleteWorkItemCommand                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+│ + notes: str | None = None                # optional                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                         GetWorkItemQuery                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                        ListWorkItemsQuery                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + status: list[str] | None = None         # filter                       │
+│ + priority: list[str] | None = None       # filter                       │
+│ + type: list[str] | None = None           # filter                       │
+│ + parent_id: str | None = None            # filter                       │
+│ + limit: int = 50                         # pagination                   │
+│ + offset: int = 0                         # pagination                   │
+│ + sort_by: str = "created_at"             # sorting                      │
+│ + sort_order: str = "desc"                # asc/desc                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                       SearchWorkItemsQuery                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + query: str                              # search text                  │
+│ + include_completed: bool = False         # filter                       │
+│ + limit: int = 20                         # pagination                   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Use Case Specifications
+
+### 7.1 Commands (Write Operations)
+
+#### UC-CMD-001: Create Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | CreateWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | None |
+| **Postconditions** | Work item exists in repository, WorkItemCreated event emitted |
+| **Trigger** | `@worktracker create <title>` |
+
+**Main Flow**:
+1. Validate command input
+2. Generate new WorkItemId
+3. Create WorkItem aggregate via factory method
+4. Save to repository within Unit of Work
+5. Dispatch WorkItemCreated event
+6. Return created WorkItemDTO
+
+**Alternative Flows**:
+- **A1**: Invalid title (empty) → Raise ValidationError
+- **A2**: Invalid parent_id → Raise WorkItemNotFoundError
+- **A3**: Invalid type for parent → Raise InvalidHierarchyError
+
+**Business Rules**:
+- Title must be non-empty, max 200 characters
+- Tasks can only have Features/Epics as parents
+- Bugs can only have Features/Epics as parents
+
+---
+
+#### UC-CMD-002: Update Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | UpdateWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | Work item exists |
+| **Postconditions** | Work item updated, WorkItemUpdated event(s) emitted |
+
+**Main Flow**:
+1. Validate command input
+2. Load WorkItem from repository
+3. Apply updates to aggregate
+4. Save to repository
+5. Dispatch events
+6. Return updated WorkItemDTO
+
+**Alternative Flows**:
+- **A1**: Work item not found → Raise WorkItemNotFoundError
+- **A2**: Invalid status transition → Raise InvalidStateTransitionError
+
+---
+
+#### UC-CMD-003: Complete Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | CompleteWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | Work item exists, not already completed |
+| **Postconditions** | Status = completed, WorkItemCompleted event emitted |
+
+**Main Flow**:
+1. Load WorkItem
+2. Call `work_item.complete(notes)`
+3. Save and dispatch events
+
+**Business Rules**:
+- Cannot complete if already completed
+- Cannot complete if blocked (must unblock first)
+- Completing parent does NOT auto-complete children
+
+---
+
+### 7.2 Queries (Read Operations)
+
+#### UC-QRY-001: Get Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | GetWorkItem |
+| **Input** | id: str |
+| **Output** | WorkItemDTO | None |
+
+---
+
+#### UC-QRY-002: List Work Items
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | ListWorkItems |
+| **Input** | ListWorkItemsQuery |
+| **Output** | list[WorkItemSummaryDTO] |
+
+---
+
+#### UC-QRY-003: Search Work Items
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | SearchWorkItems |
+| **Input** | SearchWorkItemsQuery |
+| **Output** | list[WorkItemSummaryDTO] |
+
+**Search Behavior**:
+- Searches title, description, and notes
+- Case-insensitive
+- Supports partial matches
+
+---
+
+#### UC-QRY-004: Get Work Tracker Stats
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | GetWorkTrackerStats |
+| **Input** | time_range: str (optional) |
+| **Output** | WorkTrackerStatsDTO |
+
+---
+
+## 8. Sequence Diagrams
+
+### 8.1 Create Work Item Flow
+
+```
+┌─────┐          ┌─────┐          ┌──────────┐          ┌──────────┐          ┌─────────┐
+│ CLI │          │ Use │          │ WorkItem │          │Repository│          │ Event   │
+│     │          │Case │          │          │          │          │          │Dispatcher│
+└──┬──┘          └──┬──┘          └────┬─────┘          └────┬─────┘          └────┬────┘
+   │                │                   │                    │                     │
+   │ create("title")│                   │                    │                     │
+   │───────────────>│                   │                    │                     │
+   │                │                   │                    │                     │
+   │                │  validate()       │                    │                     │
+   │                │──────────────────>│                    │                     │
+   │                │                   │                    │                     │
+   │                │               next_id()                │                     │
+   │                │───────────────────────────────────────>│                     │
+   │                │                   │                    │                     │
+   │                │                   │<───────────────────│                     │
+   │                │                   │    WORK-001        │                     │
+   │                │                   │                    │                     │
+   │                │ WorkItem.create() │                    │                     │
+   │                │──────────────────>│                    │                     │
+   │                │                   │                    │                     │
+   │                │                   │ ┌─────────────────┐│                     │
+   │                │                   │ │_raise_event(    ││                     │
+   │                │                   │ │WorkItemCreated) ││                     │
+   │                │                   │ └─────────────────┘│                     │
+   │                │                   │                    │                     │
+   │                │<──────────────────│                    │                     │
+   │                │     WorkItem      │                    │                     │
+   │                │                   │                    │                     │
+   │                │               save(item)               │                     │
+   │                │───────────────────────────────────────>│                     │
+   │                │                   │                    │                     │
+   │                │                   │                    │ dispatch(event)     │
+   │                │──────────────────────────────────────────────────────────────>│
+   │                │                   │                    │                     │
+   │<───────────────│                   │                    │                     │
+   │  WorkItemDTO   │                   │                    │                     │
+   │                │                   │                    │                     │
+```
+
+### 8.2 Complete Work Item Flow (with State Transition)
+
+```
+┌─────┐          ┌─────┐          ┌──────────┐          ┌──────────┐
+│ CLI │          │ Use │          │ WorkItem │          │Repository│
+│     │          │Case │          │          │          │          │
+└──┬──┘          └──┬──┘          └────┬─────┘          └────┬─────┘
+   │                │                   │                    │
+   │complete("WORK-001", notes)         │                    │
+   │───────────────>│                   │                    │
+   │                │                   │                    │
+   │                │              get("WORK-001")           │
+   │                │───────────────────────────────────────>│
+   │                │                   │                    │
+   │                │<───────────────────────────────────────│
+   │                │                WorkItem                │
+   │                │                   │                    │
+   │                │  complete(notes)  │                    │
+   │                │──────────────────>│                    │
+   │                │                   │                    │
+   │                │                   │ ┌─────────────────────────┐
+   │                │                   │ │_validate_state_transition│
+   │                │                   │ │(in_progress → completed) │
+   │                │                   │ └─────────────────────────┘
+   │                │                   │                    │
+   │                │                   │ ┌─────────────────┐│
+   │                │                   │ │_raise_event(    ││
+   │                │                   │ │WorkItemCompleted││
+   │                │                   │ └─────────────────┘│
+   │                │                   │                    │
+   │                │<──────────────────│                    │
+   │                │       OK          │                    │
+   │                │                   │                    │
+   │                │               save(item)               │
+   │                │───────────────────────────────────────>│
+   │                │                   │                    │
+   │<───────────────│                   │                    │
+   │  WorkItemDTO   │                   │                    │
+```
+
+---
+
+## 9. Activity Diagrams
+
+### 9.1 Work Item State Machine
+
+```
+                              ┌─────────────┐
+                              │   START     │
+                              └──────┬──────┘
+                                     │
+                                     ▼
+                              ┌─────────────┐
+                        ┌────▶│   PENDING   │◀────┐
+                        │     └──────┬──────┘     │
+                        │            │            │
+                        │     start()│            │reopen()
+                        │            ▼            │
+                        │     ┌─────────────┐     │
+                        │     │ IN_PROGRESS │─────┤
+                        │     └──────┬──────┘     │
+                        │            │            │
+                 unblock()    block()│            │
+                        │            ▼            │
+                        │     ┌─────────────┐     │
+                        └─────│   BLOCKED   │     │
+                              └─────────────┘     │
+                                     │            │
+                                     │complete()  │
+                                     ▼            │
+                              ┌─────────────┐     │
+                              │  COMPLETED  │─────┘
+                              └──────┬──────┘
+                                     │
+                                     ▼
+                              ┌─────────────┐
+                              │    END      │
+                              └─────────────┘
+
+State Transition Rules:
+┌──────────────┬────────────────────────────────────────────┐
+│ From State   │ Valid Transitions                          │
+├──────────────┼────────────────────────────────────────────┤
+│ PENDING      │ IN_PROGRESS (start)                        │
+│ IN_PROGRESS  │ BLOCKED (block), COMPLETED (complete)      │
+│ BLOCKED      │ IN_PROGRESS (unblock)                      │
+│ COMPLETED    │ PENDING (reopen)                           │
+└──────────────┴────────────────────────────────────────────┘
+```
+
+### 9.2 Create Work Item Activity
+
+```
+┌─────────────┐
+│   START     │
+└──────┬──────┘
+       │
+       ▼
+┌─────────────────────┐
+│ Receive Command     │
+└──────────┬──────────┘
+           │
+           ▼
+     ┌───────────┐
+     │ Validate  │
+     │  Input?   │
+     └─────┬─────┘
+           │
+     ┌─────┴─────┐
+     │           │
+    YES          NO
+     │           │
+     ▼           ▼
+┌─────────┐  ┌─────────────┐
+│Generate │  │ Raise       │
+│   ID    │  │ Validation  │
+└────┬────┘  │ Error       │
+     │       └──────┬──────┘
+     ▼              │
+┌─────────────┐     │
+│ Create      │     │
+│ Aggregate   │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Raise       │     │
+│ Domain Event│     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Save to     │     │
+│ Repository  │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Dispatch    │     │
+│ Events      │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Return DTO  │     │
+└──────┬──────┘     │
+       │            │
+       ▼            ▼
+┌─────────────────────┐
+│        END          │
+└─────────────────────┘
+```
+
+---
+
+## 10. JSON Schemas
+
+### 10.1 Work Item Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/work-item.json",
+  "title": "WorkItem",
+  "description": "A work item in the Jerry Work Tracker",
+  "type": "object",
+  "required": ["id", "title", "type", "status", "priority", "created_at", "updated_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^WORK-[0-9]+$",
+      "description": "Unique identifier",
+      "examples": ["WORK-001", "WORK-123"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Short description of the work item"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 10000,
+      "default": "",
+      "description": "Detailed description"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["epic", "feature", "task", "bug", "spike"],
+      "default": "task"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "in_progress", "blocked", "completed"],
+      "default": "pending"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "default": "medium"
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "pattern": "^WORK-[0-9]+$",
+      "default": null
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "default": null
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Note"
+      },
+      "default": []
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "default": []
+    }
+  },
+  "$defs": {
+    "Note": {
+      "type": "object",
+      "required": ["content", "created_at"],
+      "properties": {
+        "content": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "author": {
+          "type": "string",
+          "default": "claude"
+        }
+      }
+    }
+  }
+}
+```
+
+### 10.2 Domain Event Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/domain-event.json",
+  "title": "DomainEvent",
+  "description": "Base schema for domain events",
+  "type": "object",
+  "required": ["event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at", "version"],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "WorkItemCreated",
+        "WorkItemUpdated",
+        "WorkItemStarted",
+        "WorkItemBlocked",
+        "WorkItemUnblocked",
+        "WorkItemCompleted",
+        "WorkItemReopened",
+        "NoteAdded",
+        "TagAdded",
+        "TagRemoved"
+      ]
+    },
+    "aggregate_id": {
+      "type": "string"
+    },
+    "aggregate_type": {
+      "type": "string",
+      "enum": ["WorkItem", "Project"]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}
+```
+
+### 10.3 Command Schemas
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/commands/create-work-item.json",
+  "title": "CreateWorkItemCommand",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 10000,
+      "default": ""
+    },
+    "type": {
+      "type": "string",
+      "enum": ["epic", "feature", "task", "bug", "spike"],
+      "default": "task"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "default": "medium"
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "pattern": "^WORK-[0-9]+$"
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    }
+  }
+}
+```
+
+---
+
+## 11. BDD Test Specifications
+
+### 11.1 Feature: Create Work Item
+
+```gherkin
+Feature: Create Work Item
+  As a Claude Code agent
+  I want to create work items
+  So that I can track tasks across sessions
+
+  Background:
+    Given the work tracker is initialized
+    And no work items exist
+
+  @unit @happy-path
+  Scenario: Create a simple task
+    When I create a work item with title "Implement user authentication"
+    Then a work item should be created with id "WORK-001"
+    And the work item status should be "pending"
+    And the work item type should be "task"
+    And the work item priority should be "medium"
+    And a WorkItemCreated event should be raised
+
+  @unit @happy-path
+  Scenario: Create a feature with custom priority
+    When I create a work item with:
+      | title    | Add caching layer |
+      | type     | feature           |
+      | priority | high              |
+    Then a work item should be created
+    And the work item type should be "feature"
+    And the work item priority should be "high"
+
+  @unit @edge-case
+  Scenario: Create task with parent feature
+    Given a work item exists with:
+      | id   | WORK-001        |
+      | type | feature         |
+      | title| Parent Feature  |
+    When I create a work item with:
+      | title     | Child Task |
+      | type      | task       |
+      | parent_id | WORK-001   |
+    Then the work item should have parent_id "WORK-001"
+
+  @unit @error-case
+  Scenario: Fail to create with empty title
+    When I attempt to create a work item with title ""
+    Then a ValidationError should be raised
+    And the error message should contain "title"
+
+  @unit @error-case
+  Scenario: Fail to create with invalid parent
+    When I attempt to create a work item with:
+      | title     | Orphan Task  |
+      | parent_id | WORK-999     |
+    Then a WorkItemNotFoundError should be raised
+
+  @unit @error-case
+  Scenario: Fail to create task under task
+    Given a work item exists with:
+      | id   | WORK-001 |
+      | type | task     |
+    When I attempt to create a work item with:
+      | title     | Nested Task |
+      | type      | task        |
+      | parent_id | WORK-001    |
+    Then an InvalidHierarchyError should be raised
+```
+
+### 11.2 Feature: Work Item State Transitions
+
+```gherkin
+Feature: Work Item State Transitions
+  As a Claude Code agent
+  I want to change work item status
+  So that I can track progress accurately
+
+  Background:
+    Given a work item exists with:
+      | id     | WORK-001           |
+      | title  | Test Item          |
+      | status | pending            |
+
+  @unit @state-machine
+  Scenario: Start a pending work item
+    When I start work item "WORK-001"
+    Then the work item status should be "in_progress"
+    And a WorkItemStarted event should be raised
+
+  @unit @state-machine
+  Scenario: Block an in-progress work item
+    Given work item "WORK-001" has status "in_progress"
+    When I block work item "WORK-001" with reason "Waiting for API access"
+    Then the work item status should be "blocked"
+    And a WorkItemBlocked event should be raised with reason "Waiting for API access"
+
+  @unit @state-machine
+  Scenario: Complete an in-progress work item
+    Given work item "WORK-001" has status "in_progress"
+    When I complete work item "WORK-001" with notes "All tests passing"
+    Then the work item status should be "completed"
+    And the work item completed_at should be set
+    And a WorkItemCompleted event should be raised
+
+  @unit @state-machine @error-case
+  Scenario: Cannot complete a pending work item directly
+    When I attempt to complete work item "WORK-001"
+    Then an InvalidStateTransitionError should be raised
+    And the error message should contain "pending" and "completed"
+
+  @unit @state-machine @error-case
+  Scenario: Cannot complete a blocked work item
+    Given work item "WORK-001" has status "blocked"
+    When I attempt to complete work item "WORK-001"
+    Then an InvalidStateTransitionError should be raised
+
+  @unit @state-machine
+  Scenario: Reopen a completed work item
+    Given work item "WORK-001" has status "completed"
+    When I reopen work item "WORK-001"
+    Then the work item status should be "pending"
+    And the work item completed_at should be null
+    And a WorkItemReopened event should be raised
+```
+
+### 11.3 Feature: Query Work Items
+
+```gherkin
+Feature: Query Work Items
+  As a Claude Code agent
+  I want to query work items
+  So that I can understand current state
+
+  Background:
+    Given work items exist:
+      | id       | title          | status      | priority | type    |
+      | WORK-001 | Task One       | pending     | high     | task    |
+      | WORK-002 | Task Two       | in_progress | medium   | task    |
+      | WORK-003 | Task Three     | completed   | low      | task    |
+      | WORK-004 | Feature One    | in_progress | high     | feature |
+
+  @integration @query
+  Scenario: List all pending and in-progress items
+    When I list work items with status "pending,in_progress"
+    Then I should receive 3 work items
+    And the results should include "WORK-001", "WORK-002", "WORK-004"
+    And the results should not include "WORK-003"
+
+  @integration @query
+  Scenario: List high priority items
+    When I list work items with priority "high"
+    Then I should receive 2 work items
+    And the results should include "WORK-001", "WORK-004"
+
+  @integration @query
+  Scenario: Search by title
+    When I search work items for "Task"
+    Then I should receive 2 work items
+    And the results should include "WORK-001", "WORK-002"
+
+  @integration @query
+  Scenario: Get work tracker stats
+    When I get work tracker stats
+    Then the total_items should be 4
+    And by_status should show:
+      | status      | count |
+      | pending     | 1     |
+      | in_progress | 2     |
+      | completed   | 1     |
+```
+
+---
+
+## 12. Implementation Plan
+
+### 12.1 Phase 3.1: Domain Layer (BDD)
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-011.1**: WorkItemId VO | Implement, validate | Unit: generation, parsing, equality |
+| **WORK-011.2**: Status VO | Implement with transitions | Unit: all transitions, invalid transitions |
+| **WORK-011.3**: Priority VO | Implement with ordering | Unit: ordering, comparison |
+| **WORK-011.4**: WorkItemType VO | Implement with hierarchy rules | Unit: parent rules |
+| **WORK-011.5**: Note VO | Implement immutable | Unit: immutability |
+| **WORK-011.6**: Tag VO | Implement immutable | Unit: equality, hash |
+| **WORK-011.7**: DomainEvent base | Implement base class | Unit: serialization |
+| **WORK-011.8**: WorkItem events | All event types | Unit: payload validation |
+| **WORK-011.9**: DomainException | Exception hierarchy | Unit: messages |
+| **WORK-011.10**: WorkItem aggregate | Full implementation | BDD: all scenarios above |
+| **WORK-011.11**: Port interfaces | Define protocols | Architecture: dependency direction |
+
+### 12.2 Phase 3.2: Application Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-012.1**: DTOs | All DTO classes | Unit: serialization |
+| **WORK-012.2**: Commands | Command classes | Unit: validation |
+| **WORK-012.3**: Queries | Query classes | Unit: defaults |
+| **WORK-012.4**: CreateWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.5**: UpdateWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.6**: CompleteWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.7**: GetWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.8**: ListWorkItems handler | Implement | Integration: filtering |
+| **WORK-012.9**: SearchWorkItems handler | Implement | Integration: search |
+
+### 12.3 Phase 3.3: Infrastructure Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-013.1**: SQLite schema | Design and create | Integration: migrations |
+| **WORK-013.2**: SQLiteRepository | Implement IRepository | Integration: CRUD |
+| **WORK-013.3**: SQLiteEventStore | Implement IEventStore | Integration: append/read |
+| **WORK-013.4**: SQLiteUnitOfWork | Implement IUnitOfWork | Integration: transactions |
+| **WORK-013.5**: EventDispatcher | Implement dispatcher | Unit: subscription |
+| **WORK-013.6**: JSON schemas | Create schema files | Contract: validation |
+
+### 12.4 Phase 3.4: Interface Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-014.1**: CLI argument parser | Implement argparse | Unit: parsing |
+| **WORK-014.2**: CLI formatters | Table, JSON output | Unit: formatting |
+| **WORK-014.3**: CLI commands | All skill commands | E2E: full workflows |
+| **WORK-014.4**: Error handling | User-friendly messages | E2E: error cases |
+
+### 12.5 Phase 3.5: Integration & E2E
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-015.1**: Dependency wiring | Composition root | Architecture: DI |
+| **WORK-015.2**: E2E test suite | Full workflow tests | E2E: happy paths |
+| **WORK-015.3**: Edge case suite | Failure scenarios | E2E: edge cases |
+| **WORK-015.4**: Performance tests | Load testing | Performance: benchmarks |
+
+---
+
+## 13. Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| SQLite concurrency limits | Medium | Medium | Use WAL mode, single-writer |
+| Event replay performance | Low | Medium | Implement snapshots |
+| Schema evolution | Medium | High | Version events, migration scripts |
+| Test coverage gaps | Medium | High | Mutation testing, coverage gates |
+| Context window pressure | Medium | High | Lazy loading, pagination |
+
+---
+
+## 14. References
+
+### Primary Sources
+
+1. Evans, E. (2003). "Domain-Driven Design: Tackling Complexity in the Heart of Software"
+2. Vernon, V. (2013). "Implementing Domain-Driven Design"
+3. Cockburn, A. (2005). "[Hexagonal Architecture](https://alistair.cockburn.us/hexagonal-architecture/)"
+4. Percival, H. & Gregory, B. "[Architecture Patterns with Python](https://www.cosmicpython.com/)"
+5. Microsoft. "[Event Sourcing Pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing)"
+6. Fowler, M. "[Domain Event](https://martinfowler.com/eaaDev/DomainEvent.html)"
+
+### Implementation References
+
+7. "[Cosmic Python - CQRS](https://www.cosmicpython.com/book/chapter_12_cqrs.html)"
+8. "[Cosmic Python - Repository Pattern](https://www.cosmicpython.com/book/chapter_02_repository.html)"
+9. "[Cosmic Python - Unit of Work](https://www.cosmicpython.com/book/chapter_06_uow.html)"
+10. "[pytest-bdd Documentation](https://pytest-bdd.readthedocs.io/)"
+11. "[DDD in Python](https://dddinpython.com/)"
+12. "[Atlassian JIRA Schema](https://support.atlassian.com/analytics/docs/schema-for-jira-software/)"
+
+---
+
+## Approval
+
+| Role | Name | Status | Date |
+|------|------|--------|------|
+| **Author** | Claude | SUBMITTED | 2026-01-07 |
+| **Reviewer** | User | PENDING | - |
+| **Approver** | User | PENDING | - |
+
+---
+
+**Next Steps Upon Approval**:
+1. Create detailed sub-task breakdown in WORKTRACKER.md
+2. Begin Phase 3.1 with Domain Layer BDD tests
+3. Implement WorkItemId value object (first RED test)

--- a/docs/archive/projects-archive/plans/backups/PLAN.bkup.md
+++ b/docs/archive/projects-archive/plans/backups/PLAN.bkup.md
@@ -1,0 +1,1458 @@
+# PLAN: Jerry Framework Phase 3 - Hexagonal Core Implementation
+
+**Plan ID**: PLAN-20260107-hexagonal-core
+**Status**: DRAFT - AWAITING APPROVAL
+**Author**: Claude (Distinguished Systems Engineering Persona)
+**Created**: 2026-01-07
+**Work Items**: WORK-010, WORK-011, WORK-012, WORK-013, WORK-014
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [5W1H Analysis](#2-5w1h-analysis)
+3. [Bounded Context Diagram](#3-bounded-context-diagram)
+4. [Package Diagram](#4-package-diagram)
+5. [Domain Model - Class Diagrams](#5-domain-model---class-diagrams)
+6. [Network/DTO Class Diagrams](#6-networkdto-class-diagrams)
+7. [Use Case Specifications](#7-use-case-specifications)
+8. [Sequence Diagrams](#8-sequence-diagrams)
+9. [Activity Diagrams](#9-activity-diagrams)
+10. [JSON Schemas](#10-json-schemas)
+11. [BDD Test Specifications](#11-bdd-test-specifications)
+12. [Implementation Plan](#12-implementation-plan)
+13. [Risk Analysis](#13-risk-analysis)
+14. [References](#14-references)
+
+---
+
+## 1. Executive Summary
+
+### 1.1 Purpose
+
+This plan defines the comprehensive design for the Jerry Framework's Hexagonal Core - a Python implementation following Domain-Driven Design (DDD), Hexagonal Architecture (Ports & Adapters), CQRS, and Event Sourcing patterns.
+
+### 1.2 Scope
+
+The Work Tracker bounded context - a local Azure DevOps/JIRA alternative that:
+- Persists task state across sessions (surviving context rot)
+- Implements CQRS with separate read/write models
+- Uses domain events for loose coupling
+- Follows pure BDD Red/Green/Refactor development
+
+### 1.3 Key Decisions
+
+| Decision | Choice | Rationale | Reference |
+|----------|--------|-----------|-----------|
+| Architecture | Hexagonal | Testability, framework independence | [Cockburn, 2005](https://alistair.cockburn.us/hexagonal-architecture/) |
+| Domain Pattern | DDD Tactical | Rich domain model, aggregates | [Evans, 2003](https://www.domainlanguage.com/ddd/) |
+| Data Pattern | CQRS + Events | Separate read/write, audit trail | [Cosmic Python](https://www.cosmicpython.com/book/chapter_12_cqrs.html) |
+| Persistence | SQLite + Event Store | Zero deps, event sourcing ready | [Microsoft](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing) |
+| Testing | BDD with pytest-bdd | Behavior-focused, collaboration | [pytest-bdd](https://pytest-bdd.readthedocs.io/) |
+
+---
+
+## 2. 5W1H Analysis
+
+### 2.1 WHO (Stakeholders)
+
+| Stakeholder | Role | Needs |
+|-------------|------|-------|
+| **Claude Code Agent** | Primary User | Track work across sessions, survive compaction |
+| **Human Developer** | Supervisor | Review progress, approve changes |
+| **QA Agent** | Quality Gate | Verify tests, validate behavior |
+| **Security Agent** | Security Gate | Review for vulnerabilities |
+
+### 2.2 WHAT (Deliverables)
+
+| Component | Description | Files |
+|-----------|-------------|-------|
+| **Domain Layer** | Pure business logic | `src/domain/` |
+| **Application Layer** | Use cases (CQRS) | `src/application/` |
+| **Infrastructure Layer** | Adapters | `src/infrastructure/` |
+| **Interface Layer** | CLI adapter | `src/interface/` |
+| **Test Suites** | BDD, Unit, Integration | `tests/` |
+
+### 2.3 WHEN (Timeline)
+
+| Phase | Components | Dependencies |
+|-------|------------|--------------|
+| 3.1 | Domain Layer | None |
+| 3.2 | Application Layer | 3.1 |
+| 3.3 | Infrastructure Layer | 3.1, 3.2 |
+| 3.4 | Interface Layer | 3.1, 3.2, 3.3 |
+| 3.5 | Integration Testing | All above |
+
+### 2.4 WHERE (Location)
+
+```
+jerry/
+├── src/
+│   ├── domain/           # WHERE: Business logic lives
+│   ├── application/      # WHERE: Use cases orchestrate
+│   ├── infrastructure/   # WHERE: Technical adapters live
+│   └── interface/        # WHERE: Entry points exist
+├── tests/
+│   ├── unit/             # WHERE: Unit tests
+│   ├── integration/      # WHERE: Integration tests
+│   ├── e2e/              # WHERE: End-to-end tests
+│   └── bdd/              # WHERE: BDD feature tests
+└── data/
+    └── worktracker/      # WHERE: Persistence storage
+```
+
+### 2.5 WHY (Justification)
+
+**Problem**: Context rot degrades LLM performance as context fills.
+
+> "The effective context window where models perform optimally is often <256k tokens"
+> — [Chroma Research](https://research.trychroma.com/context-rot)
+
+**Solution**: External memory via Work Tracker persists state outside context window.
+
+**Why These Patterns**:
+1. **Hexagonal**: Enables testing without infrastructure
+2. **DDD**: Rich domain model captures business rules
+3. **CQRS**: Optimized read/write paths
+4. **Events**: Audit trail, loose coupling
+
+### 2.6 HOW (Approach)
+
+**Development Methodology**: BDD Red/Green/Refactor
+
+```
+1. WRITE failing BDD scenario (RED)
+2. IMPLEMENT minimum code to pass (GREEN)
+3. REFACTOR for quality (REFACTOR)
+4. REPEAT
+```
+
+**Architecture Approach**: Outside-In
+
+```
+1. Define ports (interfaces) first
+2. Implement domain entities
+3. Create use cases
+4. Build adapters
+5. Wire together
+```
+
+---
+
+## 3. Bounded Context Diagram
+
+### 3.1 Context Map
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           JERRY FRAMEWORK                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    WORK TRACKER CONTEXT                           │  │
+│  │                    (Core Subdomain)                               │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │  WorkItem   │────▶│   Project   │     │   Sprint    │        │  │
+│  │  │ (Aggregate) │     │ (Aggregate) │     │ (Aggregate) │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  │         │                   │                   │                │  │
+│  │         ▼                   ▼                   ▼                │  │
+│  │  ┌─────────────────────────────────────────────────────┐        │  │
+│  │  │              Domain Events Bus                       │        │  │
+│  │  │  (WorkItemCreated, WorkItemCompleted, etc.)         │        │  │
+│  │  └─────────────────────────────────────────────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                   │                                      │
+│                                   │ Anti-Corruption Layer                │
+│                                   ▼                                      │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    KNOWLEDGE CONTEXT                              │  │
+│  │                    (Supporting Subdomain)                         │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │  Document   │     │  Decision   │     │  Learning   │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    GOVERNANCE CONTEXT                             │  │
+│  │                    (Generic Subdomain)                            │  │
+│  │                                                                   │  │
+│  │  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │  │
+│  │  │    Agent    │     │    Hook     │     │    Rule     │        │  │
+│  │  └─────────────┘     └─────────────┘     └─────────────┘        │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Legend:
+  ─────▶  Uses/References
+  - - -▶  Publishes Events To
+```
+
+### 3.2 Context Relationships
+
+| Upstream | Downstream | Relationship | Pattern |
+|----------|------------|--------------|---------|
+| Work Tracker | Knowledge | Publisher-Subscriber | Domain Events |
+| Work Tracker | Governance | Conformist | Shared Kernel |
+| Governance | Work Tracker | Open Host Service | REST/CLI |
+
+---
+
+## 4. Package Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              src/                                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                        interface/                                │    │
+│  │  ┌─────────────┐    ┌─────────────┐                             │    │
+│  │  │    cli/     │    │    api/     │   (Primary Adapters)        │    │
+│  │  │  main.py    │    │ controllers │                             │    │
+│  │  │  formatter  │    │             │                             │    │
+│  │  └──────┬──────┘    └──────┬──────┘                             │    │
+│  └─────────┼──────────────────┼────────────────────────────────────┘    │
+│            │                  │                                          │
+│            ▼                  ▼                                          │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                       application/                               │    │
+│  │  ┌─────────────────────────────────────────────────────────┐    │    │
+│  │  │                    use_cases/                            │    │    │
+│  │  │  ┌──────────────┐         ┌──────────────┐              │    │    │
+│  │  │  │  commands/   │         │   queries/   │              │    │    │
+│  │  │  │              │         │              │              │    │    │
+│  │  │  │ CreateItem   │         │ GetItem      │              │    │    │
+│  │  │  │ UpdateItem   │         │ ListItems    │              │    │    │
+│  │  │  │ CompleteItem │         │ SearchItems  │              │    │    │
+│  │  │  └──────────────┘         └──────────────┘              │    │    │
+│  │  └─────────────────────────────────────────────────────────┘    │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │    dtos/     │    │ dispatcher/  │    │  services/   │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  └──────────────────────────────┬──────────────────────────────────┘    │
+│                                 │                                        │
+│                                 ▼                                        │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                         domain/                                  │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │ aggregates/  │    │value_objects/│    │   events/    │       │    │
+│  │  │              │    │              │    │              │       │    │
+│  │  │ WorkItem     │    │ Status       │    │ ItemCreated  │       │    │
+│  │  │ Project      │    │ Priority     │    │ ItemCompleted│       │    │
+│  │  │              │    │ WorkItemId   │    │ ItemUpdated  │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  │  ┌──────────────┐    ┌──────────────┐                           │    │
+│  │  │   ports/     │    │ exceptions/  │   (NO EXTERNAL DEPS)      │    │
+│  │  │              │    │              │                           │    │
+│  │  │ IRepository  │    │ DomainError  │                           │    │
+│  │  │ IEventStore  │    │ NotFound     │                           │    │
+│  │  │ INotifier    │    │ InvalidState │                           │    │
+│  │  └──────┬───────┘    └──────────────┘                           │    │
+│  └─────────┼───────────────────────────────────────────────────────┘    │
+│            │                                                             │
+│            │ implements                                                  │
+│            ▼                                                             │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │                      infrastructure/                             │    │
+│  │  ┌─────────────────────────────────────────────────────────┐    │    │
+│  │  │                    persistence/                          │    │    │
+│  │  │  ┌──────────────┐         ┌──────────────┐              │    │    │
+│  │  │  │   sqlite/    │         │     fs/      │              │    │    │
+│  │  │  │              │         │              │              │    │    │
+│  │  │  │ repository   │         │ md_adapter   │              │    │    │
+│  │  │  │ event_store  │         │              │              │    │    │
+│  │  │  └──────────────┘         └──────────────┘              │    │    │
+│  │  └─────────────────────────────────────────────────────────┘    │    │
+│  │  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │    │
+│  │  │  messaging/  │    │   schemas/   │    │ dispatcher/  │       │    │
+│  │  └──────────────┘    └──────────────┘    └──────────────┘       │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Dependency Rules:
+  interface/     → application/, infrastructure/, domain/
+  application/   → domain/ ONLY
+  infrastructure/→ domain/, application/
+  domain/        → NOTHING (stdlib only)
+```
+
+---
+
+## 5. Domain Model - Class Diagrams
+
+### 5.1 WorkItem Aggregate
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         <<Aggregate Root>>                               │
+│                            WorkItem                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ - _id: WorkItemId                                                        │
+│ - _title: str                                                            │
+│ - _description: str                                                      │
+│ - _type: WorkItemType                                                    │
+│ - _status: Status                                                        │
+│ - _priority: Priority                                                    │
+│ - _parent_id: WorkItemId | None                                          │
+│ - _created_at: datetime                                                  │
+│ - _updated_at: datetime                                                  │
+│ - _completed_at: datetime | None                                         │
+│ - _notes: list[Note]                                                     │
+│ - _tags: list[Tag]                                                       │
+│ - _events: list[DomainEvent]                                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<class methods>>                                                        │
+│ + create(title, type, priority, parent_id?) → WorkItem                   │
+│ + reconstitute(events: list[DomainEvent]) → WorkItem                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<properties>>                                                           │
+│ + id: WorkItemId {readonly}                                              │
+│ + title: str {readonly}                                                  │
+│ + status: Status {readonly}                                              │
+│ + priority: Priority {readonly}                                          │
+│ + is_completed: bool {readonly}                                          │
+│ + is_blocked: bool {readonly}                                            │
+│ + pending_events: list[DomainEvent] {readonly}                           │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<commands>>                                                             │
+│ + update_title(new_title: str) → None                                    │
+│ + update_description(desc: str) → None                                   │
+│ + change_priority(priority: Priority) → None                             │
+│ + start() → None                          # pending → in_progress        │
+│ + block(reason: str) → None               # → blocked                    │
+│ + unblock() → None                        # blocked → in_progress        │
+│ + complete(notes: str?) → None            # → completed                  │
+│ + reopen() → None                         # completed → pending          │
+│ + add_note(content: str) → None                                          │
+│ + add_tag(tag: Tag) → None                                               │
+│ + remove_tag(tag: Tag) → None                                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<internal>>                                                             │
+│ - _apply(event: DomainEvent) → None                                      │
+│ - _raise_event(event: DomainEvent) → None                                │
+│ - _validate_state_transition(from: Status, to: Status) → None            │
+└─────────────────────────────────────────────────────────────────────────┘
+           │
+           │ contains
+           ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                               Note                                       │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + content: str {readonly, frozen}                                        │
+│ + created_at: datetime {readonly, frozen}                                │
+│ + author: str {readonly, frozen}                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __eq__(other: Note) → bool                                             │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Value Objects
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                            WorkItemId                                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + value: str {readonly, frozen}                                          │
+│ + prefix: str = "WORK" {class attr}                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<class methods>>                                                        │
+│ + generate() → WorkItemId                                                │
+│ + from_string(value: str) → WorkItemId                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __str__() → str                         # "WORK-001"                   │
+│ + __eq__(other) → bool                                                   │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                              Status                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ PENDING = "pending"                                                      │
+│ IN_PROGRESS = "in_progress"                                              │
+│ BLOCKED = "blocked"                                                      │
+│ COMPLETED = "completed"                                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + can_transition_to(target: Status) → bool                               │
+│ + valid_transitions() → set[Status]                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                             Priority                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ CRITICAL = 1                                                             │
+│ HIGH = 2                                                                 │
+│ MEDIUM = 3                                                               │
+│ LOW = 4                                                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __lt__(other: Priority) → bool          # For sorting                  │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                           WorkItemType                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ <<enumeration>>                                                          │
+│ EPIC = "epic"                                                            │
+│ FEATURE = "feature"                                                      │
+│ TASK = "task"                                                            │
+│ BUG = "bug"                                                              │
+│ SPIKE = "spike"                                                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + can_have_children() → bool              # epic, feature can            │
+│ + allowed_parent_types() → set[WorkItemType]                             │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Value Object>>                               │
+│                               Tag                                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + name: str {readonly, frozen}                                           │
+│ + color: str | None {readonly, frozen}                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + __eq__(other: Tag) → bool                                              │
+│ + __hash__() → int                                                       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 Domain Events
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           <<Abstract>>                                   │
+│                          DomainEvent                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + event_id: UUID {readonly}                                              │
+│ + event_type: str {readonly}                                             │
+│ + aggregate_id: str {readonly}                                           │
+│ + aggregate_type: str {readonly}                                         │
+│ + occurred_at: datetime {readonly}                                       │
+│ + version: int {readonly}                                                │
+│ + payload: dict {readonly}                                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + to_dict() → dict                                                       │
+│ + from_dict(data: dict) → DomainEvent {class method}                     │
+└─────────────────────────────────────────────────────────────────────────┘
+           △
+           │ extends
+           │
+     ┌─────┴─────┬─────────────┬──────────────┬──────────────┐
+     │           │             │              │              │
+┌────┴────┐ ┌────┴────┐ ┌──────┴──────┐ ┌─────┴─────┐ ┌──────┴──────┐
+│WorkItem │ │WorkItem │ │  WorkItem   │ │ WorkItem  │ │  WorkItem   │
+│Created  │ │Started  │ │  Completed  │ │  Blocked  │ │   Updated   │
+├─────────┤ ├─────────┤ ├─────────────┤ ├───────────┤ ├─────────────┤
+│+title   │ │         │ │+completed_at│ │+reason    │ │+field       │
+│+type    │ │         │ │+notes       │ │           │ │+old_value   │
+│+priority│ │         │ │             │ │           │ │+new_value   │
+└─────────┘ └─────────┘ └─────────────┘ └───────────┘ └─────────────┘
+```
+
+### 5.4 Port Interfaces
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                       IWorkItemRepository                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + save(item: WorkItem) → None                                            │
+│ + get(id: WorkItemId) → WorkItem | None                                  │
+│ + get_all() → list[WorkItem]                                             │
+│ + get_by_status(status: Status) → list[WorkItem]                         │
+│ + get_by_parent(parent_id: WorkItemId) → list[WorkItem]                  │
+│ + delete(id: WorkItemId) → None                                          │
+│ + exists(id: WorkItemId) → bool                                          │
+│ + next_id() → WorkItemId                                                 │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                          IEventStore                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + append(aggregate_id: str, events: list[DomainEvent]) → None            │
+│ + get_events(aggregate_id: str) → list[DomainEvent]                      │
+│ + get_events_since(aggregate_id: str, version: int) → list[DomainEvent]  │
+│ + get_all_events() → list[DomainEvent]                                   │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                         IEventDispatcher                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + dispatch(event: DomainEvent) → None                                    │
+│ + dispatch_all(events: list[DomainEvent]) → None                         │
+│ + subscribe(event_type: str, handler: Callable) → None                   │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Protocol>>                                  │
+│                            IUnitOfWork                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + work_items: IWorkItemRepository {readonly}                             │
+│ + __enter__() → IUnitOfWork                                              │
+│ + __exit__(exc_type, exc_val, exc_tb) → None                             │
+│ + commit() → None                                                        │
+│ + rollback() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Network/DTO Class Diagrams
+
+### 6.1 Data Transfer Objects (Read Models)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                          WorkItemDTO                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                                                │
+│ + title: str                                                             │
+│ + description: str                                                       │
+│ + type: str                                                              │
+│ + status: str                                                            │
+│ + priority: str                                                          │
+│ + parent_id: str | None                                                  │
+│ + created_at: str                         # ISO 8601                     │
+│ + updated_at: str                         # ISO 8601                     │
+│ + completed_at: str | None                # ISO 8601                     │
+│ + notes: list[NoteDTO]                                                   │
+│ + tags: list[str]                                                        │
+│ + children_count: int                                                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + to_dict() → dict                                                       │
+│ + from_dict(data: dict) → WorkItemDTO {class method}                     │
+│ + from_entity(entity: WorkItem) → WorkItemDTO {class method}             │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                        WorkItemSummaryDTO                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                                                │
+│ + title: str                                                             │
+│ + status: str                                                            │
+│ + priority: str                                                          │
+│ + type: str                                                              │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                        WorkTrackerStatsDTO                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + total_items: int                                                       │
+│ + by_status: dict[str, int]                                              │
+│ + by_priority: dict[str, int]                                            │
+│ + by_type: dict[str, int]                                                │
+│ + completed_today: int                                                   │
+│ + created_today: int                                                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              <<DTO>>                                     │
+│                             NoteDTO                                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + content: str                                                           │
+│ + created_at: str                         # ISO 8601                     │
+│ + author: str                                                            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 6.2 Command Objects (Write Models)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                       CreateWorkItemCommand                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + title: str                              # required                     │
+│ + description: str = ""                   # optional                     │
+│ + type: str = "task"                      # optional                     │
+│ + priority: str = "medium"                # optional                     │
+│ + parent_id: str | None = None            # optional                     │
+│ + tags: list[str] = []                    # optional                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                       # raises ValidationError       │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                       UpdateWorkItemCommand                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+│ + title: str | None = None                # optional                     │
+│ + description: str | None = None          # optional                     │
+│ + priority: str | None = None             # optional                     │
+│ + status: str | None = None               # optional                     │
+│ + notes: str | None = None                # optional (adds note)         │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            <<Command>>                                   │
+│                      CompleteWorkItemCommand                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+│ + notes: str | None = None                # optional                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + validate() → None                                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                         GetWorkItemQuery                                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + id: str                                 # required                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                        ListWorkItemsQuery                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + status: list[str] | None = None         # filter                       │
+│ + priority: list[str] | None = None       # filter                       │
+│ + type: list[str] | None = None           # filter                       │
+│ + parent_id: str | None = None            # filter                       │
+│ + limit: int = 50                         # pagination                   │
+│ + offset: int = 0                         # pagination                   │
+│ + sort_by: str = "created_at"             # sorting                      │
+│ + sort_order: str = "desc"                # asc/desc                     │
+└─────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────┐
+│                             <<Query>>                                    │
+│                       SearchWorkItemsQuery                               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ + query: str                              # search text                  │
+│ + include_completed: bool = False         # filter                       │
+│ + limit: int = 20                         # pagination                   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Use Case Specifications
+
+### 7.1 Commands (Write Operations)
+
+#### UC-CMD-001: Create Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | CreateWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | None |
+| **Postconditions** | Work item exists in repository, WorkItemCreated event emitted |
+| **Trigger** | `@worktracker create <title>` |
+
+**Main Flow**:
+1. Validate command input
+2. Generate new WorkItemId
+3. Create WorkItem aggregate via factory method
+4. Save to repository within Unit of Work
+5. Dispatch WorkItemCreated event
+6. Return created WorkItemDTO
+
+**Alternative Flows**:
+- **A1**: Invalid title (empty) → Raise ValidationError
+- **A2**: Invalid parent_id → Raise WorkItemNotFoundError
+- **A3**: Invalid type for parent → Raise InvalidHierarchyError
+
+**Business Rules**:
+- Title must be non-empty, max 200 characters
+- Tasks can only have Features/Epics as parents
+- Bugs can only have Features/Epics as parents
+
+---
+
+#### UC-CMD-002: Update Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | UpdateWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | Work item exists |
+| **Postconditions** | Work item updated, WorkItemUpdated event(s) emitted |
+
+**Main Flow**:
+1. Validate command input
+2. Load WorkItem from repository
+3. Apply updates to aggregate
+4. Save to repository
+5. Dispatch events
+6. Return updated WorkItemDTO
+
+**Alternative Flows**:
+- **A1**: Work item not found → Raise WorkItemNotFoundError
+- **A2**: Invalid status transition → Raise InvalidStateTransitionError
+
+---
+
+#### UC-CMD-003: Complete Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | CompleteWorkItem |
+| **Actor** | Claude Agent / User |
+| **Preconditions** | Work item exists, not already completed |
+| **Postconditions** | Status = completed, WorkItemCompleted event emitted |
+
+**Main Flow**:
+1. Load WorkItem
+2. Call `work_item.complete(notes)`
+3. Save and dispatch events
+
+**Business Rules**:
+- Cannot complete if already completed
+- Cannot complete if blocked (must unblock first)
+- Completing parent does NOT auto-complete children
+
+---
+
+### 7.2 Queries (Read Operations)
+
+#### UC-QRY-001: Get Work Item
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | GetWorkItem |
+| **Input** | id: str |
+| **Output** | WorkItemDTO | None |
+
+---
+
+#### UC-QRY-002: List Work Items
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | ListWorkItems |
+| **Input** | ListWorkItemsQuery |
+| **Output** | list[WorkItemSummaryDTO] |
+
+---
+
+#### UC-QRY-003: Search Work Items
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | SearchWorkItems |
+| **Input** | SearchWorkItemsQuery |
+| **Output** | list[WorkItemSummaryDTO] |
+
+**Search Behavior**:
+- Searches title, description, and notes
+- Case-insensitive
+- Supports partial matches
+
+---
+
+#### UC-QRY-004: Get Work Tracker Stats
+
+| Attribute | Value |
+|-----------|-------|
+| **Name** | GetWorkTrackerStats |
+| **Input** | time_range: str (optional) |
+| **Output** | WorkTrackerStatsDTO |
+
+---
+
+## 8. Sequence Diagrams
+
+### 8.1 Create Work Item Flow
+
+```
+┌─────┐          ┌─────┐          ┌──────────┐          ┌──────────┐          ┌─────────┐
+│ CLI │          │ Use │          │ WorkItem │          │Repository│          │ Event   │
+│     │          │Case │          │          │          │          │          │Dispatcher│
+└──┬──┘          └──┬──┘          └────┬─────┘          └────┬─────┘          └────┬────┘
+   │                │                   │                    │                     │
+   │ create("title")│                   │                    │                     │
+   │───────────────>│                   │                    │                     │
+   │                │                   │                    │                     │
+   │                │  validate()       │                    │                     │
+   │                │──────────────────>│                    │                     │
+   │                │                   │                    │                     │
+   │                │               next_id()                │                     │
+   │                │───────────────────────────────────────>│                     │
+   │                │                   │                    │                     │
+   │                │                   │<───────────────────│                     │
+   │                │                   │    WORK-001        │                     │
+   │                │                   │                    │                     │
+   │                │ WorkItem.create() │                    │                     │
+   │                │──────────────────>│                    │                     │
+   │                │                   │                    │                     │
+   │                │                   │ ┌─────────────────┐│                     │
+   │                │                   │ │_raise_event(    ││                     │
+   │                │                   │ │WorkItemCreated) ││                     │
+   │                │                   │ └─────────────────┘│                     │
+   │                │                   │                    │                     │
+   │                │<──────────────────│                    │                     │
+   │                │     WorkItem      │                    │                     │
+   │                │                   │                    │                     │
+   │                │               save(item)               │                     │
+   │                │───────────────────────────────────────>│                     │
+   │                │                   │                    │                     │
+   │                │                   │                    │ dispatch(event)     │
+   │                │──────────────────────────────────────────────────────────────>│
+   │                │                   │                    │                     │
+   │<───────────────│                   │                    │                     │
+   │  WorkItemDTO   │                   │                    │                     │
+   │                │                   │                    │                     │
+```
+
+### 8.2 Complete Work Item Flow (with State Transition)
+
+```
+┌─────┐          ┌─────┐          ┌──────────┐          ┌──────────┐
+│ CLI │          │ Use │          │ WorkItem │          │Repository│
+│     │          │Case │          │          │          │          │
+└──┬──┘          └──┬──┘          └────┬─────┘          └────┬─────┘
+   │                │                   │                    │
+   │complete("WORK-001", notes)         │                    │
+   │───────────────>│                   │                    │
+   │                │                   │                    │
+   │                │              get("WORK-001")           │
+   │                │───────────────────────────────────────>│
+   │                │                   │                    │
+   │                │<───────────────────────────────────────│
+   │                │                WorkItem                │
+   │                │                   │                    │
+   │                │  complete(notes)  │                    │
+   │                │──────────────────>│                    │
+   │                │                   │                    │
+   │                │                   │ ┌─────────────────────────┐
+   │                │                   │ │_validate_state_transition│
+   │                │                   │ │(in_progress → completed) │
+   │                │                   │ └─────────────────────────┘
+   │                │                   │                    │
+   │                │                   │ ┌─────────────────┐│
+   │                │                   │ │_raise_event(    ││
+   │                │                   │ │WorkItemCompleted││
+   │                │                   │ └─────────────────┘│
+   │                │                   │                    │
+   │                │<──────────────────│                    │
+   │                │       OK          │                    │
+   │                │                   │                    │
+   │                │               save(item)               │
+   │                │───────────────────────────────────────>│
+   │                │                   │                    │
+   │<───────────────│                   │                    │
+   │  WorkItemDTO   │                   │                    │
+```
+
+---
+
+## 9. Activity Diagrams
+
+### 9.1 Work Item State Machine
+
+```
+                              ┌─────────────┐
+                              │   START     │
+                              └──────┬──────┘
+                                     │
+                                     ▼
+                              ┌─────────────┐
+                        ┌────▶│   PENDING   │◀────┐
+                        │     └──────┬──────┘     │
+                        │            │            │
+                        │     start()│            │reopen()
+                        │            ▼            │
+                        │     ┌─────────────┐     │
+                        │     │ IN_PROGRESS │─────┤
+                        │     └──────┬──────┘     │
+                        │            │            │
+                 unblock()    block()│            │
+                        │            ▼            │
+                        │     ┌─────────────┐     │
+                        └─────│   BLOCKED   │     │
+                              └─────────────┘     │
+                                     │            │
+                                     │complete()  │
+                                     ▼            │
+                              ┌─────────────┐     │
+                              │  COMPLETED  │─────┘
+                              └──────┬──────┘
+                                     │
+                                     ▼
+                              ┌─────────────┐
+                              │    END      │
+                              └─────────────┘
+
+State Transition Rules:
+┌──────────────┬────────────────────────────────────────────┐
+│ From State   │ Valid Transitions                          │
+├──────────────┼────────────────────────────────────────────┤
+│ PENDING      │ IN_PROGRESS (start)                        │
+│ IN_PROGRESS  │ BLOCKED (block), COMPLETED (complete)      │
+│ BLOCKED      │ IN_PROGRESS (unblock)                      │
+│ COMPLETED    │ PENDING (reopen)                           │
+└──────────────┴────────────────────────────────────────────┘
+```
+
+### 9.2 Create Work Item Activity
+
+```
+┌─────────────┐
+│   START     │
+└──────┬──────┘
+       │
+       ▼
+┌─────────────────────┐
+│ Receive Command     │
+└──────────┬──────────┘
+           │
+           ▼
+     ┌───────────┐
+     │ Validate  │
+     │  Input?   │
+     └─────┬─────┘
+           │
+     ┌─────┴─────┐
+     │           │
+    YES          NO
+     │           │
+     ▼           ▼
+┌─────────┐  ┌─────────────┐
+│Generate │  │ Raise       │
+│   ID    │  │ Validation  │
+└────┬────┘  │ Error       │
+     │       └──────┬──────┘
+     ▼              │
+┌─────────────┐     │
+│ Create      │     │
+│ Aggregate   │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Raise       │     │
+│ Domain Event│     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Save to     │     │
+│ Repository  │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Dispatch    │     │
+│ Events      │     │
+└──────┬──────┘     │
+       │            │
+       ▼            │
+┌─────────────┐     │
+│ Return DTO  │     │
+└──────┬──────┘     │
+       │            │
+       ▼            ▼
+┌─────────────────────┐
+│        END          │
+└─────────────────────┘
+```
+
+---
+
+## 10. JSON Schemas
+
+### 10.1 Work Item Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/work-item.json",
+  "title": "WorkItem",
+  "description": "A work item in the Jerry Work Tracker",
+  "type": "object",
+  "required": ["id", "title", "type", "status", "priority", "created_at", "updated_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^WORK-[0-9]+$",
+      "description": "Unique identifier",
+      "examples": ["WORK-001", "WORK-123"]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Short description of the work item"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 10000,
+      "default": "",
+      "description": "Detailed description"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["epic", "feature", "task", "bug", "spike"],
+      "default": "task"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "in_progress", "blocked", "completed"],
+      "default": "pending"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "default": "medium"
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "pattern": "^WORK-[0-9]+$",
+      "default": null
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "default": null
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Note"
+      },
+      "default": []
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "default": []
+    }
+  },
+  "$defs": {
+    "Note": {
+      "type": "object",
+      "required": ["content", "created_at"],
+      "properties": {
+        "content": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "author": {
+          "type": "string",
+          "default": "claude"
+        }
+      }
+    }
+  }
+}
+```
+
+### 10.2 Domain Event Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/domain-event.json",
+  "title": "DomainEvent",
+  "description": "Base schema for domain events",
+  "type": "object",
+  "required": ["event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at", "version"],
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "WorkItemCreated",
+        "WorkItemUpdated",
+        "WorkItemStarted",
+        "WorkItemBlocked",
+        "WorkItemUnblocked",
+        "WorkItemCompleted",
+        "WorkItemReopened",
+        "NoteAdded",
+        "TagAdded",
+        "TagRemoved"
+      ]
+    },
+    "aggregate_id": {
+      "type": "string"
+    },
+    "aggregate_type": {
+      "type": "string",
+      "enum": ["WorkItem", "Project"]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}
+```
+
+### 10.3 Command Schemas
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/commands/create-work-item.json",
+  "title": "CreateWorkItemCommand",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 10000,
+      "default": ""
+    },
+    "type": {
+      "type": "string",
+      "enum": ["epic", "feature", "task", "bug", "spike"],
+      "default": "task"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "default": "medium"
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "pattern": "^WORK-[0-9]+$"
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    }
+  }
+}
+```
+
+---
+
+## 11. BDD Test Specifications
+
+### 11.1 Feature: Create Work Item
+
+```gherkin
+Feature: Create Work Item
+  As a Claude Code agent
+  I want to create work items
+  So that I can track tasks across sessions
+
+  Background:
+    Given the work tracker is initialized
+    And no work items exist
+
+  @unit @happy-path
+  Scenario: Create a simple task
+    When I create a work item with title "Implement user authentication"
+    Then a work item should be created with id "WORK-001"
+    And the work item status should be "pending"
+    And the work item type should be "task"
+    And the work item priority should be "medium"
+    And a WorkItemCreated event should be raised
+
+  @unit @happy-path
+  Scenario: Create a feature with custom priority
+    When I create a work item with:
+      | title    | Add caching layer |
+      | type     | feature           |
+      | priority | high              |
+    Then a work item should be created
+    And the work item type should be "feature"
+    And the work item priority should be "high"
+
+  @unit @edge-case
+  Scenario: Create task with parent feature
+    Given a work item exists with:
+      | id   | WORK-001        |
+      | type | feature         |
+      | title| Parent Feature  |
+    When I create a work item with:
+      | title     | Child Task |
+      | type      | task       |
+      | parent_id | WORK-001   |
+    Then the work item should have parent_id "WORK-001"
+
+  @unit @error-case
+  Scenario: Fail to create with empty title
+    When I attempt to create a work item with title ""
+    Then a ValidationError should be raised
+    And the error message should contain "title"
+
+  @unit @error-case
+  Scenario: Fail to create with invalid parent
+    When I attempt to create a work item with:
+      | title     | Orphan Task  |
+      | parent_id | WORK-999     |
+    Then a WorkItemNotFoundError should be raised
+
+  @unit @error-case
+  Scenario: Fail to create task under task
+    Given a work item exists with:
+      | id   | WORK-001 |
+      | type | task     |
+    When I attempt to create a work item with:
+      | title     | Nested Task |
+      | type      | task        |
+      | parent_id | WORK-001    |
+    Then an InvalidHierarchyError should be raised
+```
+
+### 11.2 Feature: Work Item State Transitions
+
+```gherkin
+Feature: Work Item State Transitions
+  As a Claude Code agent
+  I want to change work item status
+  So that I can track progress accurately
+
+  Background:
+    Given a work item exists with:
+      | id     | WORK-001           |
+      | title  | Test Item          |
+      | status | pending            |
+
+  @unit @state-machine
+  Scenario: Start a pending work item
+    When I start work item "WORK-001"
+    Then the work item status should be "in_progress"
+    And a WorkItemStarted event should be raised
+
+  @unit @state-machine
+  Scenario: Block an in-progress work item
+    Given work item "WORK-001" has status "in_progress"
+    When I block work item "WORK-001" with reason "Waiting for API access"
+    Then the work item status should be "blocked"
+    And a WorkItemBlocked event should be raised with reason "Waiting for API access"
+
+  @unit @state-machine
+  Scenario: Complete an in-progress work item
+    Given work item "WORK-001" has status "in_progress"
+    When I complete work item "WORK-001" with notes "All tests passing"
+    Then the work item status should be "completed"
+    And the work item completed_at should be set
+    And a WorkItemCompleted event should be raised
+
+  @unit @state-machine @error-case
+  Scenario: Cannot complete a pending work item directly
+    When I attempt to complete work item "WORK-001"
+    Then an InvalidStateTransitionError should be raised
+    And the error message should contain "pending" and "completed"
+
+  @unit @state-machine @error-case
+  Scenario: Cannot complete a blocked work item
+    Given work item "WORK-001" has status "blocked"
+    When I attempt to complete work item "WORK-001"
+    Then an InvalidStateTransitionError should be raised
+
+  @unit @state-machine
+  Scenario: Reopen a completed work item
+    Given work item "WORK-001" has status "completed"
+    When I reopen work item "WORK-001"
+    Then the work item status should be "pending"
+    And the work item completed_at should be null
+    And a WorkItemReopened event should be raised
+```
+
+### 11.3 Feature: Query Work Items
+
+```gherkin
+Feature: Query Work Items
+  As a Claude Code agent
+  I want to query work items
+  So that I can understand current state
+
+  Background:
+    Given work items exist:
+      | id       | title          | status      | priority | type    |
+      | WORK-001 | Task One       | pending     | high     | task    |
+      | WORK-002 | Task Two       | in_progress | medium   | task    |
+      | WORK-003 | Task Three     | completed   | low      | task    |
+      | WORK-004 | Feature One    | in_progress | high     | feature |
+
+  @integration @query
+  Scenario: List all pending and in-progress items
+    When I list work items with status "pending,in_progress"
+    Then I should receive 3 work items
+    And the results should include "WORK-001", "WORK-002", "WORK-004"
+    And the results should not include "WORK-003"
+
+  @integration @query
+  Scenario: List high priority items
+    When I list work items with priority "high"
+    Then I should receive 2 work items
+    And the results should include "WORK-001", "WORK-004"
+
+  @integration @query
+  Scenario: Search by title
+    When I search work items for "Task"
+    Then I should receive 2 work items
+    And the results should include "WORK-001", "WORK-002"
+
+  @integration @query
+  Scenario: Get work tracker stats
+    When I get work tracker stats
+    Then the total_items should be 4
+    And by_status should show:
+      | status      | count |
+      | pending     | 1     |
+      | in_progress | 2     |
+      | completed   | 1     |
+```
+
+---
+
+## 12. Implementation Plan
+
+### 12.1 Phase 3.1: Domain Layer (BDD)
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-011.1**: WorkItemId VO | Implement, validate | Unit: generation, parsing, equality |
+| **WORK-011.2**: Status VO | Implement with transitions | Unit: all transitions, invalid transitions |
+| **WORK-011.3**: Priority VO | Implement with ordering | Unit: ordering, comparison |
+| **WORK-011.4**: WorkItemType VO | Implement with hierarchy rules | Unit: parent rules |
+| **WORK-011.5**: Note VO | Implement immutable | Unit: immutability |
+| **WORK-011.6**: Tag VO | Implement immutable | Unit: equality, hash |
+| **WORK-011.7**: DomainEvent base | Implement base class | Unit: serialization |
+| **WORK-011.8**: WorkItem events | All event types | Unit: payload validation |
+| **WORK-011.9**: DomainException | Exception hierarchy | Unit: messages |
+| **WORK-011.10**: WorkItem aggregate | Full implementation | BDD: all scenarios above |
+| **WORK-011.11**: Port interfaces | Define protocols | Architecture: dependency direction |
+
+### 12.2 Phase 3.2: Application Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-012.1**: DTOs | All DTO classes | Unit: serialization |
+| **WORK-012.2**: Commands | Command classes | Unit: validation |
+| **WORK-012.3**: Queries | Query classes | Unit: defaults |
+| **WORK-012.4**: CreateWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.5**: UpdateWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.6**: CompleteWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.7**: GetWorkItem handler | Implement | Integration: full flow |
+| **WORK-012.8**: ListWorkItems handler | Implement | Integration: filtering |
+| **WORK-012.9**: SearchWorkItems handler | Implement | Integration: search |
+
+### 12.3 Phase 3.3: Infrastructure Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-013.1**: SQLite schema | Design and create | Integration: migrations |
+| **WORK-013.2**: SQLiteRepository | Implement IRepository | Integration: CRUD |
+| **WORK-013.3**: SQLiteEventStore | Implement IEventStore | Integration: append/read |
+| **WORK-013.4**: SQLiteUnitOfWork | Implement IUnitOfWork | Integration: transactions |
+| **WORK-013.5**: EventDispatcher | Implement dispatcher | Unit: subscription |
+| **WORK-013.6**: JSON schemas | Create schema files | Contract: validation |
+
+### 12.4 Phase 3.4: Interface Layer
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-014.1**: CLI argument parser | Implement argparse | Unit: parsing |
+| **WORK-014.2**: CLI formatters | Table, JSON output | Unit: formatting |
+| **WORK-014.3**: CLI commands | All skill commands | E2E: full workflows |
+| **WORK-014.4**: Error handling | User-friendly messages | E2E: error cases |
+
+### 12.5 Phase 3.5: Integration & E2E
+
+| Task | Sub-tasks | Tests |
+|------|-----------|-------|
+| **WORK-015.1**: Dependency wiring | Composition root | Architecture: DI |
+| **WORK-015.2**: E2E test suite | Full workflow tests | E2E: happy paths |
+| **WORK-015.3**: Edge case suite | Failure scenarios | E2E: edge cases |
+| **WORK-015.4**: Performance tests | Load testing | Performance: benchmarks |
+
+---
+
+## 13. Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| SQLite concurrency limits | Medium | Medium | Use WAL mode, single-writer |
+| Event replay performance | Low | Medium | Implement snapshots |
+| Schema evolution | Medium | High | Version events, migration scripts |
+| Test coverage gaps | Medium | High | Mutation testing, coverage gates |
+| Context window pressure | Medium | High | Lazy loading, pagination |
+
+---
+
+## 14. References
+
+### Primary Sources
+
+1. Evans, E. (2003). "Domain-Driven Design: Tackling Complexity in the Heart of Software"
+2. Vernon, V. (2013). "Implementing Domain-Driven Design"
+3. Cockburn, A. (2005). "[Hexagonal Architecture](https://alistair.cockburn.us/hexagonal-architecture/)"
+4. Percival, H. & Gregory, B. "[Architecture Patterns with Python](https://www.cosmicpython.com/)"
+5. Microsoft. "[Event Sourcing Pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing)"
+6. Fowler, M. "[Domain Event](https://martinfowler.com/eaaDev/DomainEvent.html)"
+
+### Implementation References
+
+7. "[Cosmic Python - CQRS](https://www.cosmicpython.com/book/chapter_12_cqrs.html)"
+8. "[Cosmic Python - Repository Pattern](https://www.cosmicpython.com/book/chapter_02_repository.html)"
+9. "[Cosmic Python - Unit of Work](https://www.cosmicpython.com/book/chapter_06_uow.html)"
+10. "[pytest-bdd Documentation](https://pytest-bdd.readthedocs.io/)"
+11. "[DDD in Python](https://dddinpython.com/)"
+12. "[Atlassian JIRA Schema](https://support.atlassian.com/analytics/docs/schema-for-jira-software/)"
+
+---
+
+## Approval
+
+| Role | Name | Status | Date |
+|------|------|--------|------|
+| **Author** | Claude | SUBMITTED | 2026-01-07 |
+| **Reviewer** | User | PENDING | - |
+| **Approver** | User | PENDING | - |
+
+---
+
+**Next Steps Upon Approval**:
+1. Create detailed sub-task breakdown in WORKTRACKER.md
+2. Begin Phase 3.1 with Domain Layer BDD tests
+3. Implement WorkItemId value object (first RED test)

--- a/docs/archive/projects-archive/plans/worktracker/00-wt-index.md
+++ b/docs/archive/projects-archive/plans/worktracker/00-wt-index.md
@@ -1,0 +1,182 @@
+# Jerry Framework - Work Tracker Implementation Plan
+
+> Granular implementation plan derived from ADR-034 unified design.
+> **Source**: [ADR-034](../../decisions/ADR-034-unified-wt-km-implementation.md) | [Unified Design](../../design/work-034-e-003-unified-design.md)
+
+**Created**: 2026-01-09
+**Revised**: 2026-01-09
+**Status**: PROPOSED (awaiting approval)
+**Total Duration**: 32 weeks (4 phases)
+**Branch**: TBD (implementation branch)
+
+---
+
+## Architecture & Testing Principles
+
+> **MANDATORY**: All implementation MUST adhere to these principles.
+
+### Architecture Pure Best Practices
+
+| Pattern | Enforcement | Validation |
+|---------|-------------|------------|
+| DDD | Hard | Architecture tests verify bounded contexts |
+| Hexagonal Architecture | Hard | No adapter imports in domain |
+| Event Sourcing | Hard | Events immutable, append-only |
+| CQRS | Hard | Commands return events, queries return DTOs |
+| Repository Pattern | Hard | All data access via ports |
+| Dispatcher Pattern | Hard | Events dispatched, not directly handled |
+| Dependency Injection | Hard | No `new` in domain/application |
+
+### Test Pyramid (Per Feature)
+
+| Level | Count | Focus | Real Data |
+|-------|-------|-------|-----------|
+| Unit | Many | Single class/function | Mocked dependencies |
+| Integration | Medium | Multiple components | Real file system |
+| Contract | Few | Port compliance | Interface verification |
+| System | Few | Multi-operation workflows | Full stack |
+| E2E | Few | CLI to persistence | Real everything |
+| Architecture | Always | Layer dependencies | Static analysis |
+
+### BDD Red/Green/Refactor Protocol
+
+```
+1. RED: Write failing test with REAL assertions (no placeholders)
+2. GREEN: Implement MINIMUM code to pass
+3. REFACTOR: Clean up while maintaining GREEN
+4. REPEAT: Until acceptance criteria met
+```
+
+### Test Coverage Requirements
+
+| Scenario Type | Coverage |
+|--------------|----------|
+| Happy path | 100% of use cases |
+| Edge cases | Boundary conditions, empty/max values |
+| Failure scenarios | NotFound, InvalidState, Concurrent |
+| Negative tests | Invalid input, malformed data |
+
+---
+
+## Vertical Slice Focus: Task + Sub-Task
+
+This implementation focuses on delivering a **fully integrated vertical slice** of the Task and Sub-Task aggregates with all supporting components:
+
+### Aggregates (Separate, with Reference)
+
+| Aggregate | Description | Relationship |
+|-----------|-------------|--------------|
+| **Task** | Primary work item with lifecycle | Parent reference for Sub-Tasks |
+| **Sub-Task** | Child work item with own lifecycle | References parent Task via `task_id` |
+
+**Design Decision**: Sub-Task is a **separate aggregate** (not embedded) to allow:
+- Multiple simultaneous requests on different sub-tasks
+- Independent lifecycle management
+- Concurrent modification without aggregate-level locking
+
+### Adapters
+
+| Adapter Type | Format | Purpose |
+|--------------|--------|---------|
+| **JSON Secondary** | `.json` files | Human-readable persistence, debugging |
+| **TOON Secondary** | `.toon` files | LLM-optimized (30-60% token reduction) |
+| **CLI Primary** | argparse | User interface for CRUD operations |
+
+### Full Stack Components
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         SKILL.md                                │
+│                  (Natural Language Interface)                   │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────┐
+│                      CLI Primary Adapter                        │
+│                    (src/interface/cli/)                         │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────┐
+│                    Application Layer                            │
+│              Commands / Queries / Handlers                      │
+│                 (src/application/)                              │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────┐
+│                      Domain Layer                               │
+│      Task Aggregate │ Sub-Task Aggregate │ Events │ Ports       │
+│                    (src/domain/)                                │
+└─────────────────────────────┬───────────────────────────────────┘
+                              │
+              ┌───────────────┴───────────────┐
+              ▼                               ▼
+┌──────────────────────────┐    ┌──────────────────────────┐
+│   JSON File Adapter      │    │   TOON File Adapter      │
+│  (src/infrastructure/)   │    │  (src/infrastructure/)   │
+│                          │    │                          │
+│  - .json file storage    │    │  - .toon file storage    │
+│  - Human readable        │    │  - LLM optimized         │
+│  - Debug friendly        │    │  - 30-60% token savings  │
+└──────────────────────────┘    └──────────────────────────┘
+```
+
+---
+
+## Phase Overview
+
+| Phase | File | Status | WORK Items | Focus |
+|-------|------|--------|------------|-------|
+| **Phase 1** | [01-wt-foundation.md](01-wt-foundation.md) | PENDING | WORK-101 to WORK-104 | Task + Sub-Task vertical slice |
+| **Phase 2** | [02-wt-infrastructure.md](02-wt-infrastructure.md) | PENDING | WORK-201 to WORK-204 | Event Store, Graph, Semantic Index, RDF |
+| **Phase 3** | [03-wt-km-integration.md](03-wt-km-integration.md) | PENDING | WORK-301 to WORK-304 | Knowledge Management domain |
+| **Phase 4** | [04-wt-advanced-features.md](04-wt-advanced-features.md) | PENDING | WORK-401 to WORK-404 | HybridRAG, Pattern Discovery, API |
+
+---
+
+## Quick Status
+
+| Phase | Status | Progress |
+|-------|--------|----------|
+| Phase 1: Work Tracker Foundation | PENDING | 0% |
+| Phase 2: Shared Infrastructure | PENDING | 0% |
+| Phase 3: KM Integration | PENDING | 0% |
+| Phase 4: Advanced Features | PENDING | 0% |
+
+---
+
+## Technology Stack
+
+| Component | Technology | Version | Purpose |
+|-----------|------------|---------|---------|
+| Runtime | Python | 3.11+ | Zero-dependency core |
+| Serialization | JSON | stdlib | Human-readable persistence |
+| Serialization | TOON | python-toon | LLM-optimized format |
+| Graph | NetworkX | 3.2.1 | Property graph (Phase 2+) |
+| Vector Search | FAISS | 1.7.4 | Semantic similarity (Phase 2+) |
+| RDF | RDFLib | 7.0.0 | Knowledge export (Phase 2+) |
+| Testing | pytest | 8.x | All test types |
+| BDD | pytest-bdd | 7.x | BDD scenarios |
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Sub-Task as separate aggregate | Yes | Concurrent modification support |
+| File-based persistence (Phase 1) | JSON + TOON | Skill integration, no DB dependency |
+| Database adapters | Deferred | Add in later phase when needed |
+| TOON for LLM context | Yes | 30-60% token reduction |
+
+---
+
+## References
+
+| Document | Purpose |
+|----------|---------|
+| [ADR-034](../../decisions/ADR-034-unified-wt-km-implementation.md) | Architecture decision |
+| [Unified Design](../../design/work-034-e-003-unified-design.md) | Technical specifications |
+| [TOON Format Analysis](../../research/TOON_FORMAT_ANALYSIS.md) | TOON serialization research |
+
+---
+
+*Plan created 2026-01-09*

--- a/docs/archive/projects-archive/plans/worktracker/01-wt-foundation.md
+++ b/docs/archive/projects-archive/plans/worktracker/01-wt-foundation.md
@@ -1,0 +1,1348 @@
+# Phase 1: Work Tracker Foundation (Weeks 1-8)
+
+> **Goal**: Deliver a fully integrated vertical slice of Task + Sub-Task with file-based persistence and CLI interface.
+> **Reference**: [Index](00-wt-index.md) | [Unified Design](../../design/work-034-e-003-unified-design.md)
+
+**Status**: PENDING
+**Duration**: Weeks 1-8
+**WORK Items**: WORK-101 to WORK-104
+
+---
+
+## Phase 1 Overview
+
+| WORK Item | Name | Duration | Dependencies |
+|-----------|------|----------|--------------|
+| WORK-101 | Domain Layer - Aggregates & Ports | Weeks 1-2 | None |
+| WORK-102 | File-Based Repository Adapters | Weeks 3-4 | WORK-101 |
+| WORK-103 | CQRS Implementation | Weeks 5-6 | WORK-101, WORK-102 |
+| WORK-104 | CLI Interface & SKILL.md | Weeks 7-8 | WORK-103 |
+
+---
+
+## WORK-101: Domain Layer - Aggregates & Ports
+
+**Status**: PENDING
+**Duration**: Weeks 1-2
+**Artifacts**: Domain entities, value objects, events, ports
+**Dependencies**: None
+
+### Sub-task 101.1: Shared Kernel Value Objects
+
+**Files**: `src/domain/value_objects/`
+**Tests**: `tests/unit/domain/value_objects/`
+
+#### 101.1.1: VertexId Base Class (`vertex_id.py`)
+
+- [ ] **RED**: Write `test_vertex_id.py`
+  - [ ] Test valid UUID string creates VertexId
+  - [ ] Test invalid UUID format raises `ValueError`
+  - [ ] Test equality is by value, not reference
+  - [ ] Test immutability - cannot reassign `value` attribute
+  - [ ] Test empty string raises `ValueError`
+  - [ ] Test whitespace-only string raises `ValueError`
+  - [ ] Test `__hash__` returns consistent value for equal IDs
+  - [ ] Test `__repr__` returns readable format
+  - [ ] Test `__str__` returns raw UUID string
+  - [ ] Test `from_string()` factory method
+  - [ ] Test `generate()` factory creates valid UUID v4
+
+- [ ] **GREEN**: Implement `VertexId`
+  - [ ] Use `@dataclass(frozen=True)` for immutability
+  - [ ] Implement UUID v4 validation regex
+  - [ ] Implement `__hash__` based on value
+  - [ ] Implement `__eq__` for value equality
+  - [ ] Implement `generate()` classmethod using `uuid.uuid4()`
+  - [ ] Implement `from_string()` classmethod with validation
+
+- [ ] **REFACTOR**: Clean up implementation
+  - [ ] Extract validation to private `_validate()` method
+  - [ ] Add docstrings with examples
+  - [ ] Ensure `__slots__` for memory efficiency
+
+#### 101.1.2: TaskId Value Object (`task_id.py`)
+
+- [ ] **RED**: Write `test_task_id.py`
+  - [ ] Test TaskId extends VertexId
+  - [ ] Test TaskId is distinct type from SubTaskId (not interchangeable)
+  - [ ] Test `None` value raises `TypeError`
+  - [ ] Test TaskId can be used as dict key
+  - [ ] Test TaskId serializes to string correctly
+  - [ ] Test TaskId deserializes from string correctly
+
+- [ ] **GREEN**: Implement `TaskId`
+  - [ ] Inherit from `VertexId`
+  - [ ] Add type marker for serialization
+  - [ ] Implement `__class_getitem__` for type hints
+
+- [ ] **REFACTOR**: Ensure type safety
+  - [ ] Add runtime type checking in factory methods
+  - [ ] Add docstring with usage examples
+
+#### 101.1.3: SubTaskId Value Object (`subtask_id.py`)
+
+- [ ] **RED**: Write `test_subtask_id.py`
+  - [ ] Test SubTaskId extends VertexId
+  - [ ] Test SubTaskId is distinct type from TaskId (not interchangeable)
+  - [ ] Test `None` value raises `TypeError`
+  - [ ] Test SubTaskId can be used as dict key
+  - [ ] Test SubTaskId serializes to string correctly
+  - [ ] Test SubTaskId deserializes from string correctly
+
+- [ ] **GREEN**: Implement `SubTaskId`
+  - [ ] Inherit from `VertexId`
+  - [ ] Add type marker for serialization
+
+- [ ] **REFACTOR**: DRY with TaskId
+  - [ ] Extract common ID behavior to base class if needed
+
+#### 101.1.4: TaskStatus Enum (`task_status.py`)
+
+- [ ] **RED**: Write `test_task_status.py`
+  - [ ] Test all states exist: PENDING, IN_PROGRESS, COMPLETED, BLOCKED, CANCELLED
+  - [ ] Test `from_string()` parses case-insensitively
+  - [ ] Test invalid string raises `ValueError`
+  - [ ] Test `can_transition_to()` validates state machine:
+    - [ ] PENDING → IN_PROGRESS: valid
+    - [ ] PENDING → CANCELLED: valid
+    - [ ] PENDING → COMPLETED: invalid (must go through IN_PROGRESS)
+    - [ ] IN_PROGRESS → COMPLETED: valid
+    - [ ] IN_PROGRESS → BLOCKED: valid
+    - [ ] IN_PROGRESS → CANCELLED: valid
+    - [ ] BLOCKED → IN_PROGRESS: valid (unblock)
+    - [ ] BLOCKED → CANCELLED: valid
+    - [ ] COMPLETED → any: invalid (terminal state)
+    - [ ] CANCELLED → any: invalid (terminal state)
+  - [ ] Test `is_terminal` property returns True for COMPLETED, CANCELLED
+  - [ ] Test `is_active` property returns True for IN_PROGRESS, BLOCKED
+
+- [ ] **GREEN**: Implement `TaskStatus`
+  - [ ] Use `Enum` with string values
+  - [ ] Implement `can_transition_to(target: TaskStatus) -> bool`
+  - [ ] Implement `from_string(value: str) -> TaskStatus`
+  - [ ] Implement `is_terminal` property
+  - [ ] Implement `is_active` property
+  - [ ] Define transition matrix as class constant
+
+- [ ] **REFACTOR**: Add state machine diagram in docstring
+  - [ ] Document all valid transitions
+  - [ ] Add examples of invalid transitions
+
+#### 101.1.5: SubTaskStatus Enum (`subtask_status.py`)
+
+- [ ] **RED**: Write `test_subtask_status.py`
+  - [ ] Test all states exist: PENDING, IN_PROGRESS, COMPLETED, SKIPPED
+  - [ ] Test `from_string()` parses case-insensitively
+  - [ ] Test invalid string raises `ValueError`
+  - [ ] Test `can_transition_to()` validates state machine:
+    - [ ] PENDING → IN_PROGRESS: valid
+    - [ ] PENDING → SKIPPED: valid
+    - [ ] IN_PROGRESS → COMPLETED: valid
+    - [ ] IN_PROGRESS → SKIPPED: valid
+    - [ ] COMPLETED → any: invalid (terminal)
+    - [ ] SKIPPED → any: invalid (terminal)
+  - [ ] Test `is_terminal` property
+
+- [ ] **GREEN**: Implement `SubTaskStatus`
+  - [ ] Simpler state machine than TaskStatus (no BLOCKED)
+  - [ ] Include SKIPPED state for optional sub-tasks
+
+- [ ] **REFACTOR**: Extract common enum patterns
+  - [ ] Consider base StatusEnum class
+
+#### 101.1.6: Priority Enum (`priority.py`)
+
+- [ ] **RED**: Write `test_priority.py`
+  - [ ] Test all levels exist: LOW, NORMAL, HIGH, CRITICAL
+  - [ ] Test ordering: LOW < NORMAL < HIGH < CRITICAL
+  - [ ] Test `__lt__`, `__le__`, `__gt__`, `__ge__` operators
+  - [ ] Test `from_string()` parses case-insensitively
+  - [ ] Test `from_int()` maps 1-4 to priorities
+  - [ ] Test invalid string raises `ValueError`
+  - [ ] Test invalid int raises `ValueError`
+  - [ ] Test default is NORMAL
+
+- [ ] **GREEN**: Implement `Priority`
+  - [ ] Use `IntEnum` for natural ordering
+  - [ ] Values: LOW=1, NORMAL=2, HIGH=3, CRITICAL=4
+  - [ ] Implement `from_string()` classmethod
+  - [ ] Implement `from_int()` classmethod
+
+- [ ] **REFACTOR**: Add display names
+  - [ ] Add `display_name` property for UI
+
+#### 101.1.7: Tag Value Object (`tag.py`)
+
+- [ ] **RED**: Write `test_tag.py`
+  - [ ] Test valid tag creation with alphanumeric + hyphen
+  - [ ] Test tag is normalized to lowercase
+  - [ ] Test leading/trailing whitespace is trimmed
+  - [ ] Test max length enforcement (50 chars)
+  - [ ] Test empty string raises `ValueError`
+  - [ ] Test special characters (except hyphen) raise `ValueError`
+  - [ ] Test spaces raise `ValueError`
+  - [ ] Test equality is case-insensitive
+  - [ ] Test `__hash__` works with normalized value
+
+- [ ] **GREEN**: Implement `Tag`
+  - [ ] Use `@dataclass(frozen=True)`
+  - [ ] Normalize in `__post_init__`
+  - [ ] Validate with regex: `^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$`
+
+- [ ] **REFACTOR**: Add tag parsing
+  - [ ] Add `parse_tags(text: str) -> list[Tag]` for comma-separated input
+
+---
+
+### Sub-task 101.2: Task Aggregate Root
+
+**Files**: `src/domain/aggregates/task.py`
+**Tests**: `tests/unit/domain/aggregates/test_task.py`
+
+#### 101.2.1: Task Entity Core
+
+- [ ] **RED**: Write `test_task_creation.py`
+  - [ ] Test create with title only (defaults applied)
+  - [ ] Test create with title and description
+  - [ ] Test create with all optional fields (priority, tags, due_date)
+  - [ ] Test auto-generated TaskId is valid UUID
+  - [ ] Test initial status is PENDING
+  - [ ] Test created_at is set to current time
+  - [ ] Test updated_at equals created_at initially
+  - [ ] Test version starts at 1
+  - [ ] Test empty title raises `ValueError`
+  - [ ] Test whitespace-only title raises `ValueError`
+  - [ ] Test title > 200 chars raises `ValueError`
+  - [ ] Test description > 5000 chars raises `ValueError`
+  - [ ] Test due_date in past raises `ValueError` (configurable)
+  - [ ] Test `TaskCreated` event is emitted
+
+- [ ] **GREEN**: Implement `Task.__init__()` and `Task.create()`
+  - [ ] Private `__init__` for reconstitution
+  - [ ] Public `create()` factory for new tasks
+  - [ ] Emit `TaskCreated` event from factory
+  - [ ] Store pending events in `_events` list
+
+- [ ] **REFACTOR**: Extract validation
+  - [ ] Create `_validate_title()`, `_validate_description()` private methods
+  - [ ] Add comprehensive docstrings
+
+#### 101.2.2: Task State Transitions
+
+- [ ] **RED**: Write `test_task_transitions.py`
+  - [ ] Test `start()` transitions PENDING → IN_PROGRESS
+  - [ ] Test `start()` emits `TaskStarted` event
+  - [ ] Test `start()` on IN_PROGRESS raises `InvalidStateError`
+  - [ ] Test `start()` on COMPLETED raises `InvalidStateError`
+  - [ ] Test `complete()` transitions IN_PROGRESS → COMPLETED
+  - [ ] Test `complete()` sets `completed_at` timestamp
+  - [ ] Test `complete()` emits `TaskCompleted` event
+  - [ ] Test `complete()` with notes stores completion notes
+  - [ ] Test `complete()` on PENDING raises `InvalidStateError`
+  - [ ] Test `complete()` on BLOCKED raises `InvalidStateError`
+  - [ ] Test `block(reason)` transitions IN_PROGRESS → BLOCKED
+  - [ ] Test `block()` requires reason string
+  - [ ] Test `block()` emits `TaskBlocked` event
+  - [ ] Test `block()` on PENDING raises `InvalidStateError`
+  - [ ] Test `unblock()` transitions BLOCKED → IN_PROGRESS
+  - [ ] Test `unblock()` clears blocker_reason
+  - [ ] Test `unblock()` emits `TaskUnblocked` event
+  - [ ] Test `cancel()` transitions PENDING/IN_PROGRESS/BLOCKED → CANCELLED
+  - [ ] Test `cancel()` on COMPLETED raises `InvalidStateError`
+  - [ ] Test `cancel()` emits `TaskCancelled` event
+  - [ ] Test all transitions increment version
+  - [ ] Test all transitions update `updated_at`
+
+- [ ] **GREEN**: Implement transition methods
+  - [ ] `start() -> None`
+  - [ ] `complete(notes: str | None = None) -> None`
+  - [ ] `block(reason: str) -> None`
+  - [ ] `unblock() -> None`
+  - [ ] `cancel() -> None`
+  - [ ] Use `TaskStatus.can_transition_to()` for validation
+  - [ ] Raise `InvalidStateError` with descriptive message
+
+- [ ] **REFACTOR**: Implement state pattern or transition table
+  - [ ] Consider `_transition(new_status, event_factory)` helper
+
+#### 101.2.3: Task Attribute Updates
+
+- [ ] **RED**: Write `test_task_updates.py`
+  - [ ] Test `update_title(new_title)` changes title
+  - [ ] Test `update_title()` emits `TaskUpdated` event
+  - [ ] Test `update_title()` with invalid title raises `ValueError`
+  - [ ] Test `update_title()` on COMPLETED raises `InvalidStateError`
+  - [ ] Test `update_description(new_desc)` changes description
+  - [ ] Test `update_description()` with None clears description
+  - [ ] Test `set_priority(priority)` changes priority
+  - [ ] Test `set_priority()` emits `TaskUpdated` event
+  - [ ] Test `set_due_date(date)` changes due_date
+  - [ ] Test `set_due_date(None)` clears due_date
+  - [ ] Test `set_due_date()` with past date raises `ValueError`
+  - [ ] Test `add_tag(tag)` adds tag to set
+  - [ ] Test `add_tag()` with duplicate tag is no-op (idempotent)
+  - [ ] Test `add_tag()` emits `TaskTagAdded` event (first time only)
+  - [ ] Test `remove_tag(tag)` removes tag from set
+  - [ ] Test `remove_tag()` with non-existent tag is no-op
+  - [ ] Test `remove_tag()` emits `TaskTagRemoved` event (if existed)
+  - [ ] Test all updates increment version
+  - [ ] Test all updates set `updated_at`
+
+- [ ] **GREEN**: Implement update methods
+  - [ ] `update_title(title: str) -> None`
+  - [ ] `update_description(description: str | None) -> None`
+  - [ ] `set_priority(priority: Priority) -> None`
+  - [ ] `set_due_date(due_date: datetime | None) -> None`
+  - [ ] `add_tag(tag: Tag) -> None`
+  - [ ] `remove_tag(tag: Tag) -> None`
+
+- [ ] **REFACTOR**: Add bulk update method
+  - [ ] `update(**kwargs)` for multiple fields at once
+  - [ ] Single event emission for bulk update
+
+#### 101.2.4: Task Sub-Task References
+
+- [ ] **RED**: Write `test_task_subtask_refs.py`
+  - [ ] Test `subtask_ids` property returns frozenset of SubTaskIds
+  - [ ] Test `add_subtask_reference(subtask_id)` adds reference
+  - [ ] Test `add_subtask_reference()` emits `SubTaskLinked` event
+  - [ ] Test `add_subtask_reference()` with duplicate is no-op
+  - [ ] Test `remove_subtask_reference(subtask_id)` removes reference
+  - [ ] Test `remove_subtask_reference()` emits `SubTaskUnlinked` event
+  - [ ] Test `has_subtask(subtask_id)` returns boolean
+  - [ ] Test `subtask_count` property returns count
+  - [ ] Test cannot complete Task if has incomplete sub-tasks (configurable)
+
+- [ ] **GREEN**: Implement sub-task reference methods
+  - [ ] Store references as `frozenset[SubTaskId]`
+  - [ ] Reference only - actual SubTask is separate aggregate
+
+- [ ] **REFACTOR**: Add sub-task query helpers
+  - [ ] Document relationship with SubTask aggregate
+
+---
+
+### Sub-task 101.3: Sub-Task Aggregate Root
+
+**Files**: `src/domain/aggregates/subtask.py`
+**Tests**: `tests/unit/domain/aggregates/test_subtask.py`
+
+#### 101.3.1: SubTask Entity Core
+
+- [ ] **RED**: Write `test_subtask_creation.py`
+  - [ ] Test create with title and parent task_id
+  - [ ] Test create with optional description, order_index
+  - [ ] Test auto-generated SubTaskId is valid UUID
+  - [ ] Test initial status is PENDING
+  - [ ] Test created_at is set to current time
+  - [ ] Test version starts at 1
+  - [ ] Test parent task_id is required
+  - [ ] Test parent task_id cannot be changed after creation
+  - [ ] Test empty title raises `ValueError`
+  - [ ] Test title > 200 chars raises `ValueError`
+  - [ ] Test order_index defaults to 0
+  - [ ] Test `SubTaskCreated` event is emitted
+
+- [ ] **GREEN**: Implement `SubTask.__init__()` and `SubTask.create()`
+  - [ ] Private `__init__` for reconstitution
+  - [ ] Public `create(task_id, title, ...)` factory
+  - [ ] Emit `SubTaskCreated` event from factory
+
+- [ ] **REFACTOR**: Ensure consistency with Task
+  - [ ] Follow same patterns for validation, events
+
+#### 101.3.2: SubTask State Transitions
+
+- [ ] **RED**: Write `test_subtask_transitions.py`
+  - [ ] Test `start()` transitions PENDING → IN_PROGRESS
+  - [ ] Test `start()` emits `SubTaskStarted` event
+  - [ ] Test `complete()` transitions IN_PROGRESS → COMPLETED
+  - [ ] Test `complete()` sets `completed_at` timestamp
+  - [ ] Test `complete()` emits `SubTaskCompleted` event
+  - [ ] Test `skip(reason)` transitions PENDING → SKIPPED
+  - [ ] Test `skip()` with reason stores skip_reason
+  - [ ] Test `skip()` emits `SubTaskSkipped` event
+  - [ ] Test `skip()` on IN_PROGRESS is valid (can skip after starting)
+  - [ ] Test invalid transitions raise `InvalidStateError`
+  - [ ] Test all transitions increment version
+  - [ ] Test all transitions update `updated_at`
+
+- [ ] **GREEN**: Implement transition methods
+  - [ ] `start() -> None`
+  - [ ] `complete() -> None`
+  - [ ] `skip(reason: str | None = None) -> None`
+
+- [ ] **REFACTOR**: Simpler state machine than Task
+  - [ ] No BLOCKED state for sub-tasks
+  - [ ] No CANCELLED state (use SKIPPED)
+
+#### 101.3.3: SubTask Attribute Updates
+
+- [ ] **RED**: Write `test_subtask_updates.py`
+  - [ ] Test `update_title(new_title)` changes title
+  - [ ] Test `update_description(new_desc)` changes description
+  - [ ] Test `set_order_index(index)` changes order
+  - [ ] Test all updates emit `SubTaskUpdated` event
+  - [ ] Test all updates increment version
+  - [ ] Test updates on COMPLETED raise `InvalidStateError`
+  - [ ] Test updates on SKIPPED raise `InvalidStateError`
+
+- [ ] **GREEN**: Implement update methods
+  - [ ] `update_title(title: str) -> None`
+  - [ ] `update_description(description: str | None) -> None`
+  - [ ] `set_order_index(index: int) -> None`
+
+- [ ] **REFACTOR**: Consistency with Task update patterns
+
+---
+
+### Sub-task 101.4: Domain Events
+
+**Files**: `src/domain/events/`
+**Tests**: `tests/unit/domain/events/`
+
+#### 101.4.1: Event Base Classes (`base.py`)
+
+- [ ] **RED**: Write `test_domain_event_base.py`
+  - [ ] Test `DomainEvent` is immutable (frozen dataclass)
+  - [ ] Test `event_id` is auto-generated UUID
+  - [ ] Test `occurred_at` is auto-generated timestamp
+  - [ ] Test `aggregate_id` is required
+  - [ ] Test `aggregate_type` is required
+  - [ ] Test `event_type` returns class name
+  - [ ] Test `to_dict()` returns serializable dict
+  - [ ] Test `from_dict()` reconstructs event
+
+- [ ] **GREEN**: Implement `DomainEvent` base class
+  - [ ] `@dataclass(frozen=True)`
+  - [ ] Auto-generated `event_id: str`
+  - [ ] Auto-generated `occurred_at: datetime`
+  - [ ] Abstract `aggregate_id: str`
+  - [ ] Abstract `aggregate_type: str`
+
+- [ ] **REFACTOR**: Add CloudEvents envelope support
+  - [ ] Prepare for CloudEvents 1.0 compliance in Phase 2
+
+#### 101.4.2: Task Events (`task_events.py`)
+
+- [ ] **RED**: Write `test_task_events.py`
+  - [ ] Test `TaskCreated` has all task fields
+  - [ ] Test `TaskStarted` has task_id, timestamp
+  - [ ] Test `TaskCompleted` has task_id, completed_at, notes
+  - [ ] Test `TaskBlocked` has task_id, reason
+  - [ ] Test `TaskUnblocked` has task_id
+  - [ ] Test `TaskCancelled` has task_id
+  - [ ] Test `TaskUpdated` has task_id, changed_fields dict
+  - [ ] Test `TaskTagAdded` has task_id, tag
+  - [ ] Test `TaskTagRemoved` has task_id, tag
+  - [ ] Test `SubTaskLinked` has task_id, subtask_id
+  - [ ] Test `SubTaskUnlinked` has task_id, subtask_id
+  - [ ] Test all events extend `DomainEvent`
+  - [ ] Test all events are immutable
+
+- [ ] **GREEN**: Implement Task events
+  - [ ] One event class per significant state change
+  - [ ] Include all relevant data for event sourcing
+
+- [ ] **REFACTOR**: Group related events
+  - [ ] Consider event versioning strategy
+
+#### 101.4.3: SubTask Events (`subtask_events.py`)
+
+- [ ] **RED**: Write `test_subtask_events.py`
+  - [ ] Test `SubTaskCreated` has all subtask fields + task_id
+  - [ ] Test `SubTaskStarted` has subtask_id, timestamp
+  - [ ] Test `SubTaskCompleted` has subtask_id, completed_at
+  - [ ] Test `SubTaskSkipped` has subtask_id, reason
+  - [ ] Test `SubTaskUpdated` has subtask_id, changed_fields
+  - [ ] Test all events extend `DomainEvent`
+  - [ ] Test all events include parent task_id for correlation
+
+- [ ] **GREEN**: Implement SubTask events
+  - [ ] Include `task_id` in all events for correlation
+
+- [ ] **REFACTOR**: Ensure event naming consistency
+
+---
+
+### Sub-task 101.5: Repository Ports
+
+**Files**: `src/domain/ports/`
+**Tests**: `tests/unit/domain/ports/`
+
+#### 101.5.1: Task Repository Port (`task_repository.py`)
+
+- [ ] **RED**: Write `test_task_repository_port.py`
+  - [ ] Test `ITaskRepository` is ABC
+  - [ ] Test `get(task_id)` returns `Task | None`
+  - [ ] Test `save(task)` returns `None`
+  - [ ] Test `delete(task_id)` returns `bool`
+  - [ ] Test `list_all()` returns `list[Task]`
+  - [ ] Test `list_by_status(status)` returns filtered list
+  - [ ] Test `list_by_priority(priority)` returns filtered list
+  - [ ] Test `list_by_tag(tag)` returns filtered list
+  - [ ] Test `exists(task_id)` returns `bool`
+  - [ ] Test all methods are abstract
+
+- [ ] **GREEN**: Implement `ITaskRepository` ABC
+  - [ ] Define all method signatures with type hints
+  - [ ] Add docstrings with contracts
+
+- [ ] **REFACTOR**: Add query specification pattern
+  - [ ] Consider `TaskQuery` dataclass for complex queries
+
+#### 101.5.2: SubTask Repository Port (`subtask_repository.py`)
+
+- [ ] **RED**: Write `test_subtask_repository_port.py`
+  - [ ] Test `ISubTaskRepository` is ABC
+  - [ ] Test `get(subtask_id)` returns `SubTask | None`
+  - [ ] Test `save(subtask)` returns `None`
+  - [ ] Test `delete(subtask_id)` returns `bool`
+  - [ ] Test `list_by_task(task_id)` returns list ordered by `order_index`
+  - [ ] Test `list_by_status(status)` returns filtered list
+  - [ ] Test `exists(subtask_id)` returns `bool`
+  - [ ] Test `count_by_task(task_id)` returns count
+  - [ ] Test `count_incomplete_by_task(task_id)` returns count of non-terminal
+
+- [ ] **GREEN**: Implement `ISubTaskRepository` ABC
+  - [ ] Define all method signatures
+  - [ ] Add docstrings
+
+- [ ] **REFACTOR**: Add bulk operations
+  - [ ] `save_all(subtasks: list[SubTask])` for efficiency
+
+#### 101.5.3: Unit of Work Port (`unit_of_work.py`)
+
+- [ ] **RED**: Write `test_unit_of_work_port.py`
+  - [ ] Test `IUnitOfWork` is ABC
+  - [ ] Test `task_repository` property returns `ITaskRepository`
+  - [ ] Test `subtask_repository` property returns `ISubTaskRepository`
+  - [ ] Test `commit()` is abstract
+  - [ ] Test `rollback()` is abstract
+  - [ ] Test context manager protocol (`__enter__`, `__exit__`)
+  - [ ] Test `__exit__` calls rollback on exception
+
+- [ ] **GREEN**: Implement `IUnitOfWork` ABC
+  - [ ] Repository properties
+  - [ ] Transaction methods
+  - [ ] Context manager protocol
+
+- [ ] **REFACTOR**: Add event collection
+  - [ ] `collect_events()` to gather events from all aggregates
+
+---
+
+### Sub-task 101.6: Domain Exceptions
+
+**Files**: `src/domain/exceptions.py`
+**Tests**: `tests/unit/domain/test_exceptions.py`
+
+#### 101.6.1: Exception Hierarchy
+
+- [ ] **RED**: Write `test_domain_exceptions.py`
+  - [ ] Test `DomainError` is base exception
+  - [ ] Test `DomainError` has `message` attribute
+  - [ ] Test `EntityNotFoundError` has `entity_type`, `entity_id`
+  - [ ] Test `EntityNotFoundError` message includes type and ID
+  - [ ] Test `InvalidStateError` has `current_state`, `attempted_action`
+  - [ ] Test `InvalidStateTransitionError` has `from_state`, `to_state`
+  - [ ] Test `ValidationError` has `field`, `message`, `value`
+  - [ ] Test `ConcurrencyError` has `expected_version`, `actual_version`
+  - [ ] Test all exceptions are serializable
+
+- [ ] **GREEN**: Implement exception hierarchy
+  - [ ] `DomainError(Exception)`
+  - [ ] `EntityNotFoundError(DomainError)`
+  - [ ] `InvalidStateError(DomainError)`
+  - [ ] `InvalidStateTransitionError(InvalidStateError)`
+  - [ ] `ValidationError(DomainError)`
+  - [ ] `ConcurrencyError(DomainError)`
+
+- [ ] **REFACTOR**: Add error codes
+  - [ ] Unique error codes for each exception type
+
+---
+
+### Sub-task 101.7: Architecture Tests
+
+**Files**: `tests/architecture/`
+
+#### 101.7.1: Layer Dependency Tests
+
+- [ ] **RED**: Write `test_domain_architecture.py`
+  - [ ] Test domain/ has no imports from application/
+  - [ ] Test domain/ has no imports from infrastructure/
+  - [ ] Test domain/ has no imports from interface/
+  - [ ] Test domain/ only imports from stdlib + domain/
+  - [ ] Test all aggregates extend proper base
+  - [ ] Test all value objects are frozen dataclasses
+  - [ ] Test all events are frozen dataclasses
+  - [ ] Test all ports are ABCs
+  - [ ] Test no concrete implementations in domain/
+
+- [ ] **GREEN**: Implement architecture validation
+  - [ ] Use AST parsing or import analysis
+  - [ ] Fail fast on violations
+
+- [ ] **REFACTOR**: Add to CI pipeline
+  - [ ] Run on every commit
+
+---
+
+## WORK-102: File-Based Repository Adapters
+
+**Status**: PENDING
+**Duration**: Weeks 3-4
+**Artifacts**: JSON adapter, TOON adapter, file management
+**Dependencies**: WORK-101
+
+### Sub-task 102.1: File Store Infrastructure
+
+**Files**: `src/infrastructure/persistence/`
+**Tests**: `tests/integration/persistence/`
+
+#### 102.1.1: File Store Base (`file_store.py`)
+
+- [ ] **RED**: Write `test_file_store.py`
+  - [ ] Test `FileStore` creates directory if not exists
+  - [ ] Test `FileStore` with custom base path
+  - [ ] Test `get_file_path(entity_type, entity_id)` returns correct path
+  - [ ] Test `read_file(path)` returns content or None if not exists
+  - [ ] Test `write_file(path, content)` creates/overwrites file
+  - [ ] Test `delete_file(path)` removes file, returns bool
+  - [ ] Test `list_files(entity_type)` returns all files in directory
+  - [ ] Test `file_exists(path)` returns bool
+  - [ ] Test atomic write (write to temp, then rename)
+  - [ ] Test handles concurrent reads safely
+  - [ ] Test handles special characters in IDs
+  - [ ] Test handles very long content
+
+- [ ] **GREEN**: Implement `FileStore`
+  - [ ] Base path configuration
+  - [ ] Directory management
+  - [ ] Atomic write operations
+  - [ ] File listing with glob
+
+- [ ] **REFACTOR**: Add file locking
+  - [ ] Optional locking for concurrent writes
+  - [ ] Consider `fcntl` or `portalocker`
+
+#### 102.1.2: Serialization Port (`serialization.py`)
+
+- [ ] **RED**: Write `test_serialization_port.py`
+  - [ ] Test `ISerializer` is ABC
+  - [ ] Test `serialize(entity)` returns string
+  - [ ] Test `deserialize(data, entity_type)` returns entity
+  - [ ] Test `file_extension` property returns extension
+  - [ ] Test `content_type` property returns MIME type
+
+- [ ] **GREEN**: Implement `ISerializer` ABC
+  - [ ] Generic serialization interface
+  - [ ] Support for entity type hints
+
+- [ ] **REFACTOR**: Add schema versioning
+  - [ ] Version field in serialized output
+
+---
+
+### Sub-task 102.2: JSON Adapter
+
+**Files**: `src/infrastructure/persistence/json_adapter.py`
+**Tests**: `tests/integration/persistence/test_json_adapter.py`
+
+#### 102.2.1: JSON Serializer
+
+- [ ] **RED**: Write `test_json_serializer.py`
+  - [ ] Test Task serializes to valid JSON
+  - [ ] Test Task JSON includes all fields
+  - [ ] Test Task deserializes back to equal entity
+  - [ ] Test SubTask serializes to valid JSON
+  - [ ] Test SubTask JSON includes task_id reference
+  - [ ] Test SubTask deserializes back to equal entity
+  - [ ] Test handles datetime fields (ISO 8601)
+  - [ ] Test handles UUID fields
+  - [ ] Test handles enum fields
+  - [ ] Test handles frozenset fields (as list)
+  - [ ] Test handles None values
+  - [ ] Test handles empty strings
+  - [ ] Test handles special characters (unicode)
+  - [ ] Test pretty-print option
+  - [ ] Test compact output option
+  - [ ] Test invalid JSON raises `DeserializationError`
+  - [ ] Test missing required field raises `DeserializationError`
+  - [ ] Test extra fields are ignored (forward compatibility)
+
+- [ ] **GREEN**: Implement `JsonSerializer`
+  - [ ] Implement `ISerializer`
+  - [ ] Custom JSON encoder for domain types
+  - [ ] Custom JSON decoder for domain types
+  - [ ] `file_extension = ".json"`
+  - [ ] `content_type = "application/json"`
+
+- [ ] **REFACTOR**: Add schema validation
+  - [ ] JSON Schema for validation
+  - [ ] Version migration support
+
+#### 102.2.2: JSON Task Repository
+
+- [ ] **RED**: Write `test_json_task_repository.py`
+  - [ ] Test `save()` creates new file for new task
+  - [ ] Test `save()` overwrites file for existing task
+  - [ ] Test `get()` returns task from file
+  - [ ] Test `get()` returns None for non-existent
+  - [ ] Test `delete()` removes file, returns True
+  - [ ] Test `delete()` returns False for non-existent
+  - [ ] Test `list_all()` returns all tasks from files
+  - [ ] Test `list_all()` returns empty list when no files
+  - [ ] Test `list_by_status()` filters correctly
+  - [ ] Test `list_by_priority()` filters correctly
+  - [ ] Test `list_by_tag()` filters correctly
+  - [ ] Test `exists()` returns correct boolean
+  - [ ] Test corrupted file raises `RepositoryError`
+  - [ ] Test file permission error raises `RepositoryError`
+
+- [ ] **GREEN**: Implement `JsonTaskRepository`
+  - [ ] Implement `ITaskRepository`
+  - [ ] Use `FileStore` and `JsonSerializer`
+  - [ ] File naming: `{task_id}.json`
+
+- [ ] **REFACTOR**: Add caching layer
+  - [ ] In-memory cache for frequently accessed tasks
+  - [ ] Cache invalidation on save/delete
+
+#### 102.2.3: JSON SubTask Repository
+
+- [ ] **RED**: Write `test_json_subtask_repository.py`
+  - [ ] Test `save()` creates new file for new subtask
+  - [ ] Test `get()` returns subtask from file
+  - [ ] Test `get()` returns None for non-existent
+  - [ ] Test `delete()` removes file, returns True
+  - [ ] Test `list_by_task()` returns all subtasks for task
+  - [ ] Test `list_by_task()` returns ordered by order_index
+  - [ ] Test `list_by_task()` returns empty list when none
+  - [ ] Test `list_by_status()` filters correctly
+  - [ ] Test `count_by_task()` returns correct count
+  - [ ] Test `count_incomplete_by_task()` returns correct count
+
+- [ ] **GREEN**: Implement `JsonSubTaskRepository`
+  - [ ] Implement `ISubTaskRepository`
+  - [ ] Use `FileStore` and `JsonSerializer`
+  - [ ] File naming: `{subtask_id}.json`
+  - [ ] Consider subdirectory per parent task for performance
+
+- [ ] **REFACTOR**: Optimize listing
+  - [ ] Index file for faster queries by task_id
+
+---
+
+### Sub-task 102.3: TOON Adapter
+
+**Files**: `src/infrastructure/persistence/toon_adapter.py`
+**Tests**: `tests/integration/persistence/test_toon_adapter.py`
+
+#### 102.3.1: TOON Serializer
+
+- [ ] **RED**: Write `test_toon_serializer.py`
+  - [ ] Test Task serializes to valid TOON
+  - [ ] Test Task TOON includes all fields
+  - [ ] Test Task deserializes back to equal entity
+  - [ ] Test SubTask serializes to valid TOON
+  - [ ] Test SubTask TOON includes task_id reference
+  - [ ] Test SubTask deserializes back to equal entity
+  - [ ] Test handles datetime fields
+  - [ ] Test handles UUID fields
+  - [ ] Test handles enum fields
+  - [ ] Test handles frozenset fields
+  - [ ] Test handles None values
+  - [ ] Test handles special characters (quoting)
+  - [ ] Test invalid TOON raises `DeserializationError`
+  - [ ] Test TOON is significantly smaller than JSON (measure tokens)
+  - [ ] Test round-trip JSON ↔ TOON preserves data
+
+- [ ] **GREEN**: Implement `ToonSerializer`
+  - [ ] Implement `ISerializer`
+  - [ ] Use `python-toon` library
+  - [ ] Custom encoding for domain types
+  - [ ] `file_extension = ".toon"`
+  - [ ] `content_type = "text/toon"`
+
+- [ ] **REFACTOR**: Add token counting
+  - [ ] Method to estimate token savings vs JSON
+
+#### 102.3.2: TOON Task Repository
+
+- [ ] **RED**: Write `test_toon_task_repository.py`
+  - [ ] Test `save()` creates .toon file
+  - [ ] Test `get()` reads .toon file
+  - [ ] Test `delete()` removes .toon file
+  - [ ] Test `list_all()` returns all tasks
+  - [ ] Test filtering works same as JSON adapter
+  - [ ] Test same contract as `ITaskRepository`
+
+- [ ] **GREEN**: Implement `ToonTaskRepository`
+  - [ ] Same interface as `JsonTaskRepository`
+  - [ ] Use `ToonSerializer` instead
+
+- [ ] **REFACTOR**: Extract common base
+  - [ ] `FileTaskRepository` base class with serializer injection
+
+#### 102.3.3: TOON SubTask Repository
+
+- [ ] **RED**: Write `test_toon_subtask_repository.py`
+  - [ ] Test same contract as JSON adapter
+  - [ ] Test TOON-specific serialization
+
+- [ ] **GREEN**: Implement `ToonSubTaskRepository`
+  - [ ] Same interface as `JsonSubTaskRepository`
+  - [ ] Use `ToonSerializer`
+
+- [ ] **REFACTOR**: Extract common base
+  - [ ] `FileSubTaskRepository` base class
+
+---
+
+### Sub-task 102.4: Unit of Work Implementation
+
+**Files**: `src/infrastructure/persistence/file_unit_of_work.py`
+**Tests**: `tests/integration/persistence/test_file_unit_of_work.py`
+
+#### 102.4.1: File Unit of Work
+
+- [ ] **RED**: Write `test_file_unit_of_work.py`
+  - [ ] Test `task_repository` property returns configured repository
+  - [ ] Test `subtask_repository` property returns configured repository
+  - [ ] Test `commit()` is no-op for file-based (auto-commit on save)
+  - [ ] Test `rollback()` is no-op for file-based (no transactions)
+  - [ ] Test context manager works
+  - [ ] Test `collect_events()` gathers events from saved aggregates
+  - [ ] Test factory method for JSON format
+  - [ ] Test factory method for TOON format
+  - [ ] Test configurable base path
+
+- [ ] **GREEN**: Implement `FileUnitOfWork`
+  - [ ] Implement `IUnitOfWork`
+  - [ ] Inject serializer type (JSON or TOON)
+  - [ ] Factory methods: `create_json()`, `create_toon()`
+
+- [ ] **REFACTOR**: Add format auto-detection
+  - [ ] Detect format from existing files
+
+---
+
+### Sub-task 102.5: Contract Tests
+
+**Files**: `tests/contract/`
+
+#### 102.5.1: Repository Contract Tests
+
+- [ ] **RED**: Write `test_repository_contract.py`
+  - [ ] Parameterized tests for all repository implementations
+  - [ ] Test save/get round-trip
+  - [ ] Test delete behavior
+  - [ ] Test list behavior
+  - [ ] Test filter behavior
+  - [ ] Test not-found behavior
+  - [ ] Ensure JSON and TOON adapters behave identically
+
+- [ ] **GREEN**: Implement contract test suite
+  - [ ] Use pytest parameterization
+  - [ ] Run same tests against both adapters
+
+- [ ] **REFACTOR**: Add performance contracts
+  - [ ] Max time for operations
+  - [ ] Memory bounds
+
+---
+
+## WORK-103: CQRS Implementation
+
+**Status**: PENDING
+**Duration**: Weeks 5-6
+**Artifacts**: Commands, queries, handlers, dispatcher
+**Dependencies**: WORK-101, WORK-102
+
+### Sub-task 103.1: Command Definitions
+
+**Files**: `src/application/commands/`
+**Tests**: `tests/unit/application/commands/`
+
+#### 103.1.1: Task Commands (`task_commands.py`)
+
+- [ ] **RED**: Write `test_task_commands.py`
+  - [ ] Test `CreateTaskCommand` has title, optional description, priority, tags, due_date
+  - [ ] Test `CreateTaskCommand` is immutable
+  - [ ] Test `CreateTaskCommand` validates title not empty
+  - [ ] Test `StartTaskCommand` has task_id
+  - [ ] Test `CompleteTaskCommand` has task_id, optional notes
+  - [ ] Test `BlockTaskCommand` has task_id, reason
+  - [ ] Test `UnblockTaskCommand` has task_id
+  - [ ] Test `CancelTaskCommand` has task_id
+  - [ ] Test `UpdateTaskCommand` has task_id, optional title, description, priority, due_date
+  - [ ] Test `AddTagCommand` has task_id, tag
+  - [ ] Test `RemoveTagCommand` has task_id, tag
+  - [ ] Test `AddSubTaskReferenceCommand` has task_id, subtask_id
+  - [ ] Test `RemoveSubTaskReferenceCommand` has task_id, subtask_id
+
+- [ ] **GREEN**: Implement Task commands
+  - [ ] `@dataclass(frozen=True)` for all commands
+  - [ ] Validation in `__post_init__`
+
+- [ ] **REFACTOR**: Add command metadata
+  - [ ] `command_type` property
+  - [ ] `correlation_id` field
+
+#### 103.1.2: SubTask Commands (`subtask_commands.py`)
+
+- [ ] **RED**: Write `test_subtask_commands.py`
+  - [ ] Test `CreateSubTaskCommand` has task_id, title, optional description, order_index
+  - [ ] Test `StartSubTaskCommand` has subtask_id
+  - [ ] Test `CompleteSubTaskCommand` has subtask_id
+  - [ ] Test `SkipSubTaskCommand` has subtask_id, optional reason
+  - [ ] Test `UpdateSubTaskCommand` has subtask_id, optional title, description, order_index
+  - [ ] Test all commands are immutable
+
+- [ ] **GREEN**: Implement SubTask commands
+  - [ ] Same patterns as Task commands
+
+- [ ] **REFACTOR**: Ensure consistency
+
+---
+
+### Sub-task 103.2: Command Handlers
+
+**Files**: `src/application/handlers/commands/`
+**Tests**: `tests/unit/application/handlers/`
+
+#### 103.2.1: Task Command Handlers (`task_handlers.py`)
+
+- [ ] **RED**: Write `test_task_command_handlers.py`
+  - [ ] Test `CreateTaskHandler` creates task via factory
+  - [ ] Test `CreateTaskHandler` saves via repository
+  - [ ] Test `CreateTaskHandler` returns TaskId
+  - [ ] Test `CreateTaskHandler` collects TaskCreated event
+  - [ ] Test `StartTaskHandler` fetches task
+  - [ ] Test `StartTaskHandler` calls task.start()
+  - [ ] Test `StartTaskHandler` saves updated task
+  - [ ] Test `StartTaskHandler` raises EntityNotFoundError if not found
+  - [ ] Test `CompleteTaskHandler` same pattern
+  - [ ] Test `BlockTaskHandler` same pattern
+  - [ ] Test `UnblockTaskHandler` same pattern
+  - [ ] Test `CancelTaskHandler` same pattern
+  - [ ] Test `UpdateTaskHandler` applies partial updates
+  - [ ] Test `AddTagHandler` adds tag
+  - [ ] Test `RemoveTagHandler` removes tag
+  - [ ] Test handlers collect events for dispatch
+
+- [ ] **GREEN**: Implement Task handlers
+  - [ ] `ICommandHandler[TCommand, TResult]` interface
+  - [ ] Inject `IUnitOfWork`
+  - [ ] Fetch → Mutate → Save pattern
+
+- [ ] **REFACTOR**: Extract base handler
+  - [ ] Common fetch-mutate-save logic
+
+#### 103.2.2: SubTask Command Handlers (`subtask_handlers.py`)
+
+- [ ] **RED**: Write `test_subtask_command_handlers.py`
+  - [ ] Test `CreateSubTaskHandler` creates subtask
+  - [ ] Test `CreateSubTaskHandler` adds reference to parent task
+  - [ ] Test `CreateSubTaskHandler` raises if parent task not found
+  - [ ] Test `StartSubTaskHandler` starts subtask
+  - [ ] Test `CompleteSubTaskHandler` completes subtask
+  - [ ] Test `SkipSubTaskHandler` skips subtask
+  - [ ] Test `UpdateSubTaskHandler` updates subtask
+  - [ ] Test handlers collect events
+
+- [ ] **GREEN**: Implement SubTask handlers
+  - [ ] Same patterns as Task handlers
+  - [ ] Coordinate with parent Task for reference
+
+- [ ] **REFACTOR**: Add transaction coordinator
+  - [ ] Ensure Task and SubTask saved atomically
+
+---
+
+### Sub-task 103.3: Query Definitions
+
+**Files**: `src/application/queries/`
+**Tests**: `tests/unit/application/queries/`
+
+#### 103.3.1: Task Queries (`task_queries.py`)
+
+- [ ] **RED**: Write `test_task_queries.py`
+  - [ ] Test `GetTaskQuery` has task_id
+  - [ ] Test `ListTasksQuery` has optional filters: status, priority, tag
+  - [ ] Test `GetTaskWithSubTasksQuery` has task_id
+  - [ ] Test all queries are immutable
+
+- [ ] **GREEN**: Implement Task queries
+  - [ ] `@dataclass(frozen=True)`
+
+- [ ] **REFACTOR**: Add pagination
+  - [ ] `limit`, `offset` fields
+
+#### 103.3.2: SubTask Queries (`subtask_queries.py`)
+
+- [ ] **RED**: Write `test_subtask_queries.py`
+  - [ ] Test `GetSubTaskQuery` has subtask_id
+  - [ ] Test `ListSubTasksByTaskQuery` has task_id
+  - [ ] Test `ListSubTasksQuery` has optional status filter
+
+- [ ] **GREEN**: Implement SubTask queries
+
+- [ ] **REFACTOR**: Add sorting options
+
+---
+
+### Sub-task 103.4: Query Handlers
+
+**Files**: `src/application/handlers/queries/`
+**Tests**: `tests/unit/application/handlers/`
+
+#### 103.4.1: Task Query Handlers (`task_query_handlers.py`)
+
+- [ ] **RED**: Write `test_task_query_handlers.py`
+  - [ ] Test `GetTaskHandler` returns TaskDTO or None
+  - [ ] Test `ListTasksHandler` returns list of TaskDTO
+  - [ ] Test `ListTasksHandler` applies filters
+  - [ ] Test `GetTaskWithSubTasksHandler` returns TaskWithSubTasksDTO
+  - [ ] Test handlers don't modify state
+
+- [ ] **GREEN**: Implement Task query handlers
+  - [ ] `IQueryHandler[TQuery, TResult]` interface
+  - [ ] Return DTOs, not aggregates
+
+- [ ] **REFACTOR**: Add caching hints
+
+#### 103.4.2: SubTask Query Handlers (`subtask_query_handlers.py`)
+
+- [ ] **RED**: Write `test_subtask_query_handlers.py`
+  - [ ] Test `GetSubTaskHandler` returns SubTaskDTO or None
+  - [ ] Test `ListSubTasksByTaskHandler` returns ordered list
+  - [ ] Test `ListSubTasksHandler` applies status filter
+
+- [ ] **GREEN**: Implement SubTask query handlers
+
+- [ ] **REFACTOR**: Optimize for common queries
+
+---
+
+### Sub-task 103.5: DTOs
+
+**Files**: `src/application/dtos/`
+**Tests**: `tests/unit/application/dtos/`
+
+#### 103.5.1: Task DTOs (`task_dto.py`)
+
+- [ ] **RED**: Write `test_task_dto.py`
+  - [ ] Test `TaskDTO` has all Task fields
+  - [ ] Test `TaskDTO` is immutable
+  - [ ] Test `TaskDTO.from_entity()` creates DTO from Task
+  - [ ] Test `TaskDTO` serializes to dict
+  - [ ] Test `TaskSummaryDTO` has subset of fields (id, title, status)
+  - [ ] Test `TaskWithSubTasksDTO` includes list of SubTaskDTO
+
+- [ ] **GREEN**: Implement Task DTOs
+  - [ ] `@dataclass(frozen=True)`
+  - [ ] `from_entity()` factory
+
+- [ ] **REFACTOR**: Add serialization methods
+
+#### 103.5.2: SubTask DTOs (`subtask_dto.py`)
+
+- [ ] **RED**: Write `test_subtask_dto.py`
+  - [ ] Test `SubTaskDTO` has all SubTask fields
+  - [ ] Test `SubTaskDTO.from_entity()` creates DTO
+  - [ ] Test `SubTaskSummaryDTO` has subset
+
+- [ ] **GREEN**: Implement SubTask DTOs
+
+- [ ] **REFACTOR**: Ensure consistency with Task DTOs
+
+---
+
+### Sub-task 103.6: Event Dispatcher
+
+**Files**: `src/application/dispatcher/`
+**Tests**: `tests/unit/application/dispatcher/`
+
+#### 103.6.1: Event Dispatcher Port and Adapter
+
+- [ ] **RED**: Write `test_event_dispatcher.py`
+  - [ ] Test `IEventDispatcher` is ABC
+  - [ ] Test `dispatch(event)` is abstract
+  - [ ] Test `dispatch_all(events)` is abstract
+  - [ ] Test `subscribe(event_type, handler)` is abstract
+  - [ ] Test `InMemoryEventDispatcher` dispatches to handlers
+  - [ ] Test multiple handlers for same event type
+  - [ ] Test handler exception doesn't stop other handlers
+  - [ ] Test async handler support (future)
+
+- [ ] **GREEN**: Implement `IEventDispatcher` and `InMemoryEventDispatcher`
+  - [ ] Simple in-memory implementation for Phase 1
+
+- [ ] **REFACTOR**: Add event logging
+  - [ ] Log all dispatched events
+
+---
+
+### Sub-task 103.7: CQRS Integration Tests
+
+**Files**: `tests/integration/application/`
+
+#### 103.7.1: End-to-End CQRS Tests
+
+- [ ] **RED**: Write `test_cqrs_integration.py`
+  - [ ] Test create task → query returns it
+  - [ ] Test create task → start → query shows IN_PROGRESS
+  - [ ] Test create task → complete → query shows COMPLETED
+  - [ ] Test create task with subtasks → query with subtasks
+  - [ ] Test complete subtasks → complete task workflow
+  - [ ] Test events are dispatched correctly
+  - [ ] Test full lifecycle with file persistence
+
+- [ ] **GREEN**: Implement integration tests
+  - [ ] Use real file system (temp directory)
+  - [ ] Test both JSON and TOON adapters
+
+- [ ] **REFACTOR**: Add performance benchmarks
+
+---
+
+## WORK-104: CLI Interface & SKILL.md
+
+**Status**: PENDING
+**Duration**: Weeks 7-8
+**Artifacts**: CLI adapter, SKILL.md, BDD tests
+**Dependencies**: WORK-103
+
+### Sub-task 104.1: CLI Primary Adapter
+
+**Files**: `src/interface/cli/`
+**Tests**: `tests/e2e/cli/`
+
+#### 104.1.1: CLI Entry Point (`wt.py`)
+
+- [ ] **RED**: Write `test_cli_entry.py`
+  - [ ] Test `wt --help` shows usage
+  - [ ] Test `wt --version` shows version
+  - [ ] Test `wt` with no args shows help
+  - [ ] Test unknown command shows error
+  - [ ] Test exit code 0 on success
+  - [ ] Test exit code 1 on error
+  - [ ] Test `--format json` option
+  - [ ] Test `--format toon` option
+  - [ ] Test `--data-dir` option for custom path
+
+- [ ] **GREEN**: Implement CLI entry point
+  - [ ] Use argparse
+  - [ ] Subcommand structure
+  - [ ] Global options
+
+- [ ] **REFACTOR**: Add rich output formatting
+  - [ ] Colors for status
+  - [ ] Tables for lists
+
+#### 104.1.2: Task Subcommand (`task_cli.py`)
+
+- [ ] **RED**: Write `test_task_cli.py`
+  - [ ] Test `wt task create "Title"` creates task
+  - [ ] Test `wt task create "Title" --description "Desc"` with description
+  - [ ] Test `wt task create "Title" --priority high` with priority
+  - [ ] Test `wt task create "Title" --tag bug --tag urgent` with tags
+  - [ ] Test `wt task create "Title" --due 2026-02-01` with due date
+  - [ ] Test `wt task list` shows all tasks
+  - [ ] Test `wt task list --status pending` filters by status
+  - [ ] Test `wt task list --priority high` filters by priority
+  - [ ] Test `wt task list --tag bug` filters by tag
+  - [ ] Test `wt task show <id>` shows task details
+  - [ ] Test `wt task show <id> --subtasks` shows with subtasks
+  - [ ] Test `wt task start <id>` starts task
+  - [ ] Test `wt task complete <id>` completes task
+  - [ ] Test `wt task complete <id> --notes "Done"` with notes
+  - [ ] Test `wt task block <id> --reason "Waiting"` blocks task
+  - [ ] Test `wt task unblock <id>` unblocks task
+  - [ ] Test `wt task cancel <id>` cancels task
+  - [ ] Test `wt task update <id> --title "New"` updates title
+  - [ ] Test `wt task delete <id>` deletes task
+  - [ ] Test `wt task delete <id> --force` skips confirmation
+  - [ ] Test error messages are helpful
+  - [ ] Test invalid ID format shows error
+  - [ ] Test not found shows appropriate message
+
+- [ ] **GREEN**: Implement task subcommand
+  - [ ] Wire to command/query handlers
+  - [ ] Output formatting
+
+- [ ] **REFACTOR**: Add interactive mode
+  - [ ] Confirmation prompts for destructive actions
+
+#### 104.1.3: SubTask Subcommand (`subtask_cli.py`)
+
+- [ ] **RED**: Write `test_subtask_cli.py`
+  - [ ] Test `wt subtask create <task_id> "Title"` creates subtask
+  - [ ] Test `wt subtask create <task_id> "Title" --description "Desc"`
+  - [ ] Test `wt subtask create <task_id> "Title" --order 1` with order
+  - [ ] Test `wt subtask list <task_id>` shows subtasks for task
+  - [ ] Test `wt subtask show <id>` shows subtask details
+  - [ ] Test `wt subtask start <id>` starts subtask
+  - [ ] Test `wt subtask complete <id>` completes subtask
+  - [ ] Test `wt subtask skip <id>` skips subtask
+  - [ ] Test `wt subtask skip <id> --reason "Not needed"` with reason
+  - [ ] Test `wt subtask update <id> --title "New"` updates
+  - [ ] Test `wt subtask delete <id>` deletes
+  - [ ] Test error handling
+
+- [ ] **GREEN**: Implement subtask subcommand
+
+- [ ] **REFACTOR**: Add bulk operations
+  - [ ] `wt subtask complete-all <task_id>`
+
+---
+
+### Sub-task 104.2: SKILL.md
+
+**Files**: `skills/worktracker/SKILL.md`
+
+#### 104.2.1: Work Tracker Skill Definition
+
+- [ ] **Write SKILL.md**
+  - [ ] Natural language patterns for task operations
+  - [ ] Examples for common workflows
+  - [ ] Integration with CLI commands
+  - [ ] Error handling patterns
+  - [ ] Quick reference section
+
+- [ ] **Test skill patterns**
+  - [ ] Manual testing with Claude Code
+  - [ ] Verify pattern recognition
+
+- [ ] **Document**
+  - [ ] Add to skill index
+  - [ ] Cross-reference with CLI
+
+---
+
+### Sub-task 104.3: BDD Test Suite
+
+**Files**: `tests/bdd/`
+
+#### 104.3.1: Task Feature Files
+
+- [ ] **Write `features/task.feature`**
+  - [ ] Scenario: Create task with title only
+  - [ ] Scenario: Create task with all options
+  - [ ] Scenario: Start pending task
+  - [ ] Scenario: Complete in-progress task
+  - [ ] Scenario: Block in-progress task
+  - [ ] Scenario: Unblock blocked task
+  - [ ] Scenario: Cancel pending task
+  - [ ] Scenario: List tasks by status
+  - [ ] Scenario: Update task attributes
+  - [ ] Scenario: Add and remove tags
+  - [ ] Edge: Create task with max-length title
+  - [ ] Edge: Create task with due date today
+  - [ ] Negative: Create task with empty title
+  - [ ] Negative: Start already-started task
+  - [ ] Negative: Complete pending task
+  - [ ] Negative: Complete cancelled task
+
+- [ ] **Implement step definitions** (`steps/task_steps.py`)
+  - [ ] REAL CLI invocations (no mocks)
+  - [ ] File system verification
+  - [ ] Output parsing
+
+#### 104.3.2: SubTask Feature Files
+
+- [ ] **Write `features/subtask.feature`**
+  - [ ] Scenario: Create subtask for task
+  - [ ] Scenario: Complete subtask
+  - [ ] Scenario: Skip subtask with reason
+  - [ ] Scenario: Reorder subtasks
+  - [ ] Scenario: Complete all subtasks then complete task
+  - [ ] Negative: Create subtask for non-existent task
+  - [ ] Negative: Complete subtask for completed task
+
+- [ ] **Implement step definitions** (`steps/subtask_steps.py`)
+  - [ ] REAL CLI invocations
+
+#### 104.3.3: Workflow Feature Files
+
+- [ ] **Write `features/workflow.feature`**
+  - [ ] Scenario: Full task lifecycle with subtasks
+  - [ ] Scenario: Concurrent subtask completion
+  - [ ] Scenario: Task with blocked subtask
+  - [ ] Scenario: Export to TOON format
+
+- [ ] **Implement step definitions** (`steps/workflow_steps.py`)
+
+---
+
+### Sub-task 104.4: System Tests & Phase 1 Gate
+
+**Files**: `tests/system/`
+
+#### 104.4.1: System Integration Tests
+
+- [ ] **RED**: Write `test_system_integration.py`
+  - [ ] Test full workflow via CLI
+  - [ ] Test persistence across CLI invocations
+  - [ ] Test JSON and TOON format interop
+  - [ ] Test data directory isolation
+  - [ ] Test concurrent CLI invocations (multiple terminals)
+
+- [ ] **GREEN**: Implement system tests
+  - [ ] Real file system
+  - [ ] Real CLI process invocation
+
+- [ ] **REFACTOR**: Add chaos testing
+  - [ ] Interrupt mid-operation
+  - [ ] Corrupt file recovery
+
+#### 104.4.2: Performance Tests
+
+- [ ] **RED**: Write `test_performance.py`
+  - [ ] Test create 100 tasks < 10s
+  - [ ] Test list 100 tasks < 1s
+  - [ ] Test single operation < 100ms p95
+  - [ ] Test file size reasonable (< 1KB per task)
+  - [ ] Test memory usage bounded
+
+- [ ] **GREEN**: Implement performance tests
+  - [ ] Benchmarking with pytest-benchmark
+
+- [ ] **REFACTOR**: Add profiling
+
+#### 104.4.3: Phase 1 Go/No-Go Checklist
+
+- [ ] All unit tests pass (95%+ coverage)
+- [ ] All integration tests pass
+- [ ] All contract tests pass
+- [ ] All BDD scenarios pass
+- [ ] All E2E tests pass
+- [ ] All architecture tests pass
+- [ ] Performance targets met
+- [ ] SKILL.md complete and tested
+- [ ] No critical bugs
+- [ ] Code review approved
+
+---
+
+## Estimated Test Counts
+
+| Category | Count |
+|----------|-------|
+| Unit tests (domain) | ~150 |
+| Unit tests (application) | ~100 |
+| Integration tests | ~50 |
+| Contract tests | ~20 |
+| E2E tests | ~30 |
+| BDD scenarios | ~40 |
+| Architecture tests | ~10 |
+| System tests | ~20 |
+| Performance tests | ~10 |
+| **Total** | **~430** |
+
+---
+
+*Phase 1 plan created 2026-01-09*

--- a/docs/archive/projects-archive/plans/worktracker/02-wt-infrastructure.md
+++ b/docs/archive/projects-archive/plans/worktracker/02-wt-infrastructure.md
@@ -1,0 +1,260 @@
+# Phase 2: Shared Infrastructure (Weeks 9-16)
+
+> **Goal**: Build shared infrastructure components for Event Store, Graph, Semantic Index, and RDF.
+> **Reference**: [Index](00-wt-index.md) | [Unified Design](../../design/work-034-e-003-unified-design.md)
+
+**Status**: PENDING
+**Duration**: Weeks 9-16
+**WORK Items**: WORK-201 to WORK-204
+**Dependencies**: Phase 1 complete
+
+---
+
+## Phase 2 Overview
+
+| WORK Item | Name | Duration | Dependencies |
+|-----------|------|----------|--------------|
+| WORK-201 | Event Store | Weeks 9-10 | Phase 1 |
+| WORK-202 | Graph Store (NetworkX) | Weeks 11-12 | WORK-201 |
+| WORK-203 | Semantic Index (FAISS) | Weeks 13-14 | WORK-202 |
+| WORK-204 | RDF Serialization (RDFLib) | Weeks 15-16 | WORK-202, WORK-203 |
+
+---
+
+## WORK-201: Event Store
+
+**Status**: PENDING
+**Duration**: Weeks 9-10
+**Artifacts**: Event store port, SQLite adapter, CloudEvents compliance
+**Dependencies**: Phase 1
+
+### Sub-task 201.1: Event Store Port
+
+**Files**: `src/domain/ports/event_store.py`
+**Tests**: `tests/unit/domain/ports/test_event_store.py`
+
+- [ ] Define `IEventStore` ABC
+  - [ ] `append(event: DomainEvent) -> None`
+  - [ ] `append_batch(events: list[DomainEvent]) -> None`
+  - [ ] `get_events_for_aggregate(aggregate_id: str) -> list[DomainEvent]`
+  - [ ] `get_events_by_type(event_type: str) -> list[DomainEvent]`
+  - [ ] `get_events_since(timestamp: datetime) -> list[DomainEvent]`
+  - [ ] `get_all_events(limit: int, offset: int) -> list[DomainEvent]`
+
+### Sub-task 201.2: CloudEvents Envelope
+
+**Files**: `src/domain/events/cloud_events.py`
+**Tests**: `tests/unit/domain/events/test_cloud_events.py`
+
+- [ ] Implement CloudEvents 1.0 compliant envelope
+  - [ ] `specversion: "1.0"`
+  - [ ] `type: str` (event class name)
+  - [ ] `source: str` (Jerry URI)
+  - [ ] `id: str` (UUID)
+  - [ ] `time: datetime` (ISO 8601)
+  - [ ] `data: dict` (event payload)
+  - [ ] Jerry extensions: `x-jerry-correlation-id`, `x-jerry-causation-id`
+
+### Sub-task 201.3: SQLite Event Store Adapter
+
+**Files**: `src/infrastructure/event_store/sqlite_event_store.py`
+**Tests**: `tests/integration/event_store/test_sqlite_event_store.py`
+
+- [ ] Implement `SQLiteEventStore`
+  - [ ] Append-only semantics
+  - [ ] Indexed queries by aggregate_id, type, time
+  - [ ] Optimistic concurrency with version checking
+  - [ ] Migration: `migrations/002_event_store.sql`
+
+### Sub-task 201.4: Event Store Contract Tests
+
+**Files**: `tests/contract/event_store/`
+
+- [ ] Contract test suite for all adapters
+- [ ] Work Tracker event integration tests
+
+---
+
+## WORK-202: Graph Store (NetworkX)
+
+**Status**: PENDING
+**Duration**: Weeks 11-12
+**Artifacts**: Graph store port, NetworkX adapter, projector
+**Dependencies**: WORK-201
+
+### Sub-task 202.1: Graph Store Port
+
+**Files**: `src/domain/ports/graph_store.py`
+**Tests**: `tests/unit/domain/ports/test_graph_store.py`
+
+- [ ] Define `IGraphStore` ABC
+  - [ ] `add_vertex(id: str, properties: dict) -> None`
+  - [ ] `add_edge(from_id: str, to_id: str, edge_type: str, properties: dict) -> None`
+  - [ ] `get_vertex(id: str) -> dict | None`
+  - [ ] `get_edges(id: str, direction: str) -> list[Edge]`
+  - [ ] `traverse(start_id: str, max_depth: int) -> list[str]`
+  - [ ] `path_between(from_id: str, to_id: str) -> list[str] | None`
+  - [ ] `remove_vertex(id: str) -> bool`
+  - [ ] `remove_edge(from_id: str, to_id: str, edge_type: str) -> bool`
+
+### Sub-task 202.2: NetworkX Adapter
+
+**Files**: `src/infrastructure/graph/networkx_graph_store.py`
+**Tests**: `tests/integration/graph/test_networkx_graph_store.py`
+
+- [ ] Implement `NetworkXGraphStore`
+  - [ ] Vertex CRUD operations
+  - [ ] Edge CRUD operations
+  - [ ] BFS/DFS traversal
+  - [ ] Shortest path
+  - [ ] Graph persistence (JSON/pickle)
+
+### Sub-task 202.3: Graph Projector
+
+**Files**: `src/application/event_handlers/graph_projector.py`
+**Tests**: `tests/integration/application/test_graph_projector.py`
+
+- [ ] Project domain events to graph vertices/edges
+  - [ ] `TaskCreated` → Task vertex
+  - [ ] `SubTaskCreated` → SubTask vertex + edge to Task
+  - [ ] `TaskCompleted` → Update vertex status
+
+### Sub-task 202.4: Supernode Prevention
+
+**Files**: `src/domain/validators/`
+**Tests**: `tests/unit/domain/validators/`
+
+- [ ] Edge count validator (alert at 100, warn at 500)
+- [ ] Configurable limits
+
+---
+
+## WORK-203: Semantic Index (FAISS)
+
+**Status**: PENDING
+**Duration**: Weeks 13-14
+**Artifacts**: Semantic index port, FAISS adapter, embedding provider
+**Dependencies**: WORK-202
+
+### Sub-task 203.1: Semantic Index Port
+
+**Files**: `src/domain/ports/semantic_index.py`
+**Tests**: `tests/unit/domain/ports/test_semantic_index.py`
+
+- [ ] Define `ISemanticIndex` ABC
+  - [ ] `add_embedding(id: str, vector: list[float], metadata: dict) -> None`
+  - [ ] `search_similar(vector: list[float], k: int, threshold: float) -> list[SearchResult]`
+  - [ ] `get_embedding(id: str) -> list[float] | None`
+  - [ ] `remove_embedding(id: str) -> bool`
+  - [ ] `update_embedding(id: str, vector: list[float]) -> None`
+
+### Sub-task 203.2: Embedding Provider Port
+
+**Files**: `src/domain/ports/embedding_provider.py`
+**Tests**: `tests/unit/domain/ports/test_embedding_provider.py`
+
+- [ ] Define `IEmbeddingProvider` ABC
+  - [ ] `embed_text(text: str) -> list[float]`
+  - [ ] `embed_batch(texts: list[str]) -> list[list[float]]`
+  - [ ] `dimension: int` property
+
+### Sub-task 203.3: FAISS Adapter
+
+**Files**: `src/infrastructure/search/faiss_semantic_index.py`
+**Tests**: `tests/integration/search/test_faiss_semantic_index.py`
+
+- [ ] Implement `FAISSSemanticIndex`
+  - [ ] Index initialization (Flat, IVF)
+  - [ ] Embedding CRUD
+  - [ ] kNN search with threshold
+  - [ ] Index persistence
+
+### Sub-task 203.4: Simple Embedding Provider
+
+**Files**: `src/infrastructure/search/tfidf_embedding_provider.py`
+**Tests**: `tests/unit/infrastructure/search/test_tfidf_provider.py`
+
+- [ ] TF-IDF based provider for testing
+  - [ ] Deterministic embeddings
+  - [ ] Swappable for production embeddings
+
+---
+
+## WORK-204: RDF Serialization (RDFLib)
+
+**Status**: PENDING
+**Duration**: Weeks 15-16
+**Artifacts**: RDF serializer port, RDFLib adapter, SPARQL support
+**Dependencies**: WORK-202, WORK-203
+
+### Sub-task 204.1: RDF Serializer Port
+
+**Files**: `src/domain/ports/rdf_serializer.py`
+**Tests**: `tests/unit/domain/ports/test_rdf_serializer.py`
+
+- [ ] Define `IRDFSerializer` ABC
+  - [ ] `serialize_entity(entity) -> list[Triple]`
+  - [ ] `serialize_graph(entities) -> Graph`
+  - [ ] `deserialize(triples) -> list[Entity]`
+  - [ ] `export(graph, format: str, path: str) -> None`
+  - [ ] `import_file(path: str) -> Graph`
+
+### Sub-task 204.2: Jerry Ontology
+
+**Files**: `src/domain/ontology/jerry.ttl`
+**Tests**: `tests/unit/domain/ontology/test_jerry_ontology.py`
+
+- [ ] Define Jerry ontology in Turtle format
+  - [ ] Task class
+  - [ ] SubTask class
+  - [ ] Status enum
+  - [ ] Relationships (hasSubTask, belongsTo, etc.)
+
+### Sub-task 204.3: RDFLib Adapter
+
+**Files**: `src/infrastructure/rdf/rdflib_serializer.py`
+**Tests**: `tests/integration/rdf/test_rdflib_serializer.py`
+
+- [ ] Implement `RDFLibSerializer`
+  - [ ] Entity to triples
+  - [ ] Graph building
+  - [ ] Export formats: Turtle, JSON-LD, N-Triples
+  - [ ] Import and parsing
+
+### Sub-task 204.4: SPARQL Query Support
+
+**Files**: `src/infrastructure/rdf/sparql_executor.py`
+**Tests**: `tests/integration/rdf/test_sparql_executor.py`
+
+- [ ] SPARQL query execution
+  - [ ] SELECT queries
+  - [ ] ASK queries
+  - [ ] CONSTRUCT queries
+  - [ ] Security constraints (timeout, depth limit)
+
+### Sub-task 204.5: Phase 2 Gate
+
+- [ ] All unit tests pass (95%+ coverage)
+- [ ] All integration tests pass
+- [ ] All contract tests pass
+- [ ] Event Store append < 10ms p95
+- [ ] Graph traversal < 50ms p95
+- [ ] Semantic search < 100ms p95
+- [ ] RDF export < 1s for 1000 entities
+- [ ] No memory leaks in stress test
+
+---
+
+## Estimated Test Counts
+
+| Category | Count |
+|----------|-------|
+| Unit tests | ~120 |
+| Integration tests | ~80 |
+| Contract tests | ~30 |
+| System tests | ~20 |
+| **Total** | **~250** |
+
+---
+
+*Phase 2 plan created 2026-01-09*

--- a/docs/archive/projects-archive/plans/worktracker/03-wt-km-integration.md
+++ b/docs/archive/projects-archive/plans/worktracker/03-wt-km-integration.md
@@ -1,0 +1,298 @@
+# Phase 3: Knowledge Management Integration (Weeks 17-24)
+
+> **Goal**: Implement KM domain entities and connect to Work Tracker through events.
+> **Reference**: [Index](00-wt-index.md) | [Unified Design](../../design/work-034-e-003-unified-design.md)
+
+**Status**: PENDING
+**Duration**: Weeks 17-24
+**WORK Items**: WORK-301 to WORK-304
+**Dependencies**: Phase 2 complete
+
+---
+
+## Phase 3 Overview
+
+| WORK Item | Name | Duration | Dependencies |
+|-----------|------|----------|--------------|
+| WORK-301 | KM Domain Layer | Weeks 17-18 | Phase 2 |
+| WORK-302 | KM Repository Layer | Weeks 19-20 | WORK-301 |
+| WORK-303 | KM CQRS Implementation | Weeks 21-22 | WORK-301, WORK-302 |
+| WORK-304 | KM Interface Layer | Weeks 23-24 | WORK-303 |
+
+---
+
+## WORK-301: KM Domain Layer
+
+**Status**: PENDING
+**Duration**: Weeks 17-18
+**Artifacts**: KM entities, value objects, events
+**Dependencies**: Phase 2
+
+### Sub-task 301.1: KM Value Objects
+
+**Files**: `src/domain/value_objects/knowledge/`
+**Tests**: `tests/unit/domain/value_objects/knowledge/`
+
+- [ ] `KnowledgeId` value object
+  - [ ] Format: PAT-NNN (patterns), LES-NNN (lessons), ASM-NNN (assumptions)
+  - [ ] Type inference from prefix
+
+- [ ] `Evidence` value object
+  - [ ] `evidence_type: EvidenceType`
+  - [ ] `source: JerryUri`
+  - [ ] `confidence: float` (0.0-1.0)
+  - [ ] `timestamp: datetime`
+
+- [ ] `EvidenceType` enum
+  - [ ] TASK_COMPLETION
+  - [ ] USER_FEEDBACK
+  - [ ] PATTERN_MATCH
+  - [ ] SYSTEM_INFERENCE
+
+- [ ] `Confidence` value object
+  - [ ] Range validation
+  - [ ] `combine()` for aggregation
+  - [ ] Decay over time
+
+### Sub-task 301.2: KnowledgeItem Aggregate
+
+**Files**: `src/domain/aggregates/knowledge_item.py`
+**Tests**: `tests/unit/domain/aggregates/test_knowledge_item.py`
+
+- [ ] `KnowledgeItem` aggregate root
+  - [ ] `id: KnowledgeId`
+  - [ ] `content: str`
+  - [ ] `item_type: KnowledgeType` (PATTERN, LESSON, ASSUMPTION)
+  - [ ] `evidence: list[Evidence]`
+  - [ ] `tags: frozenset[Tag]`
+  - [ ] `confidence: Confidence` (calculated from evidence)
+  - [ ] `links: frozenset[KnowledgeId]`
+
+- [ ] Type-specific behavior
+  - [ ] Pattern: requires `example_count > 0`
+  - [ ] Lesson: requires `outcome` (POSITIVE, NEGATIVE, NEUTRAL)
+  - [ ] Assumption: requires `validation_status`
+
+- [ ] Evidence management
+  - [ ] `add_evidence(evidence)` → recalculates confidence
+  - [ ] `get_evidence()` → sorted by timestamp
+  - [ ] Evidence expiration policy
+
+- [ ] Knowledge linking
+  - [ ] `link_to(other_id, relationship)`
+  - [ ] Circular link detection
+  - [ ] Relationship types: REFERENCES, CONTRADICTS, SUPPORTS, EXTENDS
+
+### Sub-task 301.3: KM Domain Events
+
+**Files**: `src/domain/events/knowledge.py`
+**Tests**: `tests/unit/domain/events/test_knowledge_events.py`
+
+- [ ] `KnowledgeItemCreated`
+- [ ] `KnowledgeItemUpdated`
+- [ ] `EvidenceAdded`
+- [ ] `ConfidenceChanged`
+- [ ] `KnowledgeLinked`
+- [ ] `KnowledgeArchived`
+
+- [ ] Cross-domain events
+  - [ ] `TaskCompletedTriggersAAR`
+  - [ ] `PatternSuggested`
+  - [ ] `LessonExtracted`
+  - [ ] `AssumptionValidated`
+
+### Sub-task 301.4: KM Architecture Tests
+
+**Files**: `tests/architecture/test_km_architecture.py`
+
+- [ ] Domain layer isolation
+- [ ] WT→KM communication via events only
+- [ ] Shared kernel for value objects only
+
+---
+
+## WORK-302: KM Repository Layer
+
+**Status**: PENDING
+**Duration**: Weeks 19-20
+**Artifacts**: KM repository port, SQLite adapter
+**Dependencies**: WORK-301
+
+### Sub-task 302.1: KM Repository Port
+
+**Files**: `src/domain/ports/knowledge_repository.py`
+**Tests**: `tests/unit/domain/ports/test_knowledge_repository.py`
+
+- [ ] Define `IKnowledgeRepository` ABC
+  - [ ] `get(id: KnowledgeId) -> KnowledgeItem | None`
+  - [ ] `save(item: KnowledgeItem) -> None`
+  - [ ] `delete(id: KnowledgeId) -> bool`
+  - [ ] `list_by_type(item_type: KnowledgeType) -> list[KnowledgeItem]`
+  - [ ] `list_by_tag(tag: Tag) -> list[KnowledgeItem]`
+  - [ ] `search_by_content(query: str) -> list[KnowledgeItem]`
+  - [ ] `get_related(id: KnowledgeId) -> list[KnowledgeItem]`
+
+### Sub-task 302.2: SQLite KM Repository
+
+**Files**: `src/infrastructure/persistence/sqlite_knowledge_repo.py`
+**Tests**: `tests/integration/persistence/test_sqlite_knowledge_repo.py`
+
+- [ ] Schema migration: `migrations/003_knowledge_schema.sql`
+  - [ ] `knowledge_items` table
+  - [ ] `knowledge_evidence` table
+  - [ ] `knowledge_tags` junction
+  - [ ] `knowledge_links` table
+  - [ ] FTS5 index on content
+
+- [ ] Full-text search implementation
+- [ ] Link traversal queries
+
+### Sub-task 302.3: KM Repository Contracts
+
+**Files**: `tests/contract/persistence/test_knowledge_repo_contract.py`
+
+- [ ] All port methods
+- [ ] Cross-repository integrity (WT ↔ KM via JerryUri)
+
+---
+
+## WORK-303: KM CQRS Implementation
+
+**Status**: PENDING
+**Duration**: Weeks 21-22
+**Artifacts**: KM commands, queries, handlers, AAR flow
+**Dependencies**: WORK-301, WORK-302
+
+### Sub-task 303.1: KM Commands
+
+**Files**: `src/application/commands/km/`
+**Tests**: `tests/unit/application/commands/km/`
+
+- [ ] `CreateKnowledgeItemCommand`
+- [ ] `UpdateKnowledgeItemCommand`
+- [ ] `AddEvidenceCommand`
+- [ ] `LinkKnowledgeCommand`
+- [ ] `ArchiveKnowledgeCommand`
+
+### Sub-task 303.2: KM Command Handlers
+
+**Files**: `src/application/handlers/commands/km/`
+**Tests**: `tests/unit/application/handlers/km/`
+
+- [ ] Create handler
+- [ ] Update handler
+- [ ] Add evidence handler (recalculates confidence)
+- [ ] Link handler (validates both exist)
+- [ ] Archive handler
+
+### Sub-task 303.3: KM Queries & Handlers
+
+**Files**: `src/application/queries/km/`, `src/application/handlers/queries/km/`
+**Tests**: `tests/unit/application/queries/km/`
+
+- [ ] `GetKnowledgeItemQuery`
+- [ ] `ListKnowledgeItemsQuery` (with filters)
+- [ ] `SearchKnowledgeQuery`
+- [ ] `GetRelatedKnowledgeQuery`
+- [ ] `GetKnowledgeGraphQuery`
+
+### Sub-task 303.4: After Action Review (AAR) Flow
+
+**Files**: `src/application/event_handlers/aar_handler.py`
+**Tests**: `tests/integration/application/test_aar_flow.py`
+
+- [ ] `AARTriggerHandler`
+  - [ ] TaskCompleted → AAR prompt
+  - [ ] PhaseCompleted → Summary prompt
+  - [ ] Configurable delay
+  - [ ] Opt-out support
+
+- [ ] `CaptureAARCommand`
+  - [ ] Creates KnowledgeItems from AAR input
+  - [ ] Links to source task
+  - [ ] Evidence from task completion
+
+- [ ] `SkipAARCommand` / `DeferAARCommand`
+  - [ ] Track skip reasons (analytics)
+  - [ ] Defer scheduling
+
+### Sub-task 303.5: Cross-Domain Event Handlers
+
+**Files**: `src/application/event_handlers/cross_domain/`
+**Tests**: `tests/integration/application/test_cross_domain_handlers.py`
+
+- [ ] WT→KM handlers
+  - [ ] TaskCompleted → AARPrompt
+  - [ ] PatternDetected → PatternSuggestion
+
+- [ ] KM→WT handlers
+  - [ ] PatternMatched → TaskSuggestion
+  - [ ] LessonRelevant → TaskAnnotation
+
+---
+
+## WORK-304: KM Interface Layer
+
+**Status**: PENDING
+**Duration**: Weeks 23-24
+**Artifacts**: KM CLI, SKILL.md, BDD tests
+**Dependencies**: WORK-303
+
+### Sub-task 304.1: KM CLI
+
+**Files**: `src/interface/cli/km_cli.py`
+**Tests**: `tests/e2e/cli/test_km_cli.py`
+
+- [ ] `km --help`
+- [ ] `km create --type pattern "content"`
+- [ ] `km list --type lesson`
+- [ ] `km show <id>`
+- [ ] `km search "query"`
+- [ ] `km link <id1> <id2> --rel references`
+- [ ] `km aar capture --task <id> --lesson "text"`
+- [ ] `km aar pending`
+- [ ] `km aar skip <task_id> --reason`
+- [ ] `km export --format turtle --output file.ttl`
+
+### Sub-task 304.2: KM SKILL.md
+
+**Files**: `skills/km/SKILL.md`
+
+- [ ] Natural language patterns for KM operations
+- [ ] AAR capture patterns
+- [ ] Search patterns
+- [ ] Integration with WT skill
+
+### Sub-task 304.3: KM BDD Tests
+
+**Files**: `tests/bdd/km/`
+
+- [ ] `features/knowledge.feature`
+- [ ] `features/aar.feature`
+- [ ] Step definitions (REAL implementations)
+
+### Sub-task 304.4: Phase 3 Gate
+
+- [ ] All tests pass (95%+ coverage)
+- [ ] All BDD scenarios pass
+- [ ] AAR capture < 200ms p95
+- [ ] Knowledge search < 100ms p95
+- [ ] Cross-domain events < 50ms propagation
+- [ ] AAR adoption tracking in place
+
+---
+
+## Estimated Test Counts
+
+| Category | Count |
+|----------|-------|
+| Unit tests | ~150 |
+| Integration tests | ~80 |
+| Contract tests | ~20 |
+| BDD scenarios | ~30 |
+| E2E tests | ~20 |
+| **Total** | **~300** |
+
+---
+
+*Phase 3 plan created 2026-01-09*

--- a/docs/archive/projects-archive/plans/worktracker/04-wt-advanced-features.md
+++ b/docs/archive/projects-archive/plans/worktracker/04-wt-advanced-features.md
@@ -1,0 +1,337 @@
+# Phase 4: Advanced Features (Weeks 25-32)
+
+> **Goal**: Implement HybridRAG, pattern discovery, external API, and final documentation.
+> **Reference**: [Index](00-wt-index.md) | [Unified Design](../../design/work-034-e-003-unified-design.md)
+
+**Status**: PENDING
+**Duration**: Weeks 25-32
+**WORK Items**: WORK-401 to WORK-404
+**Dependencies**: Phase 3 complete
+
+---
+
+## Phase 4 Overview
+
+| WORK Item | Name | Duration | Dependencies |
+|-----------|------|----------|--------------|
+| WORK-401 | Cross-Domain Integration | Weeks 25-26 | Phase 3 |
+| WORK-402 | HybridRAG & Pattern Discovery | Weeks 27-28 | WORK-401 |
+| WORK-403 | External API & Export | Weeks 29-30 | WORK-401 |
+| WORK-404 | Documentation & Final Testing | Weeks 31-32 | All |
+
+---
+
+## WORK-401: Cross-Domain Integration
+
+**Status**: PENDING
+**Duration**: Weeks 25-26
+**Artifacts**: Unified graph service, enriched queries, sagas
+**Dependencies**: Phase 3
+
+### Sub-task 401.1: Unified Graph Service
+
+**Files**: `src/application/services/unified_graph_service.py`
+**Tests**: `tests/integration/application/test_unified_graph.py`
+
+- [ ] `UnifiedGraphService`
+  - [ ] `get_task_with_knowledge(task_id)` → Task + related patterns/lessons
+  - [ ] `get_pattern_with_tasks(pattern_id)` → Pattern + source tasks
+  - [ ] `traverse_cross_domain(start_id, depth)` → Mixed WT + KM results
+  - [ ] `path_between_domains(wt_id, km_id)` → Connection path
+
+- [ ] Graph materialization
+  - [ ] `materialize_task_knowledge_links()`
+  - [ ] Incremental updates on event
+  - [ ] Full rebuild option
+
+### Sub-task 401.2: Enriched Query Handlers
+
+**Files**: `src/application/handlers/queries/enriched/`
+**Tests**: `tests/unit/application/handlers/queries/test_enriched_queries.py`
+
+- [ ] `GetTaskWithKnowledgeQuery` → TaskDTO + patterns/lessons
+- [ ] `GetKnowledgeWithContextQuery` → KnowledgeDTO + source tasks + usage
+- [ ] `GetDashboardQuery` → Summary view
+
+### Sub-task 401.3: Event Saga Implementation
+
+**Files**: `src/application/sagas/`
+**Tests**: `tests/integration/application/test_sagas.py`
+
+- [ ] `SagaCoordinator`
+  - [ ] Execute multi-step operations
+  - [ ] Compensation on failure
+  - [ ] Idempotent steps
+  - [ ] Timeout handling
+
+- [ ] `TaskCompletionSaga`
+  - [ ] Complete task → Update graph → Trigger AAR → Create knowledge
+
+- [ ] `PatternDiscoverySaga`
+  - [ ] Detect pattern → Validate → Create item → Link sources
+
+### Sub-task 401.4: Cross-Domain Performance
+
+**Files**: `tests/integration/cross_domain/`
+
+- [ ] Cross-domain query < 150ms p95
+- [ ] Saga completion < 500ms
+- [ ] Graph traversal 3 hops < 100ms
+- [ ] Stress tests (100 concurrent queries)
+
+---
+
+## WORK-402: HybridRAG & Pattern Discovery
+
+**Status**: PENDING
+**Duration**: Weeks 27-28
+**Artifacts**: HybridRAG service, pattern discovery, CLI
+**Dependencies**: WORK-401
+
+### Sub-task 402.1: HybridRAG Service
+
+**Files**: `src/application/services/hybrid_rag.py`
+**Tests**: `tests/integration/application/test_hybrid_rag.py`
+
+- [ ] `HybridRAGService`
+  - [ ] `retrieve(query, k)` → Combined semantic + graph results
+  - [ ] Configurable weights (semantic vs graph)
+  - [ ] Duplicate removal
+  - [ ] Score combination
+
+- [ ] Re-ranking
+  - [ ] Relevance scoring
+  - [ ] Diversity promotion
+  - [ ] Recency boost
+
+- [ ] Context assembly
+  - [ ] Token budget management
+  - [ ] Chunk selection
+  - [ ] Priority ordering
+
+- [ ] Query expansion
+  - [ ] Synonym addition
+  - [ ] Related term discovery
+
+### Sub-task 402.2: Pattern Discovery Service
+
+**Files**: `src/application/services/pattern_discovery.py`
+**Tests**: `tests/integration/application/test_pattern_discovery.py`
+
+- [ ] Similarity detection
+  - [ ] `detect_similar_items(threshold)`
+  - [ ] Cluster formation
+  - [ ] Minimum cluster size
+
+- [ ] Pattern candidate generation
+  - [ ] Template extraction
+  - [ ] Confidence scoring
+  - [ ] Source tracking
+
+- [ ] Pattern validation
+  - [ ] Minimum evidence requirement
+  - [ ] User confirmation flow
+  - [ ] Rejection tracking
+
+- [ ] Pattern evolution
+  - [ ] Merge similar patterns
+  - [ ] Split divergent patterns
+  - [ ] Deprecation
+
+### Sub-task 402.3: HybridRAG CLI
+
+**Files**: `src/interface/cli/rag_cli.py`
+**Tests**: `tests/e2e/cli/test_rag_cli.py`
+
+- [ ] `rag search "query"`
+- [ ] `rag context "query" --budget 2000`
+- [ ] `--semantic-only` / `--graph-only` flags
+- [ ] `pattern discover`
+- [ ] `pattern candidates`
+- [ ] `pattern approve <id>` / `pattern reject <id>`
+
+### Sub-task 402.4: Quality Benchmarks
+
+**Files**: `tests/integration/application/test_rag_benchmarks.py`
+
+- [ ] Precision@k, Recall@k, MRR metrics
+- [ ] Golden dataset
+- [ ] Quality regression detection
+- [ ] Performance: retrieval < 200ms, reranking < 50ms, assembly < 100ms
+
+---
+
+## WORK-403: External API & Export
+
+**Status**: PENDING
+**Duration**: Weeks 29-30
+**Artifacts**: SPARQL endpoint, bulk export/import
+**Dependencies**: WORK-401
+
+### Sub-task 403.1: SPARQL Endpoint
+
+**Files**: `src/interface/api/sparql_endpoint.py`
+**Tests**: `tests/integration/api/test_sparql_endpoint.py`
+
+- [ ] HTTP endpoint
+  - [ ] POST /sparql with query body
+  - [ ] GET /sparql with query param
+  - [ ] Content negotiation
+  - [ ] Rate limiting
+
+- [ ] Query execution
+  - [ ] SELECT → JSON/XML results
+  - [ ] ASK → boolean
+  - [ ] CONSTRUCT → RDF graph
+
+- [ ] Security
+  - [ ] Query whitelist
+  - [ ] Depth limit
+  - [ ] Result size limit
+  - [ ] Audit logging
+
+### Sub-task 403.2: Bulk Export/Import
+
+**Files**: `src/application/commands/export/`, `src/application/commands/import/`
+**Tests**: `tests/integration/application/test_bulk_export_import.py`
+
+- [ ] Bulk export
+  - [ ] Streaming output for large datasets
+  - [ ] Format options (Turtle, JSON-LD, N-Triples)
+  - [ ] Progress callback
+  - [ ] Resume on failure
+
+- [ ] Bulk import
+  - [ ] Validation pass
+  - [ ] Conflict resolution strategies
+  - [ ] Transaction batching
+  - [ ] Error reporting
+  - [ ] Dry-run mode
+
+- [ ] CLI integration
+  - [ ] `export --format turtle --output data.ttl --all`
+  - [ ] `import data.ttl --validate-only`
+  - [ ] Progress bar
+
+### Sub-task 403.3: API Contract Tests
+
+**Files**: `tests/contract/api/`
+
+- [ ] SPARQL endpoint response format
+- [ ] Error codes
+- [ ] Export format validation
+- [ ] Round-trip preservation
+
+---
+
+## WORK-404: Documentation & Final Testing
+
+**Status**: PENDING
+**Duration**: Weeks 31-32
+**Artifacts**: User docs, final tests, release
+**Dependencies**: All previous WORK items
+
+### Sub-task 404.1: User Documentation
+
+**Files**: `docs/user-guide/`
+
+- [ ] `getting-started.md`
+  - [ ] Installation
+  - [ ] First task
+  - [ ] First knowledge item
+  - [ ] AAR walkthrough
+
+- [ ] `work-tracker.md`
+  - [ ] Task lifecycle
+  - [ ] Sub-task management
+  - [ ] CLI reference
+  - [ ] Best practices
+
+- [ ] `knowledge-management.md`
+  - [ ] Patterns, lessons, assumptions
+  - [ ] Evidence and confidence
+  - [ ] Linking knowledge
+  - [ ] AAR workflow
+
+- [ ] `advanced.md`
+  - [ ] HybridRAG queries
+  - [ ] SPARQL endpoint
+  - [ ] Export/import
+  - [ ] Pattern discovery
+
+- [ ] `api/` reference
+  - [ ] CLI commands
+  - [ ] SPARQL reference
+  - [ ] Export formats
+
+### Sub-task 404.2: Final Integration Testing
+
+**Files**: `tests/system/final/`
+
+- [ ] Full workflow tests
+  - [ ] Create plan → phases → tasks → complete → AAR → lessons → patterns → export
+
+- [ ] Regression test suite
+  - [ ] All Phase 1-4 gates re-verified
+  - [ ] No performance degradation
+
+- [ ] Load testing
+  - [ ] 1000 concurrent users
+  - [ ] 10,000 tasks
+  - [ ] 5,000 knowledge items
+  - [ ] Sustained load 1hr
+
+- [ ] Security testing
+  - [ ] Injection tests
+  - [ ] Authorization tests
+  - [ ] OWASP top 10 checks
+
+### Sub-task 404.3: Release Preparation
+
+- [ ] Final gate checklist
+  - [ ] All 1200+ tests pass
+  - [ ] Coverage > 90%
+  - [ ] Performance targets met
+  - [ ] Security review approved
+  - [ ] Documentation reviewed
+
+- [ ] Release artifacts
+  - [ ] CHANGELOG.md
+  - [ ] Version bump
+  - [ ] Migration guide
+  - [ ] Release notes
+
+- [ ] Deployment preparation
+  - [ ] CI/CD pipeline verified
+  - [ ] Rollback procedure
+  - [ ] Monitoring configured
+
+---
+
+## Estimated Test Counts
+
+| Category | Count |
+|----------|-------|
+| Unit tests | ~100 |
+| Integration tests | ~80 |
+| Contract tests | ~20 |
+| System tests | ~40 |
+| Load tests | ~10 |
+| Security tests | ~20 |
+| **Total** | **~270** |
+
+---
+
+## Grand Total Test Counts (All Phases)
+
+| Phase | Tests |
+|-------|-------|
+| Phase 1 | ~430 |
+| Phase 2 | ~250 |
+| Phase 3 | ~300 |
+| Phase 4 | ~270 |
+| **Total** | **~1,250** |
+
+---
+
+*Phase 4 plan created 2026-01-09*

--- a/docs/archive/projects-archive/proposals/PS_EXPORT_DOMAIN_ALIGNMENT.md
+++ b/docs/archive/projects-archive/proposals/PS_EXPORT_DOMAIN_ALIGNMENT.md
@@ -1,0 +1,712 @@
+# Proposal: PS-EXPORT-SPECIFICATION and Domain Model Alignment
+
+> **Proposal ID:** PROP-001
+> **Status:** REVISED (v1.2)
+> **Created:** 2026-01-08
+> **Revised:** 2026-01-08
+> **Author:** Claude (Session claude/create-code-plugin-skill-MG1nh)
+
+---
+
+## Executive Summary
+
+This proposal recommends enhancing PS-EXPORT-SPECIFICATION v2.1 to align with Jerry's planned Domain Model properties. The alignment ensures:
+
+1. **Consistency** - Same property patterns across PS entities and Domain entities
+2. **Serialization** - Unified JSON + TOON export for all entities
+3. **Graph Readiness** - Both PS and Domain entities map to Vertex/Edge model
+4. **Provenance** - Common audit trail patterns (IAuditable: created_on, updated_on, created_by, updated_by)
+5. **Extensibility** - Metadata dictionary and tags for future needs
+6. **Unified Identity** - Jerry URI scheme for all resources (see SPEC-001)
+
+**Recommendation:** Adopt a unified **Entity Base Specification** that both PS-EXPORT and Domain Model inherit from.
+
+**Related Specifications:**
+- **SPEC-001:** Jerry URI Scheme (`docs/specifications/JERRY_URI_SPECIFICATION.md`)
+
+---
+
+## I. Current State Analysis
+
+### A. PS-EXPORT-SPECIFICATION v2.1 Common Properties
+
+> **ADDRESSED (AN: feedback):**
+> - Added `created_by`, `updated_by` (IAuditable pattern)
+> - Added `hash_algorithm` property
+> - Added `version` property (Date+Hash composite)
+> - Defined slug max length (75 characters, per SEO best practices)
+> - Clarified ID as strongly-typed object (JerryId)
+
+| Property | Format | Description | Constraint |
+|----------|--------|-------------|------------|
+| `id` | `JerryId` object | Strongly typed identifier | Required, immutable |
+| `uri` | `JerryUri` | Full resource URI (SPEC-001) | Computed from id |
+| `slug` | `kebab-case` | URL-safe identifier | ≤75 chars (SEO optimal) |
+| `name` | Free text | Human-readable display name | ≤80 chars |
+| `short_description` | Free text | Brief summary | ≤200 chars |
+| `long_description` | Markdown | Detailed content | Unlimited |
+| `created_on` | ISO 8601 | Creation timestamp | Required |
+| `updated_on` | ISO 8601 | Last modification | Required |
+| `created_by` | String | User/system that created | Required (IAuditable) |
+| `updated_by` | String | User/system that last modified | Required (IAuditable) |
+| `session_id` | String | Session provenance | Required |
+| `content_hash` | Hex (16 chars) | Content hash for change detection | Required |
+| `hash_algorithm` | String | Algorithm used (e.g., "sha256") | Required |
+| `version` | String | Composite version (timestamp+hash) | Required |
+
+**Citations:**
+- IAuditable pattern: [Clean DDD lessons: audit metadata](https://medium.com/unil-ci-software-engineering/clean-ddd-lessons-audit-metadata-for-domain-entities-5935a5c6db5b)
+- Slug length: [Backlinko SEO URL Best Practices](https://backlinko.com/hub/seo/url-slug) - Average top-10 URL is 66 chars; ≤75 recommended
+
+### B. Planned Domain Model Properties (from PLAN.md)
+
+**Task Entity:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `TaskId` (JerryId) | Strongly typed identifier object |
+| `title` | `str` | Task name |
+| `description` | `str` | Task details |
+| `status` | `TaskStatus` | State machine |
+| `created_at` | `datetime` | Creation timestamp |
+| `updated_at` | `datetime` | Last update |
+| `created_by` | `str` | Creator (IAuditable) |
+| `updated_by` | `str` | Last modifier (IAuditable) |
+| `subtask_ids` | `List[SubtaskId]` | Child references |
+| `metadata` | `Dict[str, str]` | Extensibility |
+| `tags` | `List[str]` | Categorization |
+
+**Phase Entity:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `PhaseId` (JerryId) | Strongly typed identifier object |
+| `name` | `str` | Phase name |
+| `status` | `PhaseStatus` | State machine |
+| `task_ids` | `List[TaskId]` | Child references |
+| `metadata` | `Dict[str, str]` | Extensibility |
+| `tags` | `List[str]` | Categorization |
+
+### C. Identified Gaps (UPDATED)
+
+> **ADDRESSED (AN: feedback):**
+> - Added Metadata dictionary for extensibility
+> - Added Tags array for categorization/filtering
+> - Clarified relationship representation (see Section IV.B)
+
+| Gap | PS-EXPORT | Domain Model | Resolution |
+|-----|-----------|--------------|------------|
+| ID Format | Prefix-based (c-001) | Strongly typed (TaskId) | JerryId object with prefix+sequence+uuid |
+| Session Tracking | `session_id` | Not planned | Add to Domain |
+| Hash | Content hash | Not planned | Add to Domain with algorithm indicator |
+| Hash Algorithm | Not specified | Not planned | Add `hash_algorithm` property |
+| Version | Not specified | Not planned | Add composite version (timestamp+hash) |
+| Slug | URL-safe | Not planned | Add to Domain (max 75 chars) |
+| Status | Entity-specific | State machine | PS adopts state machine |
+| References | KB refs (kb:type:id) | ID references | Unify reference format |
+| Metadata | Not present | Not planned | Add `Dict[str, str]` for extensibility |
+| Tags | Not present | Not planned | Add `List[str]` for categorization |
+| Relationships | Implicit | Implicit | Explicit Edge entities (Section IV.B) |
+| IAuditable | Partial | Partial | Full IAuditable interface |
+
+---
+
+## II. Proposed Unified Entity Base
+
+### A. IAuditable Interface (Prior Art)
+
+Following DDD best practices for audit metadata:
+
+```python
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
+
+class IAuditable(ABC):
+    """
+    Interface for entities requiring audit trail.
+
+    Prior Art:
+    - Clean DDD: Audit metadata for domain entities (UNIL Engineering)
+    - EF Core: IAuditableEntity pattern
+    - DDD Aggregate Root: Audit information in base class
+
+    Citation: https://medium.com/unil-ci-software-engineering/clean-ddd-lessons-audit-metadata-for-domain-entities-5935a5c6db5b
+    """
+
+    @property
+    @abstractmethod
+    def created_on(self) -> datetime:
+        """When the entity was created."""
+        ...
+
+    @property
+    @abstractmethod
+    def updated_on(self) -> datetime:
+        """When the entity was last modified."""
+        ...
+
+    @property
+    @abstractmethod
+    def created_by(self) -> str:
+        """User or system that created the entity."""
+        ...
+
+    @property
+    @abstractmethod
+    def updated_by(self) -> str:
+        """User or system that last modified the entity."""
+        ...
+```
+
+### B. IVersioned Interface
+
+```python
+class IVersioned(ABC):
+    """
+    Interface for versioned entities with optimistic concurrency support.
+
+    Version format: "{ISO8601_timestamp}_{content_hash[:8]}"
+    Example: "2026-01-08T10:30:00Z_a1b2c3d4"
+    """
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Composite version for optimistic concurrency."""
+        ...
+
+    @property
+    @abstractmethod
+    def content_hash(self) -> str:
+        """Hash of content fields (16 hex chars)."""
+        ...
+
+    @property
+    @abstractmethod
+    def hash_algorithm(self) -> str:
+        """Algorithm used for hashing (e.g., 'sha256')."""
+        ...
+```
+
+### C. Entity Base Specification (REVISED)
+
+All entities (PS and Domain) should inherit these common properties:
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Any, Optional
+
+@dataclass
+class EntityBase(IAuditable, IVersioned):
+    """
+    Common base for all Jerry entities.
+    Aligns PS-EXPORT-SPECIFICATION with Domain Model.
+
+    Implements:
+    - IAuditable: Full audit trail (created_on/by, updated_on/by)
+    - IVersioned: Optimistic concurrency (version, content_hash, hash_algorithm)
+    - Graph-ready: Vertex label and properties
+    - Extensible: Metadata dictionary and tags
+    """
+
+    # Identity (Graph-Ready) - ID is a strongly-typed object
+    id: "JerryId"                 # Strongly typed, extends VertexId
+    uri: "JerryUri" = field(init=False)  # Full resource URI (SPEC-001), computed from id
+    slug: str                     # URL-safe identifier (≤75 chars, kebab-case)
+
+    # Display
+    name: str                     # Human-readable (≤80 chars)
+    short_description: str        # Brief summary (≤200 chars, 1 sentence)
+    long_description: str         # Detailed content (Markdown, unlimited)
+
+    # Provenance (IAuditable)
+    created_on: datetime          # Creation timestamp (ISO 8601)
+    updated_on: datetime          # Last modification (ISO 8601)
+    created_by: str               # User/system that created ("user:alice" or "system:scheduler")
+    updated_by: str               # User/system that last modified
+    session_id: str               # Session that created/modified
+
+    # Change Detection (IVersioned)
+    content_hash: str             # SHA-256 of content fields (16 hex chars)
+    hash_algorithm: str = "sha256"  # Algorithm used for hashing
+    version: str = ""             # Computed: "{timestamp}_{hash[:8]}"
+
+    # Graph Properties
+    label: str = ""               # Vertex label for graph storage
+    properties: Dict[str, Any] = field(default_factory=dict)  # Additional vertex properties
+
+    # Extensibility (NEW - per feedback)
+    metadata: Dict[str, str] = field(default_factory=dict)  # Key-value for extensibility
+    tags: List[str] = field(default_factory=list)           # Categorization and filtering
+
+    def __post_init__(self):
+        """Compute derived fields."""
+        if not self.version:
+            self.version = self._compute_version()
+        # Compute URI from ID (see SPEC-001: Jerry URI Specification)
+        object.__setattr__(self, 'uri', self._compute_uri())
+
+    def _compute_version(self) -> str:
+        """
+        Compute composite version from timestamp and hash.
+        Format: "{ISO8601}_{hash[:8]}"
+        """
+        timestamp = self.updated_on.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return f"{timestamp}_{self.content_hash[:8]}"
+
+    def _compute_uri(self) -> "JerryUri":
+        """
+        Compute Jerry URI from entity ID.
+        See SPEC-001: Jerry URI Specification.
+
+        Format: jer:<partition>:<domain>:<entity_type>:<id>[+<version>]
+        Example: jer:jer:work-tracker:task:task-042+a1b2c3d4
+        """
+        from src.domain.identity import JerryUri  # Deferred import
+        return JerryUri.for_entity(
+            domain=self.label.lower().replace(" ", "-"),  # e.g., "work-tracker"
+            entity_type=self.id.prefix,                   # e.g., "task"
+            entity_id=self.id.full_form,                  # e.g., "task-042"
+            version=self.content_hash[:8] if self.content_hash else None
+        )
+
+    @classmethod
+    def compute_content_hash(cls, content_fields: Dict[str, Any], algorithm: str = "sha256") -> str:
+        """
+        Compute content hash for change detection.
+
+        Args:
+            content_fields: Fields to include in hash
+            algorithm: Hash algorithm ('sha256', 'sha1', 'md5')
+
+        Returns:
+            16-character hexadecimal hash
+        """
+        import hashlib
+        import json
+
+        serialized = json.dumps(content_fields, sort_keys=True, default=str)
+        hasher = hashlib.new(algorithm)
+        hasher.update(serialized.encode('utf-8'))
+        return hasher.hexdigest()[:16]
+```
+
+### D. JerryId - Strongly Typed Identity Object
+
+> **ADDRESSED (AN: feedback):** ID is an object in DDD aggregates
+
+```python
+@dataclass(frozen=True)
+class JerryId:
+    """
+    Unified strongly-typed identity for all Jerry entities.
+
+    Extends VertexId for graph compatibility while providing:
+    - Type safety (TaskId, PhaseId, etc.)
+    - Human-readable short form (c-001, task-042)
+    - Globally unique full form (c-001-a1b2c3d4)
+
+    DDD Prior Art:
+    - Evans, E. (2003). Domain-Driven Design. Value Objects chapter.
+    - Vernon, V. (2013). Implementing DDD. Identity chapter.
+    """
+    prefix: str       # Entity type prefix (task, phase, c, e, etc.)
+    sequence: int     # Sequence number within prefix
+    uuid: str = ""    # Optional UUID for global uniqueness
+
+    def __post_init__(self):
+        """Validate ID components."""
+        if not self.prefix:
+            raise ValueError("ID prefix is required")
+        if self.sequence < 0:
+            raise ValueError("ID sequence must be non-negative")
+
+    @property
+    def short_form(self) -> str:
+        """Return prefix-sequence format (c-001, task-042)."""
+        return f"{self.prefix}-{self.sequence:03d}"
+
+    @property
+    def full_form(self) -> str:
+        """Return full unique identifier."""
+        if self.uuid:
+            return f"{self.prefix}-{self.sequence:03d}-{self.uuid[:8]}"
+        return self.short_form
+
+    @property
+    def vertex_id(self) -> str:
+        """Return ID suitable for graph vertex."""
+        return self.full_form
+
+    def __str__(self) -> str:
+        return self.short_form
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, JerryId):
+            return self.prefix == other.prefix and self.sequence == other.sequence
+        return False
+
+    def __hash__(self) -> int:
+        return hash((self.prefix, self.sequence))
+
+
+# Type-specific aliases for compile-time safety
+class TaskId(JerryId):
+    """Strongly typed Task identifier."""
+    def __init__(self, sequence: int, uuid: str = ""):
+        super().__init__(prefix="task", sequence=sequence, uuid=uuid)
+
+class PhaseId(JerryId):
+    """Strongly typed Phase identifier."""
+    def __init__(self, sequence: int, uuid: str = ""):
+        super().__init__(prefix="phase", sequence=sequence, uuid=uuid)
+
+class PlanId(JerryId):
+    """Strongly typed Plan identifier."""
+    def __init__(self, sequence: int, uuid: str = ""):
+        super().__init__(prefix="plan", sequence=sequence, uuid=uuid)
+
+class ConstraintId(JerryId):
+    """Strongly typed Constraint identifier."""
+    def __init__(self, sequence: int, uuid: str = ""):
+        super().__init__(prefix="c", sequence=sequence, uuid=uuid)
+```
+
+---
+
+## III. Schema Alignment
+
+### A. Unified YAML Frontmatter (REVISED)
+
+```yaml
+---
+# Entity Identity (JerryId object, JerryUri - SPEC-001)
+id: "{prefix}-{sequence}"      # Short form: "task-042", "c-001"
+id_full: "{prefix}-{sequence}-{uuid[:8]}"  # Full form (optional)
+uri: "jer:jer:{domain}:{type}:{id}+{version}"  # Jerry URI (SPEC-001)
+slug: "{kebab-case-slug}"      # Max 75 chars
+label: "{vertex-label}"        # e.g., "Task", "Constraint"
+
+# Display
+name: "{human-readable-name}"  # Max 80 chars
+short_description: "{one-sentence}"  # Max 200 chars
+
+# Status (State Machine)
+status: "{DRAFT|ACTIVE|BLOCKED|COMPLETED|CLOSED}"
+
+# Provenance (IAuditable)
+created_on: "{ISO-8601}T{HH:MM:SS}Z"
+updated_on: "{ISO-8601}T{HH:MM:SS}Z"
+created_by: "{user:username|system:name}"
+updated_by: "{user:username|system:name}"
+session_id: "{session-identifier}"
+
+# Change Detection (IVersioned)
+content_hash: "{16-hex-chars}"
+hash_algorithm: "sha256"
+version: "{ISO-8601}_{hash[:8]}"
+
+# Extensibility
+metadata:
+  key1: "value1"
+  key2: "value2"
+tags:
+  - tag1
+  - tag2
+
+# Type-Specific Properties
+# (varies by entity type)
+---
+```
+
+### B. JSON/TOON Export Schema (REVISED)
+
+```json
+{
+  "$schema": "https://jerry.dev/schemas/entity-base-v1.2.json",
+  "$id": "jer:jer:jerry:schemas/EntityBase+1.2.0",
+  "type": "object",
+  "required": ["id", "uri", "slug", "label", "name", "status", "created_on", "created_by", "content_hash", "hash_algorithm", "version"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z]+-[0-9]{3,}(-[a-f0-9]{8})?$",
+      "description": "JerryId in short or full form"
+    },
+    "uri": {
+      "type": "string",
+      "pattern": "^jer(\\+[0-9]+)?:[a-z]+:([a-z0-9-]+:)?[a-z0-9-]+:.+(\\+[a-z0-9.-]+)?$",
+      "description": "Jerry URI per SPEC-001 (jer:<partition>:<domain>:<resource>[+version])"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 75,
+      "description": "URL-safe identifier (max 75 chars per SEO best practice)"
+    },
+    "label": {
+      "type": "string",
+      "enum": ["Task", "Phase", "Plan", "Constraint", "Question", "Exploration", "Experience", "Wisdom"]
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 80
+    },
+    "short_description": {
+      "type": "string",
+      "maxLength": 200
+    },
+    "long_description": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "created_on": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_on": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": "string",
+      "pattern": "^(user|system):.+$",
+      "description": "Format: 'user:username' or 'system:name'"
+    },
+    "updated_by": {
+      "type": "string",
+      "pattern": "^(user|system):.+$"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{16}$"
+    },
+    "hash_algorithm": {
+      "type": "string",
+      "enum": ["sha256", "sha1", "md5"],
+      "default": "sha256"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z_[a-f0-9]{8}$",
+      "description": "Composite version: timestamp_hash[:8]"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Key-value pairs for extensibility"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Tags for categorization and filtering"
+    }
+  }
+}
+```
+
+---
+
+## IV. Graph Model Alignment
+
+### A. Vertex Mapping (Entities)
+
+| Entity Type | Vertex Label | ID Pattern | Key Properties |
+|-------------|--------------|------------|----------------|
+| Task | `Task` | `task-NNN` | status, priority, metadata, tags |
+| Phase | `Phase` | `phase-NNN` | status, progress, metadata, tags |
+| Plan | `Plan` | `plan-NNN` | status, metadata, tags |
+| Constraint | `Constraint` | `c-NNN` | status, priority, category, metadata, tags |
+| Question | `Question` | `q-NNN` | status, answer, metadata, tags |
+| Exploration | `Exploration` | `e-NNN` | entry_type, severity, metadata, tags |
+| Experience | `Experience` | `exp-NNN` | applicability, metadata, tags |
+| Wisdom | `Wisdom` | `wiz-NNN` | confidence, metadata, tags |
+
+### B. Edge Types (Relationships)
+
+> **ADDRESSED (AN: feedback):** Relationships are represented as **Edge entities** in the graph model, NOT as NodeProperty or EdgeProperty. This follows TinkerPop's property graph model where:
+> - **Vertices** = Entities (Task, Phase, Constraint, etc.)
+> - **Edges** = Relationships with their own properties
+> - **VertexProperty** = Properties on vertices (with meta-properties for audit)
+> - **EdgeProperty** = Simple key-value on edges (no meta-properties)
+
+```python
+@dataclass
+class Edge:
+    """
+    Relationship between two vertices in the graph model.
+
+    Edges are first-class entities with:
+    - Unique ID
+    - Label (relationship type)
+    - Direction (from → to)
+    - Properties (edge metadata)
+
+    TinkerPop Prior Art: Edge is an Element with id, label, properties
+    """
+    id: str                       # Unique edge identifier
+    label: str                    # Relationship type (e.g., "CONTAINS")
+    from_vertex_id: str           # Source vertex ID
+    to_vertex_id: str             # Target vertex ID
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    # Audit (optional for edges)
+    created_on: Optional[datetime] = None
+    created_by: Optional[str] = None
+```
+
+**Defined Edge Types:**
+
+| Edge Label | From | To | Properties | Semantics |
+|------------|------|----|-----------|-----------|
+| `CONTAINS` | Phase | Task | position: int | Phase contains Task at position |
+| `CONTAINS` | Plan | Phase | position: int | Plan contains Phase at position |
+| `HAS_SUBTASK` | Task | Task | position: int | Parent → Child subtask |
+| `REFERENCES` | Constraint | Knowledge | kb_type: str | Constraint references KB item |
+| `VALIDATES` | Exploration | Constraint | evidence: str | Exploration validates Constraint |
+| `SYNTHESIZES` | Wisdom | Experience | weight: float | Wisdom synthesized from Experience |
+| `EMITS` | Entity | CloudEvent | timestamp: datetime | Entity emitted event |
+| `BLOCKS` | Task | Task | reason: str | Task A blocks Task B |
+| `DEPENDS_ON` | Task | Task | type: str | Task A depends on Task B |
+| `TAGGED_WITH` | Entity | Tag | - | Entity has tag (optional pattern) |
+
+**Relationship Query Examples (Gremlin):**
+```groovy
+// Find all tasks in a phase
+g.V('phase-001').out('CONTAINS').hasLabel('Task')
+
+// Find blocked tasks
+g.V().hasLabel('Task').as('blocked').in('BLOCKS').as('blocker').select('blocked', 'blocker')
+
+// Find wisdom synthesized from experiences
+g.V('wiz-001').out('SYNTHESIZES').hasLabel('Experience')
+```
+
+---
+
+## V. Implementation Plan (REVISED)
+
+### A. Phase 1: Update PS-EXPORT-SPECIFICATION (v2.2)
+
+1. Add IAuditable fields (`created_by`, `updated_by`)
+2. Add IVersioned fields (`version`, `hash_algorithm`)
+3. Add extensibility fields (`metadata`, `tags`)
+4. Update slug constraint (max 75 chars)
+5. Add graph-alignment section
+6. Add relationship documentation (Edge types)
+
+### B. Phase 2: Domain Model Base Class
+
+1. Create `IAuditable` interface
+2. Create `IVersioned` interface
+3. Create `EntityBase` dataclass with all common properties
+4. Create `JerryId` strongly-typed identity object
+5. Create type-specific IDs (TaskId, PhaseId, etc.)
+6. Create `Edge` dataclass for relationships
+7. Task, Phase, Plan extend EntityBase
+8. Implement `content_hash` computation with algorithm selector
+9. Implement `version` computation
+10. Add `slug` generation utility with length validation
+
+### C. Phase 3: Serialization Adapters
+
+1. JSON adapter produces unified schema v1.1
+2. TOON adapter produces tabular format
+3. Both handle EntityBase properties automatically
+4. Both handle metadata and tags
+
+### D. Phase 4: Migration
+
+1. Update existing PS entities to unified format
+2. Add IAuditable fields to historical data (default: "system:migration")
+3. Add IVersioned fields to historical data
+4. Generate `content_hash` for all entities
+5. Add empty metadata and tags where missing
+
+---
+
+## VI. Benefits (UPDATED)
+
+| Benefit | Description |
+|---------|-------------|
+| **Consistency** | Single property model for all entities |
+| **Serialization** | One serializer handles PS and Domain entities |
+| **Graph Ready** | All entities map to vertices; relationships to edges |
+| **Audit Trail** | Full IAuditable interface (who created/modified, when) |
+| **Change Detection** | Content hash + algorithm enables verification |
+| **Optimistic Concurrency** | Composite version enables conflict detection |
+| **URL Safety** | Slug enables clean API routes (max 75 chars for SEO) |
+| **Extensibility** | Metadata dictionary for future needs |
+| **Categorization** | Tags array for filtering and organization |
+| **Type Safety** | JerryId as object prevents ID type mixing |
+
+---
+
+## VII. Risks & Mitigations (UPDATED)
+
+| Risk | Mitigation |
+|------|------------|
+| Migration complexity | Phase incrementally; maintain backward compatibility |
+| ID format changes | Support both short (c-001) and full (c-001-abc123) forms |
+| Breaking existing PS exports | Version bumps (v2.2, v3.0) with migration guides |
+| Hash algorithm changes | Store algorithm name; support multiple algorithms |
+| Metadata abuse | Document intended use; consider size limits |
+| Tag explosion | Consider tag registry; normalize case |
+
+---
+
+## VIII. Decision
+
+**Recommendation:** APPROVE (v1.1)
+
+This revised alignment provides:
+- Unified data model for Jerry with full audit trail
+- Clean serialization path (JSON + TOON)
+- Graph database migration readiness with explicit Edge types
+- Consistent audit/provenance tracking (IAuditable)
+- Optimistic concurrency support (IVersioned)
+- Extensibility for future needs (metadata, tags)
+- Type-safe identity objects (JerryId)
+
+**Next Steps:**
+1. Review and approve proposal v1.1
+2. Update PS-EXPORT-SPECIFICATION to v2.2
+3. Implement IAuditable and IVersioned interfaces
+4. Implement EntityBase and JerryId in Domain Layer
+5. Implement Edge dataclass for relationships
+6. Update serialization adapters
+
+---
+
+## IX. References
+
+### Specification Documents
+- PS-EXPORT-SPECIFICATION v2.1: `docs/knowledge/exemplars/templates/PS-EXPORT-SPECIFICATION.md`
+- Domain Model Plan: `docs/PLAN.md`
+- Graph Data Model: `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md`
+- TOON Format: `docs/research/TOON_FORMAT_ANALYSIS.md`
+
+### Industry Sources
+- [Clean DDD: Audit metadata for domain entities](https://medium.com/unil-ci-software-engineering/clean-ddd-lessons-audit-metadata-for-domain-entities-5935a5c6db5b) - IAuditable pattern
+- [EF Core Auditing](https://dev.to/rickystam/ef-core-how-to-implement-basic-auditing-on-your-entities-1mbm) - Automatic audit field population
+- [DDD Aggregate Root](https://dev.to/leelanagaramya/updating-audit-columns-in-aggregate-roots-and-child-entities-with-ef-core-and-ddd-481b) - Audit in base class
+- [Backlinko SEO URL Best Practices](https://backlinko.com/hub/seo/url-slug) - Slug length recommendation (≤75 chars)
+- [Evans, E. (2003). Domain-Driven Design](https://www.oreilly.com/library/view/domain-driven-design/9780321125217/) - Value Objects, Identity
+- [Vernon, V. (2013). Implementing DDD](https://www.oreilly.com/library/view/implementing-domain-driven-design/9780133039900/) - Aggregate Root, Identity
+
+---
+
+## X. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial proposal |
+| 1.1 | 2026-01-08 | Addressed user feedback (AN:): IAuditable, hash_algorithm, version, slug limits, metadata, tags, Edge relationships |
+| 1.2 | 2026-01-08 | Integrated Jerry URI scheme (SPEC-001): Added `uri` property to EntityBase, updated JSON schema to v1.2 with `$id` using Jerry URI |

--- a/docs/archive/projects-archive/research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/AGENT_BEHAVIOR_ENFORCEMENT_ANALYSIS.md
@@ -1,0 +1,1272 @@
+# Agent Behavior Enforcement Analysis
+## Research on LLM Agent Guardrails and Behavioral Governance
+
+**Author**: Claude Code (Research Agent)
+**Date**: 2026-01-08
+**Version**: 1.0
+**Status**: Final
+
+---
+
+## Executive Summary
+
+This document presents comprehensive research on industry best practices for LLM agent behavior enforcement and guardrails, synthesizing findings from leading AI research organizations (Anthropic, OpenAI, Google DeepMind), academic institutions, and industry practitioners.
+
+### Key Findings
+
+1. **Multi-Layered Defense is Standard**: All major AI organizations employ layered approaches combining Constitutional AI, runtime enforcement, prompt engineering, and human oversight rather than relying on single enforcement mechanisms.
+
+2. **Soft Enforcement Dominates**: The industry strongly favors advisory and soft enforcement (prompts, system messages, self-critique) over hard blocks, with progressive escalation only when necessary.
+
+3. **Constitutional AI as Foundation**: Anthropic's Constitutional AI framework represents a paradigm shift toward self-supervised alignment using principles rather than extensive human labeling.
+
+4. **Runtime Safety is Emerging**: New research frameworks (Pro2Guard, AgentSpec, GaaS) focus on proactive runtime enforcement using probabilistic risk assessment and graduated interventions.
+
+5. **No Silver Bullet**: Industry consensus is clear: "no single intervention is the 'solution' for safe and beneficial AI" (OpenAI). Effective governance requires orchestrated, multi-tier systems.
+
+### Recommended Approach for Jerry Framework
+
+Jerry should implement a **4-tier progressive enforcement model**:
+- **Tier 1 (Advisory)**: System prompts, skill instructions, constitutional principles
+- **Tier 2 (Soft)**: Self-monitoring, reflection prompts, warning messages
+- **Tier 3 (Medium)**: Tool restrictions, action logging, escalation triggers
+- **Tier 4 (Hard)**: Runtime blocks, forced escalation, session termination (rare, only for critical risks)
+
+This aligns with Jerry's philosophy of "behavior and workflow guardrails" while maintaining agent autonomy and learning capacity.
+
+---
+
+## Research Methodology (5W1H)
+
+### Who
+Research conducted by Claude Code agent, synthesizing work from:
+- **Anthropic** (Constitutional AI, Claude system prompts)
+- **OpenAI** (Model Spec, RLHF, safety frameworks)
+- **Google DeepMind** (Frontier Safety Framework, AGI safety research)
+- **Academic researchers** (MIT, Stanford, UK AI Security Institute)
+- **Industry practitioners** (Datadog, Guardrails AI, LangChain)
+
+### What
+Investigation of LLM agent behavior enforcement mechanisms, focusing on:
+- Advisory/soft enforcement patterns
+- Constitutional AI implementation
+- Prompt engineering for guardrails
+- Self-monitoring and reflection capabilities
+- Multi-tier progressive enforcement systems
+
+### When
+- Research conducted: 2026-01-08
+- Sources reviewed: 2024-2025 publications
+- Focus on contemporary best practices (2025 standards)
+
+### Where
+Web search of:
+- Official documentation (Anthropic, OpenAI, Google DeepMind)
+- Academic preprint servers (arXiv)
+- Industry blogs and technical reports
+- Open-source framework documentation
+
+### Why
+To inform Jerry Framework's agent governance layer design, ensuring:
+- Alignment with industry best practices
+- Evidence-based architectural decisions
+- Balance between safety and autonomy
+- Scalable, maintainable governance patterns
+
+### How
+1. Conducted targeted web searches on 5 key topic areas
+2. Analyzed findings from 50+ authoritative sources
+3. Synthesized patterns and recommendations
+4. Mapped findings to Jerry's architectural context
+5. Generated actionable recommendations
+
+---
+
+## Key Findings from Authoritative Sources
+
+### 1. Anthropic: Constitutional AI Framework
+
+**Source**: [Constitutional AI: Harmlessness from AI Feedback](https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback)
+
+#### Core Concept
+Constitutional AI (CAI) is Anthropic's method for aligning language models using a "constitution" of principles rather than extensive human labeling of harmful outputs. The AI system evaluates its own outputs against these principles, enabling self-supervised alignment.
+
+#### Two-Phase Training Process
+
+**Phase 1: Supervised Learning**
+- Sample from initial model
+- Generate self-critiques based on constitutional principles
+- Generate revisions addressing critiques
+- Finetune original model on revised responses
+
+**Phase 2: Reinforcement Learning**
+- Train via RL using AI-generated feedback (not human feedback)
+- AI chooses more harmless outputs based on constitutional principles
+- Creates Pareto improvement: more helpful AND more harmless
+
+#### Results
+- Constitutional RL outperforms RLHF on both helpfulness and harmlessness
+- Responds appropriately to adversarial inputs without being evasive
+- Enables transparency: principles are easily specified, inspected, and understood
+- Reduces need for humans to view disturbing content during training
+
+#### Constitutional Principles Sources
+Anthropic drew from diverse sources including:
+- Apple's Terms of Service
+- UN Declaration on Human Rights
+- Suggestions from research labs
+- Public input via Collective Constitutional AI (using Polis platform)
+
+**Key Insight**: General principles like "do what's best for humanity" can work with large models, but specific constitutions improve fine-grained control over particular harms. Both general and specific principles have value.
+
+**Relevance to Jerry**: Constitutional AI provides a blueprint for self-governing agents using declarative principles rather than procedural rules.
+
+---
+
+### 2. OpenAI: Model Spec and Deliberative Alignment
+
+**Source**: [Model Spec (2025/12/18)](https://model-spec.openai.com/2025-12-18.html)
+
+#### Model Spec Philosophy
+OpenAI's Model Spec outlines intended behavior for models powering their products. Key principle: models should be "useful, safe, and aligned with the needs of users and developers."
+
+**Core Tenet**: "Humanity should be in control of how AI is used."
+
+#### Layered Safety Approach
+OpenAI explicitly rejects single-intervention approaches:
+> "No single intervention is the 'solution' for safe and beneficial AI."
+
+Instead, they draw from safety-critical fields (aerospace, nuclear power) using multiple layered defenses where all would need to fail simultaneously for a safety incident.
+
+#### Risk Categories
+Three broad categories:
+1. **Misaligned goals**: Assistant pursues wrong objective due to misalignment, misunderstanding, or being misled
+2. **Misuse**: Deliberate use for harmful purposes
+3. **Accidents**: Unintended harmful consequences
+
+#### Deliberative Alignment (2025)
+New approach significantly improving on earlier safety training methods. Released alongside gpt-oss-safeguard, open-weight reasoning models for safety classification.
+
+#### Flexibility with Defaults
+Model Spec specifies guidelines that **can be overridden**, improving predictability while leaving developers flexibility to adapt instructions. This represents soft enforcement philosophy.
+
+**Relevance to Jerry**: The "overridable defaults" pattern is crucial for maintaining agent autonomy while providing strong behavioral guidance.
+
+---
+
+### 3. Google DeepMind: Frontier Safety Framework
+
+**Source**: [Introducing the Frontier Safety Framework](https://deepmind.google/discover/blog/introducing-the-frontier-safety-framework/)
+
+#### Framework Purpose
+Protocols for proactively identifying future AI capabilities that could cause severe harm, focusing on:
+- Exceptional agency
+- Sophisticated cyber capabilities
+- Harmful manipulation (manipulative capabilities changing beliefs/behaviors in high-stakes contexts)
+
+#### Critical Capability Levels (CCLs)
+DeepMind introduced tiered risk assessment using Critical Capability Levels, particularly focused on:
+- Autonomous LLM agents
+- Deceptive alignment risks (AI aware of goal misalignment, deliberately bypassing safety)
+- Amplified oversight (AI helping evaluate its own outputs)
+
+#### Governance Structure
+- **AGI Safety Council (ASC)**: Led by Chief AGI Scientist, analyzes AGI risk
+- **Responsibility and Safety Council**: Co-chaired by COO and Senior Director of Responsibility
+- Evaluation against AI Principles before deployment
+
+#### Four Key Risk Areas
+1. **Misuse**: Deliberate harmful use
+2. **Misalignment**: Pursuing unintended goals
+3. **Accidents**: Unintended harmful consequences
+4. **Structural risks**: Systemic societal impacts
+
+#### Agentic AI Safety Principle
+> "Leverage learnings from safety in agentics, such as the principle of having a human in the loop to check in for consequential actions."
+
+**Relevance to Jerry**: Critical Capability Levels provide a model for graduated risk assessment, and the "human in loop for consequential actions" aligns with Jerry's escalation patterns.
+
+---
+
+### 4. Runtime Enforcement Frameworks: Pro2Guard and AgentSpec
+
+**Source**: [Pro2Guard: Proactive Runtime Enforcement](https://arxiv.org/html/2508.00500v1)
+
+#### Proactive vs Reactive Enforcement
+Traditional guardrails are reactive (detect violations after they occur). Pro2Guard is **proactive**: anticipates future risks before violations.
+
+#### Technical Approach
+1. **State Abstraction**: Abstract agent behaviors into symbolic states
+2. **DTMC Learning**: Learn Discrete-Time Markov Chain from execution traces
+3. **Probabilistic Reachability**: Estimate probability of reaching unsafe states
+4. **Early Intervention**: Trigger interventions before violations occur
+
+#### Enforcement Modes
+- **Warn**: Low-threshold warnings for potential risks
+- **Reflect**: Prompt agent self-assessment and course correction
+- **Block**: High-threshold hard blocks for imminent violations
+
+#### Results
+- Enforces safety early in 93.6% of unsafe tasks (using low thresholds)
+- Configurable modes maintain up to 80.4% task completion
+- Balances safety with availability
+
+#### AgentSpec DSL
+**Source**: [AgentSpec: Customizable Runtime Enforcement](https://arxiv.org/html/2503.18666v1)
+
+Domain-specific language for specifying runtime constraints with:
+- **Triggers**: When to activate rules
+- **Predicates**: Conditions to evaluate
+- **Enforcement mechanisms**: Actions to take
+
+**Relevance to Jerry**: Runtime enforcement frameworks provide technical patterns for implementing graduated interventions at execution time.
+
+---
+
+### 5. Governance-as-a-Service (GaaS) Framework
+
+**Source**: [Governance-as-a-Service: Multi-Agent Framework](https://arxiv.org/abs/2508.18765)
+
+#### Core Innovation
+Modular, policy-driven enforcement layer that:
+- Operates at runtime
+- Doesn't modify internal model logic
+- Doesn't assume agent cooperation
+- Uses declarative rule sets
+
+#### Trust Factor Mechanism
+Scores agents based on:
+- Longitudinal compliance history
+- Severity-aware violation tracking
+- Graduated enforcement based on trust score
+
+#### Intervention Types
+1. **Coercive**: Hard blocks for critical violations
+2. **Normative**: Soft guidance and recommendations
+3. **Adaptive**: Dynamic adjustment based on agent behavior patterns
+
+#### Per-Agent Trust Modulation
+Different agents can have different trust levels, enabling:
+- Proven agents → more autonomy
+- Untrusted agents → tighter constraints
+- Learning agents → graduated privilege escalation
+
+**Relevance to Jerry**: Trust-based graduated enforcement aligns perfectly with Jerry's multi-agent architecture and skill system.
+
+---
+
+### 6. Industry Best Practices: LLM Guardrails
+
+**Source**: [Datadog - LLM Guardrails Best Practices](https://www.datadoghq.com/blog/llm-guardrails-best-practices/)
+
+#### Definition
+Guardrails are validation and control layers around model inputs, tools, and outputs, enforcing policies such as:
+- "No PII"
+- "Always valid JSON"
+- "Never execute arbitrary code"
+
+#### OWASP Top LLM Threats (2025)
+Guardrails address:
+- **LLM01:2025** - Prompt Injection
+- **LLM02:2025** - Sensitive Data Leakage
+- **LLM06:2025** - Excessive Agency
+- **LLM07:2025** - System Prompt Leakage
+
+#### Implementation Patterns
+
+**Input/Output Guards**
+- Input guards: Clean data entering the model
+- Output guards: Ensure responses are safe, structured, compliant
+
+**Interaction-Level Guardrails**
+For agentic systems:
+- Restrict available tools during function calling
+- Cap number of autonomous decisions in task chains
+- Set limits on agent retries or actions
+
+#### Best Practices
+
+1. **Layered Approach**
+   - Combine rule-based and AI-assisted mechanisms
+   - Create boundaries around acceptable inputs and behavior
+   - Enforce security, safety, and compliance
+
+2. **Start Simple, Add Complexity**
+   - Address critical failure modes first
+   - Add complexity incrementally
+   - Integrate red-teaming, monitoring, logging
+
+3. **Treat as Core Components**
+   - Version control for guardrails
+   - Testing and validation
+   - Maintenance and updates
+   - Keep pace with emerging regulations
+
+4. **Balance Speed, Accuracy, Reliability**
+   - Guardrails must be blazing-fast (ultra-low latency)
+   - When applying >5 guards, even 90% accurate guards produce false positives 40% of the time
+   - Use async execution: send guardrails parallel with main LLM call
+
+5. **Use Multiple Specialized Guardrails**
+   - LLM-based guardrails
+   - Rule-based guardrails (regex)
+   - Moderation APIs
+   - Multiple layers create resilient systems
+
+#### Important Limitation
+When using LLMs as guardrails, they have the same vulnerabilities as your base LLM call. Prompt injection can evade both guardrail and main call.
+
+**Relevance to Jerry**: The emphasis on layered, fast, versioned guardrails aligns with Jerry's infrastructure-as-code approach.
+
+---
+
+### 7. Prompt Engineering for Behavioral Guidance
+
+**Source**: [Lakera - Ultimate Guide to Prompt Engineering](https://www.lakera.ai/blog/prompt-engineering-guide)
+
+#### Prompt Engineering as "Soft Skill with Hard Consequences"
+Unlike traditional programming where code controls behavior, prompt engineering works through natural language. The quality of prompts directly affects usefulness, safety, and reliability.
+
+#### Behavioral Control Through Constraints
+> "If the constraints are loose, the model expands into possibility. If the constraints are tight, the model contracts into precision."
+
+Well-designed prompts shrink the space of valid continuations until answers align with product intent.
+
+#### Role-Based Prompts
+Align model's voice and behavior with specific contexts:
+- Legal advisor
+- Data analyst
+- Customer support agent
+
+#### Common Pitfalls
+
+**Monolithic Prompt Syndrome**
+Teams add more instructions → more competing objectives → more latent contradictions → model must guess priorities.
+
+> "The most common symptom of an inexperienced team is the monolithic prompt that grows month by month."
+
+**Assumed Safety**
+> "Teams often assume the model will choose the safest option when in doubt. It won't. Unless constraints forbid shortcuts, the model will resolve ambiguity the way a language model is trained to."
+
+#### Security Considerations
+> "You can often bypass LLM guardrails by simply reframing a question—the line between aligned and adversarial behavior is thinner than most people think."
+
+**Relevance to Jerry**: Skill-based prompt engineering (not monolithic prompts) avoids competing objectives and provides clear behavioral context.
+
+---
+
+### 8. Claude System Prompts and Guardrails
+
+**Source**: [Claude Docs - Keep Claude in Character](https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/keep-claude-in-character)
+
+#### Role Prompting for Consistency
+Anthropic recommends using system prompts to define Claude's role and personality, setting a strong foundation for consistent responses with:
+- Detailed personality information
+- Background context
+- Specific traits or quirks
+
+#### Building Safeguards
+Anthropic's multi-layered approach:
+1. **Pre-deployment testing**: Rigorous testing to verify training under pressure
+2. **Automated systems**: Detect harm and enforce Usage Policy
+3. **Human review**: Oversight for edge cases
+4. **Powered by Claude**: Detection systems use prompted or fine-tuned Claude models
+
+#### Ethical Guardrails Refusal Strategy
+When Claude cannot fulfill requests due to ethical guardrails:
+- **Don't** explain potential negative consequences
+- **Do** offer helpful alternatives if possible
+- **Do** keep refusals concise (1-2 sentences)
+
+#### Claude 4.5 Responsiveness
+Claude Opus 4.5 is MORE responsive to system prompts than previous models. Teams may need to dial back aggressive language to avoid overtriggering.
+
+#### Constitutional AI Integration
+Claude is built on Constitutional AI framework, incorporating a built-in "constitution" of safety rules, unlike models requiring heavy manual filtering.
+
+**Relevance to Jerry**: Claude's own system demonstrates soft enforcement through role prompting and graceful refusals rather than hard blocks.
+
+---
+
+### 9. Self-Learning and Self-Monitoring Agents
+
+**Source**: [Beam AI - Self-Learning AI Agents](https://beam.ai/agentic-insights/self-learning-ai-agents-transforming-automation-with-continuous-improvement)
+
+#### Self-Monitoring Capabilities
+> "Autonomy implies self-monitoring: an agent gauges its battery life or job completion and adapts as needed."
+
+Agents need built-in evaluation mechanisms to assess their own performance.
+
+#### Graph-Based Architecture for Self-Evaluation
+Each node in agent's reasoning flow tracks:
+- Accuracy rates
+- Evaluation scores
+- Performance metrics
+
+Creates detailed performance map guiding optimization.
+
+#### Feedback Mechanisms
+AI systems receive information about results of actions/predictions:
+- **Positive feedback**: Reinforcing correct behavior
+- **Negative feedback**: Correcting errors
+- Essential for guiding system improvement
+
+#### Continuous Performance Tracking
+Essential evaluation protocols:
+- Episode returns
+- Regret analysis
+- Behavior divergence
+- Trust scores
+- Long-term metrics: cost, risk, latency, satisfaction
+
+#### RLHF as Gold Standard
+Reinforcement Learning from Human Feedback remains gold standard for alignment:
+1. Acquire human preference data
+2. Train reward model
+3. Apply policy optimization
+4. LLM internalizes reward model values
+
+**Relevance to Jerry**: Self-monitoring and feedback loops are essential for Jerry's Work Tracker and task management systems.
+
+---
+
+### 10. Multi-Agent Systems and Coordination
+
+**Source**: [Why Multi-Agent LLM Systems Fail](https://www.augmentcode.com/guides/why-multi-agent-llm-systems-fail-and-how-to-fix-them)
+
+#### Failure Rates
+Multi-agent LLM systems fail at rates between **41-86.7%** in production.
+
+#### Root Causes
+- **Specification problems**: 41.77%
+- **Coordination failures**: 36.94%
+- Combined: Nearly 79% of breakdowns
+
+#### Tradeoff: Freedom vs Control
+> "The freedom to define the solution strategy makes it less likely that fine-grained control can be enforced on the behavior of the system."
+
+Effective frameworks must:
+- Establish reasonable constraints
+- Permit autonomy
+- Balance control with flexibility
+
+#### Security Controls for Multi-Agent Systems
+Recommended controls:
+- Input/output policy enforcement
+- Context isolation
+- Instruction hardening
+- Least-privilege tool use
+- Data redaction
+- Rate limiting
+- Moderation
+- Supply-chain & provenance controls
+- Egress filtering
+- Monitoring/auditing
+- Red-teaming
+
+**Relevance to Jerry**: Jerry's agent architecture must address coordination challenges while maintaining clear behavioral boundaries.
+
+---
+
+## Comparison of Enforcement Approaches
+
+### Four-Tier Enforcement Model
+
+Based on industry research, enforcement mechanisms can be categorized into four tiers of increasing restrictiveness:
+
+| Tier | Name | Mechanism | When to Use | Examples | Pros | Cons |
+|------|------|-----------|-------------|----------|------|------|
+| **1** | **Advisory** | System prompts, constitutional principles, role definitions | Default for all agents | Claude's constitution, OpenAI Model Spec, Jerry skills | Maximum autonomy, transparent, self-supervised | Relies on model alignment, can be ignored |
+| **2** | **Soft** | Warnings, reflection prompts, self-monitoring, logging | When patterns suggest potential issues | Pro2Guard "warn" mode, self-critique loops | Maintains agency, enables learning, non-blocking | Requires model capability, may be bypassed |
+| **3** | **Medium** | Tool restrictions, action caps, escalation triggers, trust scoring | When risks are elevated or trust is low | GaaS normative interventions, retry limits, human-in-loop | Balance safety/autonomy, graduated response | Adds complexity, requires monitoring |
+| **4** | **Hard** | Runtime blocks, forced termination, complete denial | Critical safety violations only | Pro2Guard "block" mode, GaaS coercive interventions | Absolute safety guarantee, clear boundaries | Breaks user experience, stops work, last resort |
+
+### Industry Preference Distribution
+
+Based on reviewed sources, the industry emphasis is:
+
+```
+Advisory (Tier 1): ~40% of enforcement effort
+Soft (Tier 2):     ~35% of enforcement effort
+Medium (Tier 3):   ~20% of enforcement effort
+Hard (Tier 4):     ~5% of enforcement effort
+```
+
+**Key Insight**: Industry heavily favors soft approaches (75% Advisory + Soft combined), using hard enforcement sparingly.
+
+---
+
+### Detailed Tier Analysis
+
+#### Tier 1: Advisory Enforcement
+
+**Philosophy**: "Guide through principles, not rules"
+
+**Mechanisms**:
+- Constitutional principles (Anthropic)
+- System prompts and role definitions (OpenAI)
+- Model Spec overridable defaults (OpenAI)
+- Skill instructions (Jerry)
+- Documentation and context (CLAUDE.md)
+
+**Strengths**:
+- Respects agent autonomy
+- Transparent and inspectable
+- Self-supervised (scales with model capability)
+- Low latency (no runtime overhead)
+- Enables creative problem-solving
+
+**Weaknesses**:
+- Depends on model alignment quality
+- Can be ignored or misinterpreted
+- Vulnerable to prompt injection
+- No guarantees of compliance
+
+**Best Practices**:
+- Use clear, specific principles
+- Combine general + specific guidance
+- Version control constitutions
+- Test with adversarial inputs
+- Document rationale for principles
+
+**When to Use**:
+- Default for all agents
+- Well-aligned models
+- Low-risk operations
+- Creative/exploratory tasks
+- When learning is priority
+
+---
+
+#### Tier 2: Soft Enforcement
+
+**Philosophy**: "Nudge and reflect, don't block"
+
+**Mechanisms**:
+- Self-critique and revision (Constitutional AI supervised phase)
+- Warning messages (Pro2Guard warn mode)
+- Reflection prompts ("Before proceeding, consider...")
+- Performance tracking and feedback
+- Logging and observability
+- Trust score notifications
+
+**Strengths**:
+- Maintains forward progress
+- Enables agent learning
+- Provides valuable signal for improvement
+- Non-blocking user experience
+- Graduated response capability
+
+**Weaknesses**:
+- Requires model capability for self-assessment
+- Can be ignored under pressure
+- Adds token overhead
+- May create false sense of safety
+
+**Best Practices**:
+- Design clear reflection prompts
+- Log all warnings for analysis
+- Use warnings to adjust trust scores
+- Provide specific guidance in warnings
+- Escalate after repeated warnings
+
+**When to Use**:
+- First violation of soft guidelines
+- Moderate-risk operations
+- Learning/training scenarios
+- When user education is goal
+- Before escalating to medium/hard
+
+---
+
+#### Tier 3: Medium Enforcement
+
+**Philosophy**: "Constrain actions, not thinking"
+
+**Mechanisms**:
+- Tool restrictions (subset of available functions)
+- Action caps (max retries, max API calls)
+- Escalation triggers (human-in-loop for consequential actions)
+- Trust-based privilege modulation (GaaS)
+- Rate limiting
+- Context isolation
+- Require approvals for specific operations
+
+**Strengths**:
+- Balance safety and autonomy
+- Graduated response to risk
+- Clear boundaries
+- Maintains some agency
+- Enables recovery paths
+
+**Weaknesses**:
+- Adds system complexity
+- Requires monitoring infrastructure
+- May frustrate legitimate use cases
+- Need clear escalation paths
+- Harder to debug
+
+**Best Practices**:
+- Define clear escalation criteria
+- Provide escape hatches (request override)
+- Log all restrictions for analysis
+- Design graceful degradation
+- Communicate restrictions clearly to user
+
+**When to Use**:
+- Elevated risk operations (data deletion, API calls)
+- Low-trust agents
+- After multiple soft warnings
+- When user intent is unclear
+- Production deployments with stakes
+
+---
+
+#### Tier 4: Hard Enforcement
+
+**Philosophy**: "Absolute safety through denial"
+
+**Mechanisms**:
+- Runtime blocks (Pro2Guard block mode)
+- Forced session termination
+- Complete operation denial
+- Coercive interventions (GaaS)
+- Safety shutdowns
+
+**Strengths**:
+- Absolute safety guarantee
+- Clear, unambiguous boundaries
+- Prevents catastrophic failures
+- Simple to implement
+- Easy to audit
+
+**Weaknesses**:
+- Breaks user experience
+- Stops all work
+- No learning opportunity
+- May create false sense of security elsewhere
+- Highest user friction
+
+**Best Practices**:
+- Reserve for critical safety only
+- Provide clear error messages
+- Log all blocks with full context
+- Enable human override with authorization
+- Review blocks regularly for false positives
+
+**When to Use**:
+- Critical safety violations (data exfiltration attempt)
+- Confirmed malicious behavior
+- Legal/compliance hard requirements
+- After medium enforcement failed
+- When no safe alternative exists
+
+---
+
+## Industry Best Practices
+
+### 1. Layered Defense-in-Depth
+
+**Principle**: No single mechanism is sufficient; combine multiple complementary approaches.
+
+**Implementation Pattern**:
+```
+Layer 1: Pre-training alignment (Constitutional AI, RLHF)
+Layer 2: System prompts and role definitions (Advisory)
+Layer 3: Runtime guardrails (Input/output validation)
+Layer 4: Self-monitoring and reflection (Soft enforcement)
+Layer 5: Tool restrictions and caps (Medium enforcement)
+Layer 6: Human oversight for critical actions
+Layer 7: Hard blocks for unacceptable behavior
+```
+
+**Source**: OpenAI, Google DeepMind, Anthropic all emphasize layered approaches.
+
+---
+
+### 2. Start Simple, Add Complexity Incrementally
+
+**Principle**: Address critical failure modes first; add sophistication only when needed.
+
+**Implementation Pattern**:
+1. Identify top 3 critical risks
+2. Implement simple guardrails for those
+3. Monitor and measure effectiveness
+4. Identify next tier of risks
+5. Add guardrails incrementally
+6. Avoid premature optimization
+
+**Source**: Datadog, industry practitioners
+
+---
+
+### 3. Treat Guardrails as Core Infrastructure
+
+**Principle**: Guardrails are not afterthoughts; they're first-class system components.
+
+**Implementation Pattern**:
+- Version control all guardrail rules
+- Automated testing of guardrail behavior
+- CI/CD for guardrail changes
+- Monitoring and alerting
+- Regular review and updates
+- Documentation of rationale
+
+**Source**: Datadog, Anthropic
+
+---
+
+### 4. Optimize for Speed and Low Latency
+
+**Principle**: Slow guardrails break user experience; fast guardrails enable safety.
+
+**Implementation Pattern**:
+- Async execution (parallel to main LLM call)
+- Lightweight rule-based checks first
+- Cache guardrail results when possible
+- Use smaller, faster models for guardrails
+- Minimize sequential blocking
+
+**Mathematical Insight**: With 5 guardrails at 90% accuracy each:
+- False positive rate = 1 - 0.9^5 = 0.41 (41%)
+- Need higher accuracy or smarter composition
+
+**Source**: Datadog, industry practitioners
+
+---
+
+### 5. Use Probabilistic Risk Assessment
+
+**Principle**: Don't wait for violations; anticipate and prevent them.
+
+**Implementation Pattern**:
+- Learn behavior patterns (DTMC models)
+- Estimate probability of reaching unsafe states
+- Intervene based on risk thresholds
+- Configure risk tolerance per context
+- Balance safety with task success
+
+**Source**: Pro2Guard, UK AI Security Institute
+
+---
+
+### 6. Graduated Enforcement Based on Trust
+
+**Principle**: Different agents/users should have different privilege levels based on track record.
+
+**Implementation Pattern**:
+- Track compliance history per agent
+- Calculate trust scores
+- Severity-aware violation weighting
+- Graduated privilege escalation
+- Proven agents → more autonomy
+- Untrusted agents → tighter constraints
+
+**Source**: GaaS framework, IBM research
+
+---
+
+### 7. Self-Monitoring and Continuous Feedback
+
+**Principle**: Agents should evaluate their own performance and adapt.
+
+**Implementation Pattern**:
+- Track performance metrics per task/node
+- Maintain evaluation scores
+- Implement feedback loops
+- Use RLHF or similar approaches
+- Enable self-improvement over time
+
+**Source**: Beam AI, OpenAI, academic research
+
+---
+
+### 8. Human-in-Loop for Consequential Actions
+
+**Principle**: High-stakes decisions require human judgment.
+
+**Implementation Pattern**:
+- Define "consequential actions" clearly
+- Require approval for those actions
+- Provide context for approval decision
+- Enable fast-path approval for trusted users
+- Log all approvals/denials
+
+**Source**: Google DeepMind, OpenAI
+
+---
+
+### 9. Transparency and Inspectability
+
+**Principle**: Users and developers should understand why guardrails trigger.
+
+**Implementation Pattern**:
+- Document all principles and rules
+- Provide clear refusal messages
+- Log full context of violations
+- Enable audit trails
+- Public constitutions (Anthropic model)
+
+**Source**: Anthropic, OpenAI Model Spec
+
+---
+
+### 10. Graceful Degradation and Alternatives
+
+**Principle**: When blocking, offer alternatives; don't just say "no."
+
+**Implementation Pattern**:
+- Suggest safer alternatives
+- Offer partial fulfillment
+- Explain constraints clearly
+- Provide workarounds when possible
+- Keep refusals concise (1-2 sentences)
+
+**Source**: Claude system prompts, Anthropic
+
+---
+
+## Recommendations for Jerry Framework
+
+Based on comprehensive industry research, here are specific recommendations for Jerry's agent governance architecture:
+
+### 1. Implement 4-Tier Progressive Enforcement
+
+**Recommendation**: Adopt the four-tier model (Advisory → Soft → Medium → Hard) with heavy emphasis on Tiers 1-2.
+
+**Implementation**:
+
+```python
+# Conceptual framework
+class EnforcementTier(Enum):
+    ADVISORY = 1   # Constitutional principles, system prompts
+    SOFT = 2       # Warnings, reflection, logging
+    MEDIUM = 3     # Tool restrictions, caps, escalation
+    HARD = 4       # Blocks, termination
+
+class GuardrailPolicy:
+    def __init__(self, tier: EnforcementTier, principle: str):
+        self.tier = tier
+        self.principle = principle
+
+    def enforce(self, context: AgentContext) -> EnforcementResult:
+        # Tier-specific enforcement logic
+        pass
+```
+
+**Distribution Target**:
+- 60% of guardrails: Tier 1 (Advisory)
+- 30% of guardrails: Tier 2 (Soft)
+- 8% of guardrails: Tier 3 (Medium)
+- 2% of guardrails: Tier 4 (Hard)
+
+---
+
+### 2. Create Jerry Constitutional Framework
+
+**Recommendation**: Develop Jerry-specific constitutional principles similar to Anthropic's approach.
+
+**Suggested Constitution Structure**:
+
+```markdown
+# Jerry Framework Constitution
+
+## General Principles
+1. Maximize learning and knowledge accrual
+2. Respect user autonomy and intent
+3. Maintain system integrity and data safety
+4. Prefer transparency over opacity
+5. Enable graceful degradation under constraints
+
+## Domain-Specific Principles
+1. **Problem-Solving**: Never delete context without explicit user confirmation
+2. **Work Tracker**: Persist state before any destructive operation
+3. **Architecture**: Challenge decisions that violate hexagonal boundaries
+4. **Code Generation**: Default to editing existing files over creating new ones
+
+## Operational Principles
+1. Ask for clarification when user intent is ambiguous
+2. Surface risks proactively but don't be paralyzed by them
+3. Escalate to human for consequential actions
+4. Learn from mistakes; update guardrails based on failures
+```
+
+**Location**: `/docs/governance/JERRY_CONSTITUTION.md`
+
+---
+
+### 3. Implement Self-Monitoring for Skills
+
+**Recommendation**: Each skill should track its own performance and compliance.
+
+**Implementation Pattern**:
+
+```python
+class SkillExecution:
+    def __init__(self, skill_name: str):
+        self.skill_name = skill_name
+        self.metrics = PerformanceMetrics()
+        self.violations = []
+
+    def evaluate_performance(self) -> SkillReport:
+        """Self-assessment against skill-specific criteria."""
+        return SkillReport(
+            success_rate=self.metrics.success_rate,
+            avg_quality=self.metrics.avg_quality,
+            compliance_score=self.calculate_compliance(),
+            violations=self.violations
+        )
+
+    def calculate_compliance(self) -> float:
+        """Score based on constitutional adherence."""
+        # Check against Jerry Constitution
+        pass
+```
+
+**Storage**: Work Tracker should maintain skill performance history.
+
+---
+
+### 4. Add Reflection Prompts to Critical Operations
+
+**Recommendation**: Before destructive or consequential operations, prompt agent self-reflection.
+
+**Example Reflection Prompts**:
+
+```markdown
+## File Deletion Reflection
+Before deleting files, consider:
+1. Is this deletion explicitly requested by the user?
+2. Could this impact other parts of the system?
+3. Is there a backup or recovery path?
+4. Should this require user confirmation?
+
+If ANY answer is uncertain, escalate to user for approval.
+```
+
+**Implementation**: Add reflection sections to `.claude/rules/` files for specific operations.
+
+---
+
+### 5. Implement Trust-Based Agent Scoring
+
+**Recommendation**: Adopt GaaS-style trust factor mechanism for different agent types.
+
+**Agent Trust Tiers**:
+
+| Agent Type | Initial Trust | Privilege Level | Restrictions |
+|------------|---------------|-----------------|--------------|
+| Orchestrator (Opus 4.5) | High | Full access | None (trusted conductor) |
+| QA Engineer | Medium-High | Read-all, Write-test | Cannot modify src/ |
+| Code Generator | Medium | Read-src, Write-src | Requires review for critical files |
+| Research Agent | Medium | Read-all, Write-docs | Cannot modify src/ or .claude/ |
+| Untrusted/New | Low | Minimal | Heavy oversight |
+
+**Scoring Mechanism**:
+- Start with base trust score
+- Increment for successful completions
+- Decrement for violations (weighted by severity)
+- Escalate enforcement tier as trust decreases
+
+---
+
+### 6. Create Runtime Safety Checker
+
+**Recommendation**: Implement lightweight runtime safety checks inspired by Pro2Guard.
+
+**Check Categories**:
+
+1. **Data Safety**
+   - No accidental PII commits
+   - No credential exposure
+   - Validate file paths before deletion
+
+2. **System Integrity**
+   - No modification of core framework without plan
+   - No breaking dependency changes
+   - Validate graph schema changes
+
+3. **Workflow Integrity**
+   - Persist Work Tracker state before destructive ops
+   - Validate PLAN completion before archiving
+   - Ensure tests pass before commits (when applicable)
+
+**Implementation**: `/scripts/runtime_safety_check.py`
+
+---
+
+### 7. Enhance Skill Instructions with Constitutional Guidance
+
+**Recommendation**: Each skill's SKILL.md should include constitutional principles relevant to that domain.
+
+**Template Addition**:
+
+```markdown
+## Constitutional Guidance
+
+This skill operates under the following principles:
+
+1. **Primary Principle**: [Domain-specific core principle]
+2. **Safety Constraints**: [What this skill must never do]
+3. **Escalation Triggers**: [When to escalate to user/orchestrator]
+4. **Self-Monitoring**: [How this skill evaluates its performance]
+
+## Violation Response
+
+If this skill violates principles:
+- [Tier 1 violation] → Log and continue with correction
+- [Tier 2 violation] → Warn user, request guidance
+- [Tier 3 violation] → Escalate to orchestrator
+- [Tier 4 violation] → Hard stop, require human override
+```
+
+---
+
+### 8. Implement Async Guardrail Execution
+
+**Recommendation**: For performance, run non-blocking guardrails in parallel with main operations.
+
+**Pattern**:
+
+```python
+import asyncio
+
+async def execute_with_guardrails(operation, guardrails):
+    # Run operation and guardrails concurrently
+    results = await asyncio.gather(
+        operation(),
+        *[g.check() for g in guardrails if not g.blocking]
+    )
+
+    operation_result = results[0]
+    guardrail_results = results[1:]
+
+    # Check if any guardrails triggered
+    if any(r.violated for r in guardrail_results):
+        # Handle violations based on tier
+        return handle_violations(operation_result, guardrail_results)
+
+    return operation_result
+```
+
+---
+
+### 9. Create Guardrail Testing Framework
+
+**Recommendation**: Test guardrails like any other code.
+
+**Test Categories**:
+
+1. **Effectiveness Tests**: Do guardrails catch violations?
+2. **False Positive Tests**: Do guardrails block legitimate actions?
+3. **Performance Tests**: Are guardrails fast enough?
+4. **Adversarial Tests**: Can guardrails be bypassed?
+5. **Integration Tests**: Do layered guardrails work together?
+
+**Location**: `/tests/guardrails/`
+
+---
+
+### 10. Establish Guardrail Governance Process
+
+**Recommendation**: Treat guardrails as evolving, not static.
+
+**Process**:
+
+1. **Quarterly Review**: Evaluate all guardrails
+   - Effectiveness metrics
+   - False positive rates
+   - Coverage gaps
+
+2. **Incident-Driven Updates**: When guardrails fail
+   - Root cause analysis
+   - Update principles/rules
+   - Add test cases
+
+3. **Version Control**: Track changes
+   - Semantic versioning for constitution
+   - Changelog for rule updates
+   - Migration guides for breaking changes
+
+4. **Community Input**: For open-source Jerry
+   - Public constitution (like Anthropic)
+   - Community feedback on principles
+   - Collective constitutional process (like Collective CAI)
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundation (Immediate)
+
+1. Create `/docs/governance/JERRY_CONSTITUTION.md`
+2. Add constitutional guidance to existing skills
+3. Implement basic logging for policy violations
+4. Define enforcement tiers in documentation
+
+**Deliverables**:
+- Jerry Constitution v1.0
+- Updated skill templates
+- Violation logging infrastructure
+
+---
+
+### Phase 2: Soft Enforcement (Near-term)
+
+1. Add reflection prompts to critical operations
+2. Implement warning system for policy violations
+3. Create skill self-monitoring infrastructure
+4. Develop trust scoring mechanism
+
+**Deliverables**:
+- Reflection prompt library
+- Warning/alert system
+- Skill performance tracking
+- Basic trust scoring
+
+---
+
+### Phase 3: Runtime Safety (Medium-term)
+
+1. Implement runtime safety checker
+2. Add async guardrail execution
+3. Create guardrail testing framework
+4. Develop escalation workflows
+
+**Deliverables**:
+- Runtime safety checker
+- Async guardrail engine
+- Comprehensive test suite
+- Escalation protocols
+
+---
+
+### Phase 4: Advanced Governance (Long-term)
+
+1. Implement probabilistic risk assessment
+2. Add machine learning for trust scoring
+3. Develop collective constitutional process
+4. Create guardrail analytics dashboard
+
+**Deliverables**:
+- ML-based risk prediction
+- Adaptive trust system
+- Public governance process
+- Analytics and insights
+
+---
+
+## Conclusion
+
+The research reveals clear industry consensus:
+
+1. **Multi-layered approaches work**: No single mechanism is sufficient
+2. **Soft enforcement dominates**: 75% of effort should be advisory + soft
+3. **Self-supervision is the future**: Constitutional AI and self-monitoring scale better than manual oversight
+4. **Speed matters**: Slow guardrails break user experience
+5. **Transparency builds trust**: Public constitutions and clear principles
+
+For Jerry Framework, this translates to:
+- Implement 4-tier progressive enforcement with heavy emphasis on Tiers 1-2
+- Create Jerry-specific constitutional principles
+- Enable self-monitoring for skills
+- Use trust-based graduated enforcement
+- Design for speed and low latency
+- Maintain transparency through public governance
+
+The goal is not to create a rigid, restrictive system, but to establish **guardrails that guide without constraining, that protect without paralyzing, and that enable agents to learn and improve over time.**
+
+---
+
+## Citations and References
+
+### Primary Sources
+
+#### Anthropic
+1. [Constitutional AI: Harmlessness from AI Feedback](https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback)
+2. [Claude's Constitution](https://www.anthropic.com/news/claudes-constitution)
+3. [Collective Constitutional AI](https://www.anthropic.com/research/collective-constitutional-ai-aligning-a-language-model-with-public-input)
+4. [Building Safeguards for Claude](https://www.anthropic.com/news/building-safeguards-for-claude)
+5. [Keep Claude in Character](https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/keep-claude-in-character)
+6. [Specific versus General Principles for Constitutional AI](https://www.anthropic.com/research/specific-versus-general-principles-for-constitutional-ai)
+
+#### OpenAI
+7. [Model Spec (2025/12/18)](https://model-spec.openai.com/2025-12-18.html)
+8. [How We Think About Safety and Alignment](https://openai.com/safety/how-we-think-about-safety-alignment/)
+9. [OpenAI Safety Practices](https://openai.com/index/openai-safety-update/)
+10. [How to Implement LLM Guardrails](https://cookbook.openai.com/examples/how_to_use_guardrails)
+11. [Practices for Governing Agentic AI Systems](https://cdn.openai.com/papers/practices-for-governing-agentic-ai-systems.pdf)
+12. [Self-Evolving Agents](https://cookbook.openai.com/examples/partners/self_evolving_agents/autonomous_agent_retraining)
+
+#### Google DeepMind
+13. [Introducing the Frontier Safety Framework](https://deepmind.google/discover/blog/introducing-the-frontier-safety-framework/)
+14. [Taking a Responsible Path to AGI](https://deepmind.google/blog/taking-a-responsible-path-to-agi/)
+15. [An Approach to Technical AGI Safety](https://www.alignmentforum.org/posts/3ki4mt4BA6eTx56Tc/google-deepmind-an-approach-to-technical-agi-safety-and)
+16. [Gemma Scope 2](https://deepmind.google/blog/gemma-scope-2-helping-the-ai-safety-community-deepen-understanding-of-complex-language-model-behavior/)
+
+### Academic Papers
+
+17. [Constitutional AI: Harmlessness from AI Feedback (arXiv)](https://arxiv.org/abs/2212.08073)
+18. [Pro2Guard: Proactive Runtime Enforcement](https://arxiv.org/abs/2508.00500)
+19. [AgentSpec: Customizable Runtime Enforcement](https://arxiv.org/html/2503.18666v1)
+20. [Governance-as-a-Service Framework](https://arxiv.org/abs/2508.18765)
+21. [Decentralized Governance of AI Agents](https://arxiv.org/html/2412.17114v3)
+22. [Regulatory Potential of User Interfaces for AI Agent Governance](https://arxiv.org/html/2512.00742v1)
+
+### Industry Resources
+
+23. [Datadog - LLM Guardrails Best Practices](https://www.datadoghq.com/blog/llm-guardrails-best-practices/)
+24. [Leanware - LLM Guardrails Strategies 2025](https://www.leanware.co/insights/llm-guardrails)
+25. [Medium - Ultimate Guide to Guardrails in GenAI](https://medium.com/@ajayverma23/the-ultimate-guide-to-guardrails-in-genai-securing-and-standardizing-llm-applications-1502c90fdc72)
+26. [Lakera - Prompt Engineering Guide](https://www.lakera.ai/blog/prompt-engineering-guide)
+27. [Guardrails AI GitHub](https://github.com/guardrails-ai/guardrails)
+28. [Palo Alto - Comparing LLM Guardrails](https://unit42.paloaltonetworks.com/comparing-llm-guardrails-across-genai-platforms/)
+
+### Frameworks and Tools
+
+29. [LangChain Guardrails Documentation](https://docs.langchain.com/oss/python/langchain/guardrails)
+30. [Constitutional AI Website](https://constitutional.ai/)
+31. [Beam AI - Self-Learning AI Agents](https://beam.ai/agentic-insights/self-learning-ai-agents-transforming-automation-with-continuous-improvement)
+
+### Research Organizations
+
+32. [Future of Life Institute - 2025 AI Safety Index](https://futureoflife.org/ai-safety-index-summer-2025/)
+33. [IBM - AI Agent Learning](https://www.ibm.com/think/topics/ai-agent-learning)
+34. [Toloka - Constitutional AI Explained](https://toloka.ai/blog/constitutional-ai-explained/)
+
+### Security and Compliance
+
+35. [IAPP - AI Governance in the Agentic Era](https://iapp.org/resources/article/ai-governance-in-the-agentic-era)
+36. [Martin Fowler - Agentic AI and Security](https://martinfowler.com/articles/agentic-ai-security.html)
+37. [Trend Micro - Securing LLM Services](https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/unveiling-ai-agent-vulnerabilities-part-v-securing-llm-services)
+38. [Oligo Security - LLM Security in 2025](https://www.oligo.security/academy/llm-security-in-2025-risks-examples-and-best-practices)
+
+### Community and Practitioners
+
+39. [Why Multi-Agent LLM Systems Fail](https://www.augmentcode.com/guides/why-multi-agent-llm-systems-fail-and-how-to-fix-them)
+40. [Top 12 Papers on Agentic AI Governance](https://oliverpatel.substack.com/p/top-12-papers-on-agentic-ai-governance)
+41. [Surfing the Guardrails: 7 Prompting Patterns](https://natesnewsletter.substack.com/p/surfing-the-guardrails-7-production)
+42. [PromptHub - Claude 4 System Prompt Analysis](https://www.prompthub.us/blog/an-analysis-of-the-claude-4-system-prompt)
+
+---
+
+**Document Metadata**
+- Total sources reviewed: 50+
+- Primary sources: 16
+- Academic papers: 6
+- Industry resources: 12
+- Frameworks/tools: 3
+- Research organizations: 3
+- Security/compliance: 4
+- Community sources: 6
+
+**Research Quality Indicators**
+- Authoritative sources: ✓ (Anthropic, OpenAI, DeepMind)
+- Peer-reviewed research: ✓ (arXiv preprints)
+- Industry practitioners: ✓ (Datadog, LangChain, etc.)
+- Current/recent: ✓ (2024-2025 publications)
+- Diverse perspectives: ✓ (Academic, industry, open-source)
+
+---
+
+*End of Document*

--- a/docs/archive/projects-archive/research/AGGREGATE_ROOT_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/AGGREGATE_ROOT_ANALYSIS.md
@@ -1,0 +1,350 @@
+# Aggregate Root Analysis for Work Tracker v3.0
+
+> **Research Date:** 2026-01-07
+> **Status:** COMPLETE
+> **Decision:** Task-level Aggregate Root with Phase and Plan as separate ARs
+
+---
+
+## 1. Executive Summary
+
+Based on research from authoritative DDD sources (Vernon, Evans, Young) and analysis of the previous ECW framework's lessons learned, we recommend:
+
+| Aggregate Root | Contains | Consistency |
+|----------------|----------|-------------|
+| **Task** (Primary AR) | Task entity + Subtasks | Immediate |
+| **Phase** (Secondary AR) | Phase entity + Task IDs (references only) | Eventual |
+| **Plan** (Tertiary AR) | Plan entity + Phase IDs (references only) | Eventual |
+
+This addresses the user's stated problem: *"We tried using Work Tracker (ADO Project) as AR - very slow. We tried Phase (ADO Epic) - also slow."*
+
+---
+
+## 2. Problem Statement (5W1H)
+
+### WHO is affected?
+- Claude Code instances managing large work trackers
+- Users experiencing slow response times on task operations
+
+### WHAT is the problem?
+- Large aggregate roots cause performance degradation
+- Concurrent modifications cause lock contention
+- Full aggregate loading creates N+1 query problems
+
+### WHERE does it manifest?
+- Task completion operations (load entire Plan/Phase)
+- Subtask check/uncheck operations
+- Progress calculations (lock escalation)
+
+### WHEN did it start?
+- ECW v2.x with Plan as primary aggregate root
+- Worsened as trackers grew beyond ~50 tasks
+
+### WHY does it matter?
+- Context rot is exacerbated by slow tool operations
+- User experience degrades with larger projects
+- System cannot scale horizontally
+
+### HOW is it manifesting?
+- Previous Claude session reported "very slow" with Plan AR
+- Also reported "quite slow" with Phase AR
+
+---
+
+## 3. Research Findings
+
+### 3.1 Vaughn Vernon's Four Rules for Aggregate Design
+
+**Source:** *Implementing Domain-Driven Design* (2013), "Effective Aggregate Design" series
+
+1. **Model True Invariants in Consistency Boundaries**
+   - Only include entities that MUST remain transactionally consistent
+   - Ask: "What business rule requires these entities to change together?"
+
+2. **Design Small Aggregates**
+   - Start with single entity per aggregate
+   - Only add entities when true invariants require them
+   - *"70% of aggregates consist of just the root entity plus value-type properties"* (Niclas Hedhman study)
+
+3. **Reference Other Aggregates by Identity**
+   - Never hold direct object references to other aggregates
+   - Store only IDs/keys
+   - Prevents accidental modification of other aggregates
+
+4. **Use Eventual Consistency Outside the Boundary**
+   - Cross-aggregate coordination via domain events
+   - Accept temporary inconsistency
+
+### 3.2 Vernon's ProjectOvation Case Study
+
+Vernon's "Effective Aggregate Design" series uses a Scrum project management system identical to our hierarchy:
+
+**Initial (Failed) Design:**
+```
+Project ← Release ← Sprint ← BacklogItem ← Task
+(All in one aggregate)
+```
+**Result:** Severe performance degradation, high contention, transaction failures
+
+**Refactored (Successful) Design:**
+```
+Aggregate 1: BacklogItem (contains Task children)
+Aggregate 2: Sprint (references BacklogItem IDs)
+Aggregate 3: Release (references Sprint IDs)
+```
+
+**Key Quote:**
+> "A large-cluster Aggregate will never perform or scale well. It is more likely to become a nightmare leading only to failure."
+
+### 3.3 The Cascading Delete Test
+
+A practical rule for aggregate boundaries:
+
+> "When considering aggregate structure, ask: should deleting the root delete all its children?"
+
+Applied to Jerry Work Tracker:
+- Delete Task → Should delete Subtasks ✓ (same aggregate)
+- Delete Phase → Should delete Tasks? **Maybe** (could be eventual)
+- Delete Plan → Should delete Phases? **Maybe** (could be eventual)
+
+### 3.4 Eric Evans' Evolved Perspective (QCon 2009)
+
+> "Aggregates turned out to be one of the most difficult patterns to apply... A much more useful view at aggregates is to look at them as **consistency boundaries for transactions, distributions and concurrency**."
+
+This shifts focus from "what belongs together logically" to "what must change together atomically."
+
+---
+
+## 4. Analysis: Task vs Phase vs Plan as Aggregate Root
+
+### 4.1 Option Analysis
+
+| Level | As AR? | Pros | Cons |
+|-------|--------|------|------|
+| **Plan** | NO | Strong consistency | Lock contention, N+1 queries, cannot scale |
+| **Phase** | MAYBE | Smaller than Plan | Still causes contention across tasks |
+| **Task** | YES | Minimal contention, scales horizontally | Cross-task invariants need eventual consistency |
+
+### 4.2 Invariants Analysis
+
+**Question:** What business rules require immediate consistency?
+
+| Invariant | Scope | Requires Same AR? |
+|-----------|-------|-------------------|
+| "Subtask completion affects task progress" | Task ← Subtask | YES |
+| "All subtasks must be checked to complete task" | Task ← Subtask | YES |
+| "Phase progress = average of task progress" | Phase ← Task | NO (derived) |
+| "Plan progress = average of phase progress" | Plan ← Phase | NO (derived) |
+| "Task must belong to exactly one phase" | Task → Phase | NO (referential) |
+
+**Conclusion:** Only Task ↔ Subtask requires immediate consistency.
+
+### 4.3 Recommended Aggregate Structure
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    AGGREGATE ROOT: TASK                          │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Task                                                       │ │
+│  │  ├── TaskId (strongly typed)                               │ │
+│  │  ├── PhaseId (reference to Phase AR)                       │ │
+│  │  ├── title, description, status                            │ │
+│  │  ├── verification, evidence_refs[]                         │ │
+│  │  └── subtasks: List[Subtask]  ◄── Child entities           │ │
+│  │       ├── SubtaskId                                        │ │
+│  │       ├── title                                            │ │
+│  │       └── checked: bool                                    │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    AGGREGATE ROOT: PHASE                         │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Phase                                                      │ │
+│  │  ├── PhaseId (strongly typed)                              │ │
+│  │  ├── PlanId (reference to Plan AR)                         │ │
+│  │  ├── title, description, status                            │ │
+│  │  ├── task_ids: List[TaskId]  ◄── References only!          │ │
+│  │  └── progress: float (derived via projection)              │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    AGGREGATE ROOT: PLAN                          │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Plan                                                       │ │
+│  │  ├── PlanId (strongly typed)                               │ │
+│  │  ├── InitiativeId (reference)                              │ │
+│  │  ├── title, description, status                            │ │
+│  │  ├── phase_ids: List[PhaseId]  ◄── References only!        │ │
+│  │  └── progress: float (derived via projection)              │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Event Flow for Eventual Consistency
+
+### 5.1 Task Completion Flow
+
+```
+1. User: "mark task 5.3 complete"
+2. Load Task aggregate (small, fast)
+3. Task.complete() validates:
+   - All subtasks checked
+   - Evidence attached (if required)
+4. Task emits: TaskCompletedEvent
+5. Persist Task (single small transaction)
+
+--- EVENTUAL CONSISTENCY BOUNDARY ---
+
+6. EventHandler receives TaskCompletedEvent
+7. Load Phase aggregate
+8. Phase recalculates progress from task projections
+9. Phase emits: PhaseProgressUpdatedEvent
+10. Persist Phase
+
+--- EVENTUAL CONSISTENCY BOUNDARY ---
+
+11. EventHandler receives PhaseProgressUpdatedEvent
+12. Load Plan aggregate
+13. Plan recalculates progress from phase projections
+14. Plan emits: PlanProgressUpdatedEvent
+15. Persist Plan
+```
+
+### 5.2 CloudEvents Format (Per User Requirement)
+
+```json
+{
+  "specversion": "1.0",
+  "type": "com.jerry.worktracker.task.completed.v1",
+  "source": "/jerry/worktracker/tasks/TASK-001",
+  "id": "evt-a1b2c3d4",
+  "time": "2026-01-07T14:30:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "task_id": "TASK-001",
+    "phase_id": "PHASE-001",
+    "completed_by": {"type": "CLAUDE", "id": "main"},
+    "subtasks_completed": 5,
+    "evidence_count": 2
+  }
+}
+```
+
+---
+
+## 6. Strongly Typed Identity Objects (Per User Requirement)
+
+```python
+# domain/value_objects/identifiers.py
+
+from dataclasses import dataclass
+from typing import NewType
+import uuid
+
+@dataclass(frozen=True)
+class TaskId:
+    """Strongly typed Task identifier."""
+    value: str
+
+    def __post_init__(self):
+        if not self.value:
+            raise ValueError("TaskId cannot be empty")
+
+    @classmethod
+    def generate(cls) -> "TaskId":
+        return cls(f"TASK-{uuid.uuid4().hex[:8].upper()}")
+
+    def __str__(self) -> str:
+        return self.value
+
+@dataclass(frozen=True)
+class PhaseId:
+    """Strongly typed Phase identifier."""
+    value: str
+
+    @classmethod
+    def generate(cls) -> "PhaseId":
+        return cls(f"PHASE-{uuid.uuid4().hex[:8].upper()}")
+
+@dataclass(frozen=True)
+class PlanId:
+    """Strongly typed Plan identifier."""
+    value: str
+
+    @classmethod
+    def generate(cls) -> "PlanId":
+        return cls(f"PLAN-{uuid.uuid4().hex[:8].upper()}")
+
+@dataclass(frozen=True)
+class SubtaskId:
+    """Strongly typed Subtask identifier - scoped to parent Task."""
+    task_id: TaskId
+    sequence: int
+
+    def __str__(self) -> str:
+        return f"{self.task_id.value}.{self.sequence}"
+```
+
+---
+
+## 7. Performance Comparison (Projected)
+
+| Operation | Plan as AR | Phase as AR | Task as AR |
+|-----------|-----------|-------------|------------|
+| Complete single task | O(n) load all | O(m) load phase | O(1) load task |
+| Check subtask | O(n) | O(m) | O(1) |
+| Concurrent task updates | Blocked | Partially blocked | Parallel |
+| Horizontal scaling | Not possible | Limited | Full support |
+
+Where:
+- n = total tasks in plan
+- m = tasks in phase
+- O(1) = single task + subtasks only
+
+---
+
+## 8. References
+
+### Primary Sources
+1. **Vaughn Vernon** - *Implementing Domain-Driven Design* (2013)
+2. **Vaughn Vernon** - "Effective Aggregate Design" (3-part series)
+   - https://www.dddcommunity.org/library/vernon_2011/
+3. **Eric Evans** - *Domain-Driven Design* (2003)
+4. **Eric Evans** - QCon London 2009: "What I've Learned About DDD Since the Book"
+
+### Secondary Sources
+5. **Martin Fowler** - DDD Aggregate (bliki)
+   - https://martinfowler.com/bliki/DDD_Aggregate.html
+6. **Microsoft Learn** - Domain Events Design and Implementation
+7. **Niclas Hedhman** - Aggregate sizing study (cited by Vernon)
+
+### ECW Lessons Learned
+8. `docs/knowledge/dragonsbelurkin/glimmering-brewing-lake.md` (v3.0 Strategic Design)
+9. `docs/knowledge/dragonsbelurkin/history/REVISED-ARCHITECTURE-v3.0.md`
+
+---
+
+## 9. Decision Record
+
+**Decision:** Implement three Aggregate Roots (Task, Phase, Plan) with eventual consistency.
+
+**Rationale:**
+- Evidence from Vernon's ProjectOvation case study
+- User's direct experience with performance issues
+- Alignment with "small aggregates" principle
+
+**Consequences:**
+- Cross-aggregate operations require domain events
+- Progress calculations are eventually consistent
+- More complex event handling infrastructure
+
+**Status:** APPROVED FOR IMPLEMENTATION
+
+---
+
+*Document Version: 1.0*
+*Last Updated: 2026-01-07*

--- a/docs/archive/projects-archive/research/ECW_COMPREHENSIVE_LESSONS_LEARNED.md
+++ b/docs/archive/projects-archive/research/ECW_COMPREHENSIVE_LESSONS_LEARNED.md
@@ -1,0 +1,488 @@
+# ECW Framework: Comprehensive Lessons Learned
+
+> **Research Date:** 2026-01-07
+> **Sources:** 60+ markdown files from docs/knowledge/dragonsbelurkin/
+> **Purpose:** Synthesize all learnings from ECW v1-v3 for Jerry Work Tracker implementation
+> **Status:** DECISION-GRADE (Validation: 19/19 criteria met)
+
+---
+
+## Executive Summary
+
+Analysis of 60+ ECW artifacts reveals a mature, well-documented framework that evolved through three major versions. The key learnings fall into five categories:
+
+1. **Architectural Patterns** - Blackboard, Event Sourcing, CQRS, Hexagonal
+2. **Process Discipline** - 26 Hard Rules, SOPs, Three-Tier Enforcement
+3. **Problem-Solving** - 7-Step Meta-Framework, Domain-Specific Playbooks
+4. **Agent Orchestration** - 8 Specialized Agents, Capability-Based Self-Selection
+5. **Resilience Patterns** - MAPE-K Self-Healing, Circuit Breaker, Consent Enforcement
+
+**Critical Insight:** The ECW framework's sophistication indicates significant investment. Jerry should adopt these patterns wholesale rather than reinventing them.
+
+---
+
+## 1. Architectural Patterns to Adopt
+
+### 1.1 Blackboard Pattern for Agent Orchestration
+
+**Source:** `aspirations/blackboard/*.md` (13 documents)
+
+**What It Is:**
+- Shared knowledge repository (blackboard) where agents post and claim signals
+- Capability-based self-selection (agents choose tasks matching their skills)
+- Alternative to rigid coordinator-worker patterns
+
+**Evidence:**
+> "Blackboard re-emerged for LLM systems: 13-57% improvement over master-slave" (ArXiv 2025 research)
+
+**Why It Matters for Jerry:**
+- Work Tracker will have multiple agents (analyst, researcher, validator)
+- Blackboard enables loose coupling between agents
+- Signals survive context compaction (persisted to file/DB)
+
+**Pattern Implementation:**
+```
+Signal Lifecycle: POSTED → CLAIMED → COMPLETED/FAILED/EXPIRED
+Agent Claims: Optimistic locking with version check
+Persistence: SQLite event store + file-based signal bridge
+```
+
+**What I'd Do Differently:**
+- Use Redis Streams instead of filesystem for signal bus
+- Implement signal expiration/timeout from day 1
+- Monitor signal queue depth continuously
+
+---
+
+### 1.2 Event Sourcing with CloudEvents 1.0
+
+**Source:** `glimmering-brewing-lake.md`, `REVISED-ARCHITECTURE-v3.0.md`
+
+**What It Is:**
+- All state changes persisted as immutable events
+- State reconstructed by replaying events
+- Snapshots for performance optimization
+
+**User Requirement:** "CloudEvents will be our Event Schema"
+
+**CloudEvents Structure:**
+```json
+{
+  "specversion": "1.0",
+  "type": "com.jerry.worktracker.task.completed.v1",
+  "source": "/jerry/worktracker/tasks/TASK-001",
+  "id": "evt-a1b2c3d4",
+  "time": "2026-01-07T14:30:00Z",
+  "data": { ... }
+}
+```
+
+**Lessons:**
+- Event schema versioning required from day 1
+- Snapshots are CACHE, events are TRUTH
+- Projections enable optimized read models
+
+**What I'd Do Differently:**
+- Define event upgrade/downgrade paths upfront
+- Include correlation IDs for distributed tracing
+- Plan snapshot frequency based on aggregate size
+
+---
+
+### 1.3 Three Aggregate Roots with Eventual Consistency
+
+**Source:** `AGGREGATE_ROOT_ANALYSIS.md`, user feedback
+
+**Problem:**
+> "We tried using Work Tracker (ADO Project) as AR - very slow. We tried Phase (ADO Epic) - also slow."
+
+**Solution (Vernon's Small Aggregates Principle):**
+
+| Aggregate | Contains | Consistency |
+|-----------|----------|-------------|
+| **Task** (Primary) | Task + Subtasks | Immediate |
+| **Phase** (Secondary) | Phase + TaskId refs | Eventual |
+| **Plan** (Tertiary) | Plan + PhaseId refs | Eventual |
+
+**Evidence:**
+> "70% of aggregates consist of just the root entity plus value-type properties" (Niclas Hedhman study, cited by Vernon)
+
+**Event Flow:**
+```
+Task.complete() → TaskCompletedEvent → [immediate response]
+                                     ↓
+                  [async] PhaseProgressProjection recalculates
+                                     ↓
+                  [async] PlanProgressProjection updates
+```
+
+---
+
+### 1.4 Hexagonal Architecture (Ports & Adapters)
+
+**Source:** `work_tracker_architecture_hexagonal_ddd_cqrs_layered_teaching_edition.md`
+
+**Three-Level Explanation:**
+
+| Level | Mental Model |
+|-------|--------------|
+| **ELI5** | Castle with different gates - same rules inside |
+| **Junior** | Ports (interfaces) + Adapters (implementations) |
+| **Architect** | Primary/Secondary ports, Capability surfaces, Repository chains |
+
+**Key Principles:**
+1. Domain owns abstractions (no external imports)
+2. Adapters are thin (logic in domain/application)
+3. Different capability surfaces (Public API ≠ Admin API)
+4. Repository chain: `IRepository` ← `FileRepository` ← `MarkdownAdapter`
+
+**Architectural Smells to Avoid:**
+```
+SMELL: "Just this once" logic in adapters
+SMELL: Repository returns ORM entities
+SMELL: Cross-aggregate writes in one transaction
+SMELL: Queries reusing command models
+SMELL: Direct calls between bounded contexts
+```
+
+---
+
+## 2. Process Discipline: 26 Hard Rules
+
+**Source:** `exemplars/rules/hard-rules.md`
+
+### Critical Rules for Jerry
+
+| Rule | Gate | What It Prevents |
+|------|------|-----------------|
+| **Rule 9** | Before implementation | TDD: Test FIRST (RED) |
+| **Rule 20** | Before integration features | Architectural feasibility proof |
+| **Rule 21** | Before claiming "integrated" | E2E tests (not mocks) |
+| **Rule 22** | Before commit | Integration proof required |
+| **Rule 24** | Before "Complete" status | 90% checkbox threshold |
+| **Rule 26** | Before spawning agents | Design review approval |
+
+### Integration Theater (Anti-Pattern)
+
+**Source:** Rules 20-22, Phase 32.G failure
+
+**What Happened:**
+- Feature claimed integration with hooks
+- Tests passed via mocks
+- Real execution failed (hooks can't access MCP context)
+
+**Lesson (LES-030):**
+> "Hooks run as subprocesses, cannot access MCP context. Use file-based bridge."
+
+**Prevention:**
+- E2E tests in production-like environment
+- Integration proof with actual execution evidence
+- Document process boundaries explicitly
+
+---
+
+## 3. Standard Operating Procedures (SOPs)
+
+**Source:** `exemplars/rules/sop.md`
+
+### SOP-I: Implementation (MUST ADOPT)
+
+```
+SOP-I.1: BDD + TDD approach (Red/Green/Refactor)
+SOP-I.2: Test pyramid: unit, integration, system, contract, architecture, E2E
+SOP-I.3: NO placeholders, stubs, or FALSE data in tests
+SOP-I.4: ALL tests MUST be real and validatable with evidence
+SOP-I.5: Edge cases tested alongside happy path
+SOP-I.6: Plan for negative, edge cases, and failure scenarios
+```
+
+### SOP-DES: Design Artifacts (MUST ADOPT)
+
+Required design artifacts:
+- Use Cases + Use Case Diagrams
+- Class Diagrams, Component Diagrams
+- Activity Diagrams, State Machine Diagrams
+- Sequence Diagrams, Communication Diagrams
+- JSON Schemas, OpenAPI Specifications
+- Playbooks + Runbooks
+
+### SOP-ENF: Design Review Enforcement (MUST ADOPT)
+
+**Four-Tier Enforcement:**
+
+| Tier | Name | Mechanism | Behavior |
+|------|------|-----------|----------|
+| 1 | ADVISORY | CLAUDE.md | Display reminder |
+| 2 | SOFT | Template prompts | Warn, don't block |
+| 3 | MEDIUM | Pre-commit hooks | Block commits |
+| 4 | **HARD** | Agent-level gate | Refuse to proceed |
+
+**Approval Protocol:**
+1. Present DESIGN SUMMARY
+2. List proposed artifacts and locations
+3. Ask "May I proceed?"
+4. WAIT for explicit approval
+5. ONLY THEN proceed
+
+---
+
+## 4. Problem-Solving Meta-Framework
+
+**Source:** `frameworks/problemsolving/problem_solving_meta_framework.md`
+
+### 7-Step Universal Framework
+
+```
+1. FRAME (5W1H)      ← Explain so a 5-year-old understands
+2. CLASSIFY          ← Simple/Complicated/Complex/Chaotic (Cynefin)
+3. DIAGNOSE (WHY)    ← 5 Whys / Fishbone / Abduction
+4. IDEATE (DIVERGE)  ← No evaluation, no feasibility
+5. DECIDE (CONVERGE) ← Tradeoffs: Risk, Cost, Time, Reversibility
+6. ACT               ← Execute with monitoring; ready to abort
+7. VERIFY & LEARN    ← Confirm outcome; institutionalize learning
+```
+
+### Common Failure Modes
+
+| Failure | Consequence |
+|---------|-------------|
+| Solving before framing | Wrong problem solved perfectly |
+| Wrong classification | Wrong approach applied |
+| No divergence | Best idea never considered |
+| No red team | Blind spots undetected |
+| No learning loop | Same mistakes repeated |
+
+### Domain-Specific Playbooks
+
+| Domain | Core Loop | Prior Art |
+|--------|-----------|-----------|
+| **Software** | TRIAGE → DIAGNOSE → FIX → VERIFY → LEARN | Google SRE |
+| **Security** | PREPARE → DETECT → CONTAIN → ERADICATE → RECOVER | NIST 800-61 |
+| **Research** | Observe → Hypothesize → Design → Run → Analyze → Conclude | Scientific Method |
+
+---
+
+## 5. Agent Orchestration System
+
+**Source:** `skills/problem-solving/agents/*.md` (8 files)
+
+### 8 Specialized Agents
+
+| Agent | Role | Cognitive Mode |
+|-------|------|----------------|
+| **ps-researcher** | Deep research, information gathering | Divergent |
+| **ps-analyst** | Analysis of gathered information | Convergent |
+| **ps-synthesizer** | Cross-document pattern extraction | Meta-analysis |
+| **ps-architect** | ADR creation, architectural decisions | Design |
+| **ps-investigator** | Failure analysis, debugging | Root cause |
+| **ps-validator** | Constraint checking (binary) | Validation |
+| **ps-reviewer** | Quality assessment (spectrum) | Quality |
+| **ps-reporter** | Status documentation | Reporting |
+
+### Mandatory Persistence (c-009)
+
+> "Every agent output MUST be persisted to file. Transient-only output is forbidden."
+
+**File Locations:**
+```
+docs/research/{ps-id}-{entry-id}-{topic-slug}.md
+docs/analysis/{ps-id}-{entry-id}-{analysis-type}.md
+docs/decisions/{ps-id}-{entry-id}-adr-{slug}.md
+docs/investigations/{ps-id}-{entry-id}-investigation.md
+docs/synthesis/{ps-id}-{entry-id}-synthesis.md
+```
+
+### Agent Workflow
+
+```
+ps-researcher → ps-analyst → ps-synthesizer → ps-architect
+                    ↓              ↓              ↓
+                ps-investigator ←──┴──────────────┘
+                    ↓
+                ps-validator
+                    ↓
+                ps-reviewer
+                    ↓
+                ps-reporter
+```
+
+---
+
+## 6. Self-Healing Architecture
+
+**Source:** `aspirations/self-healing/*.md` (3 files)
+
+### MAPE-K Control Loop
+
+```
+MONITOR → ANALYZE → PLAN → EXECUTE → KNOWLEDGE
+   ↓         ↓        ↓        ↓          ↓
+Health    Symptom   Strategy  Circuit   Pattern
+Monitor   Analyzer  Planner   Breaker   Database
+```
+
+### Failure Categories & Recovery
+
+| Category | Example | Recovery Strategy |
+|----------|---------|-------------------|
+| TRANSIENT | Timeout | Retry with exponential backoff |
+| VALIDATION | Invalid status | Normalize input |
+| RESOURCE | File not found | Escalate to user |
+| CORRUPTION | Checksum mismatch | Repair from backup |
+| UNKNOWN | Unexpected error | Escalate with context |
+
+### Four-Level Enforcement (Consent)
+
+| Level | Mechanism | Behavior |
+|-------|-----------|----------|
+| **ADVISORY** | Recommendations | Display warning |
+| **SOFT** | Consent prompts | Ask before proceeding |
+| **MEDIUM** | Agent restrictions | Block subagent actions |
+| **HARD** | Hook blocks | Refuse to execute |
+
+### Circuit Breaker Pattern
+
+```
+CLOSED (normal) → HALF_OPEN (testing) → OPEN (blocked)
+      ↑                                       │
+      └───────────── after timeout ───────────┘
+```
+
+---
+
+## 7. Critical Constraints Discovered
+
+### LES-030: Hook Subprocess Isolation
+
+> "Hooks run as subprocesses, CANNOT access MCP context. Cannot call Task tool or MCP services directly. File-based bridge is required workaround."
+
+**Impact:** Any orchestration via hooks must use two-phase approach:
+1. Hook detects/writes signal
+2. External process reads signal and executes
+
+### c-015: No Recursive Subagents
+
+> "Task tool filtered at adapter level. Subagents cannot spawn subagents."
+
+**Impact:** Agent depth is limited to 1 level. Orchestrator pattern required.
+
+### c-009: Mandatory Persistence
+
+> "All agent outputs must be persisted to file. Transient-only responses are forbidden."
+
+**Impact:** Every agent invocation must produce a file artifact.
+
+---
+
+## 8. What I'd Do Differently (5W1H Analysis)
+
+### WHO should implement this?
+- Jerry framework authors with understanding of ECW patterns
+- Must understand DDD, Event Sourcing, CQRS
+
+### WHAT should change from ECW?
+1. **Use Task as primary AR** (not Plan or Phase)
+2. **Use Redis/message queue** (not filesystem for signals)
+3. **Implement backup/health checks from day 1**
+4. **Test E2E before claiming integration**
+5. **Adopt 26 Hard Rules as gates**
+
+### WHERE should changes be made?
+- Domain layer: Small aggregates, strongly typed IDs
+- Infrastructure: Message queue, not file signals
+- Process: Three-tier enforcement from start
+
+### WHEN should these be implemented?
+- Phase 1: Domain model with correct aggregates
+- Phase 2: Event sourcing infrastructure
+- Phase 3: Self-healing patterns
+- Phase 4: Agent orchestration
+
+### WHY make these changes?
+- ECW had 128+ failing tests (test isolation)
+- Plan/Phase as AR = slow performance (user confirmed)
+- File-based signals = eventual consistency issues
+- Missing E2E tests = integration theater
+
+### HOW to avoid ECW's mistakes?
+1. **Test isolation** - Fresh fixtures per test, no global state
+2. **Small aggregates** - Task as AR, not Plan
+3. **Event schema versioning** - Plan migrations from day 1
+4. **E2E proof required** - Rule 21/22 enforcement
+5. **Defense in depth** - Three-tier enforcement
+
+---
+
+## 9. Patterns to Adopt Wholesale
+
+### PAT-048: Three-Tier Enforcement
+Soft (template) → Medium (pre-commit) → Hard (agent gate)
+
+### PAT-049: Progressive Thresholds
+Research quality: ≥16/19 criteria = DECISION-GRADE
+
+### PAT-051: Pre-Commit Validation
+Block commits that violate quality gates
+
+### PAT-052: Agent-Level Gate
+Agent refuses to write incomplete artifacts
+
+### PAT-070: Capability-Based Self-Selection
+Agents choose signals matching their capabilities
+
+---
+
+## 10. Templates to Adopt
+
+| Template | Purpose | Location |
+|----------|---------|----------|
+| **ADR** | Architecture decisions | `templates/adr.md` |
+| **Analysis** | Deep analysis | `templates/deep-analysis.md` |
+| **Investigation** | Root cause analysis | `templates/investigation.md` |
+| **Research** | Evidence-based inquiry | `templates/research.md` |
+| **Review** | Quality assessment | `templates/review.md` |
+| **Synthesis** | Cross-document patterns | `templates/synthesis.md` |
+
+---
+
+## 11. Validation Status
+
+| Category | Status | Score |
+|----------|--------|-------|
+| W-DIMENSION COVERAGE | ✅ COMPLETE | 6/6 |
+| FRAMEWORK APPLICATION | ✅ COMPLETE | 5/5 |
+| EVIDENCE & GAPS | ✅ COMPLETE | 4/4 |
+| OUTPUT SECTIONS | ✅ COMPLETE | 4/4 |
+
+**Quality Status:** DECISION-GRADE (19/19 criteria met)
+
+---
+
+## 12. References
+
+### Primary ECW Sources
+1. `docs/knowledge/dragonsbelurkin/glimmering-brewing-lake.md` (v3 design)
+2. `docs/knowledge/dragonsbelurkin/glimmering-brewing-lake-v1.md` (v1 design)
+3. `docs/knowledge/dragonsbelurkin/history/REVISED-ARCHITECTURE-v3.0.md`
+4. `docs/knowledge/dragonsbelurkin/aspirations/blackboard/*.md` (13 files)
+5. `docs/knowledge/dragonsbelurkin/aspirations/self-healing/*.md` (3 files)
+
+### Exemplar Sources
+6. `docs/knowledge/exemplars/rules/hard-rules.md`
+7. `docs/knowledge/exemplars/rules/sop.md`
+8. `docs/knowledge/exemplars/frameworks/problemsolving/*.md`
+9. `docs/knowledge/exemplars/architecture/*.md`
+10. `docs/knowledge/exemplars/templates/*.md`
+
+### Industry References
+11. Vaughn Vernon - *Implementing Domain-Driven Design*
+12. Eric Evans - *Domain-Driven Design*
+13. CloudEvents Specification 1.0 (CNCF)
+14. Google SRE Handbook
+15. NIST SP 800-61r2 (Incident Response)
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-07*
+*Author: Claude (Distinguished Systems Engineer persona)*

--- a/docs/archive/projects-archive/research/GRAPH_DATA_MODEL_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/GRAPH_DATA_MODEL_ANALYSIS.md
@@ -1,0 +1,1057 @@
+# Graph Data Model Analysis for Jerry Work Tracker
+
+> **Research Date:** 2026-01-07
+> **Status:** DECISION-GRADE (Validation: 19/19 criteria met)
+> **Purpose:** Design graph-ready data model compatible with Apache TinkerPop Gremlin
+> **Decision:** Hybrid Property Graph Model with Vertex/Edge abstractions
+
+---
+
+## Executive Summary
+
+This analysis designs a graph-ready data model for Jerry Work Tracker that:
+1. **Supports Apache TinkerPop Gremlin** as the target traversal language
+2. **Maintains DDD principles** with Aggregate Roots and bounded contexts
+3. **Enables CloudEvents** event sourcing with graph persistence
+4. **Provides extensibility** for future graph database migration
+
+**Key Design Decision:** Implement a **Property Graph abstraction layer** in the domain model that can target:
+- File-based JSON storage (Phase 1)
+- SQLite with graph schema (Phase 2)
+- Native graph database (Phase 3 - Neo4j, Neptune, JanusGraph)
+
+---
+
+## 1. Problem Statement (5W1H)
+
+### WHO is affected?
+- Jerry Work Tracker users tracking complex multi-phase work
+- Future integrations requiring graph analytics
+- System architects planning database migrations
+
+### WHAT is the requirement?
+- Graph-ready data model with Node (Vertex) and Edge concepts
+- Gremlin-compatible structure for future traversal queries
+- Strongly typed IDs that work across storage backends
+- Event sourcing with CloudEvents 1.0 schema
+
+### WHERE will this be implemented?
+- Domain layer: Graph abstractions (Vertex, Edge, VertexProperty, EdgeProperty) — See Section 2.4
+- Infrastructure layer: Storage adapters (File, SQLite, Graph DB)
+- Application layer: Traversal queries via repository pattern
+
+### WHEN should graph concepts be introduced?
+- Phase 1: Domain model with graph abstractions
+- Phase 2: File-based storage with graph semantics
+- Phase 3: Native graph database adapter
+
+### WHY use a graph model?
+- Work tracking has natural hierarchical relationships (Plan → Phase → Task)
+- Dependency tracking benefits from graph traversals
+- Progress calculation requires recursive aggregation
+- Future extensibility for complex queries
+
+### HOW will we implement this?
+- Abstract Vertex and Edge base classes in domain
+- Property Graph schema for entities and relationships
+- Gremlin-compatible ID and property naming conventions
+- Adapter pattern for storage backend abstraction
+
+---
+
+## 2. Property Graph Model Fundamentals
+
+### 2.1 Core Concepts (Apache TinkerPop)
+
+**Source:** [Apache TinkerPop Reference](https://tinkerpop.apache.org/docs/current/reference/)
+
+| Concept | Definition | Example |
+|---------|------------|---------|
+| **Vertex** | Node/entity in the graph | Task, Phase, Plan |
+| **Edge** | Directed relationship between vertices | `contains`, `depends_on` |
+| **Property** | Key-value attribute on vertex/edge | `title`, `status`, `created_at` |
+| **Label** | Type classification for vertex/edge | `Task`, `Phase`, `CONTAINS` |
+
+### 2.2 Property Graph Structure
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         PROPERTY GRAPH MODEL                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│    ┌─────────────────┐         ┌─────────────────┐                      │
+│    │     VERTEX      │         │      EDGE       │                      │
+│    ├─────────────────┤         ├─────────────────┤                      │
+│    │ id: VertexId    │         │ id: EdgeId      │                      │
+│    │ label: string   │◄────────│ label: string   │                      │
+│    │ properties: Map │         │ outV: VertexId  │                      │
+│    └─────────────────┘         │ inV: VertexId   │                      │
+│                                │ properties: Map │                      │
+│                                └─────────────────┘                      │
+│                                                                          │
+│    Key Characteristics:                                                  │
+│    • Directed: Edges have source (outV) and target (inV)                │
+│    • Attributed: Both vertices and edges can have properties            │
+│    • Multi-graph: Multiple edges between same vertex pair allowed       │
+│    • Labeled: Types via labels, not inheritance                         │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 TinkerPop Type System
+
+**Source:** [Practical Gremlin, Kelvin Lawrence](https://www.kelvinlawrence.net/book/PracticalGremlin.html)
+
+| Type | GraphSON | Jerry Usage |
+|------|----------|-------------|
+| `g:UUID` | UUID string | Strongly typed IDs |
+| `g:Int64` | Long integer | Sequence numbers |
+| `g:Double` | Float | Progress percentages |
+| `g:Date` | ISO timestamp | `created_at`, `modified_at` |
+| `g:List` | JSON array | `subtask_ids`, `evidence_refs` |
+| `g:Map` | JSON object | Complex properties |
+
+### 2.4 VertexProperty vs EdgeProperty Investigation
+
+> **AN Response:** Investigating separate property realizations as suggested.
+
+**Source:** [TinkerPop VertexProperty API](https://tinkerpop.apache.org/javadocs/current/core/org/apache/tinkerpop/gremlin/structure/VertexProperty.html)
+
+#### Key Distinction in TinkerPop
+
+| Feature | Property (Edges) | VertexProperty (Vertices) |
+|---------|------------------|---------------------------|
+| Key/Value pair | ✓ | ✓ |
+| Is an Element | ✗ | ✓ |
+| Can have meta-properties | ✗ | ✓ |
+| Multi-value support | ✗ | ✓ (cardinality) |
+| Cardinality control | ✗ | ✓ (SINGLE/LIST/SET) |
+
+#### Why TinkerPop Has Distinct VertexProperty
+
+TinkerPop introduced `VertexProperty` to enable two critical features:
+
+1. **Multi-Properties (Multiple Values)**: A vertex can have multiple values for the same property key with cardinality control:
+   - `SINGLE`: Replace existing value
+   - `LIST`: Add new value (allow duplicates)
+   - `SET`: Add new value (no duplicates)
+
+2. **Meta-Properties (Properties on Properties)**: VertexProperty implements Element, allowing it to have key/value data attached. This creates a third level in the property hierarchy.
+
+#### Use Cases for Meta-Properties in Jerry
+
+| Use Case | Example | Benefit |
+|----------|---------|---------|
+| **Auditing** | `task.property("status", "complete", "changed_by", "claude", "changed_at", "2026-01-08")` | Track who/when for any property change |
+| **Permissions** | `task.property("title", "Secret", "readable_by", "admin")` | Property-level access control |
+| **Temporal** | `phase.property("target_date", "2026-03-01", "valid_from", "2026-01-01")` | Validity periods |
+| **Data Quality** | `task.property("estimate", 4, "confidence", 0.8, "source", "user")` | Confidence scores, provenance |
+
+#### Design Decision for Jerry
+
+**Recommendation:** Implement **separate VertexProperty and EdgeProperty classes** to align with TinkerPop semantics:
+
+```python
+# src/domain/graph/properties.py
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, TypeVar, Generic
+from enum import Enum, auto
+
+class Cardinality(Enum):
+    """Property cardinality for VertexProperty (TinkerPop alignment)."""
+    SINGLE = auto()   # Replace existing value
+    LIST = auto()     # Allow duplicates
+    SET = auto()      # No duplicates
+
+T = TypeVar('T')
+
+@dataclass
+class Property(Generic[T]):
+    """
+    Simple property for edges (no meta-properties).
+
+    Aligned with TinkerPop Property interface.
+    """
+    key: str
+    value: T
+
+    def __hash__(self):
+        return hash((self.key, self.value))
+
+
+@dataclass
+class VertexProperty(Generic[T]):
+    """
+    Rich property for vertices with meta-property support.
+
+    Aligned with TinkerPop VertexProperty interface.
+    Implements Element semantics (has id, can have properties).
+
+    Reference: https://tinkerpop.apache.org/javadocs/current/core/
+               org/apache/tinkerpop/gremlin/structure/VertexProperty.html
+    """
+    id: str  # VertexProperty is an Element with its own ID
+    key: str
+    value: T
+    cardinality: Cardinality = Cardinality.SINGLE
+    meta_properties: Dict[str, Any] = field(default_factory=dict)
+
+    def set_meta(self, key: str, value: Any) -> None:
+        """Add meta-property (property on this property)."""
+        self.meta_properties[key] = value
+
+    def get_meta(self, key: str, default: Any = None) -> Any:
+        """Get meta-property value."""
+        return self.meta_properties.get(key, default)
+
+    def with_audit(self, changed_by: str, changed_at: str) -> "VertexProperty[T]":
+        """Add audit trail meta-properties."""
+        self.meta_properties["changed_by"] = changed_by
+        self.meta_properties["changed_at"] = changed_at
+        return self
+
+
+@dataclass
+class EdgeProperty(Property[T]):
+    """
+    Edge property (alias for clarity in domain model).
+
+    Edges in TinkerPop use simple Property (no meta-properties).
+    """
+    pass
+```
+
+#### Impact on Jerry Domain Model
+
+1. **Vertex class** should use `VertexProperty` for properties that need audit trails
+2. **Edge class** should use `EdgeProperty` (simple key-value)
+3. **Audit-critical properties** (status, title, etc.) should leverage meta-properties
+4. **Performance consideration**: Meta-properties add overhead; use selectively
+
+#### Compatibility Notes
+
+- **GraphML**: Does NOT preserve meta-properties (use GraphSON for export)
+- **GraphSON**: Full support for meta-properties
+- **Neo4j**: Native property graph, no meta-properties (flatten to separate edges if needed)
+- **Amazon Neptune**: TinkerPop-compatible, supports VertexProperty semantics
+
+---
+
+## 3. Jerry Work Tracker Graph Schema
+
+### 3.1 Vertex Types (Labels)
+
+> **Note:** All vertices include a `uri` property using Jerry URI scheme (SPEC-001).
+> See: `docs/specifications/JERRY_URI_SPECIFICATION.md`
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          VERTEX LABELS                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   PLAN (Aggregate Root)                                                  │
+│   ├── id: PlanId (g:UUID with prefix "PLAN-")                           │
+│   ├── uri: JerryUri (e.g., "jer:jer:work-tracker:plan:PLAN-001+hash")   │
+│   ├── title: string                                                      │
+│   ├── description: string?                                               │
+│   ├── status: PlanStatus                                                 │
+│   ├── progress: double (computed via traversal)                          │
+│   ├── created_at: datetime                                               │
+│   ├── created_by: ActorId                                                │
+│   ├── modified_at: datetime                                              │
+│   └── modified_by: ActorId                                               │
+│                                                                          │
+│   PHASE (Aggregate Root)                                                 │
+│   ├── id: PhaseId (g:UUID with prefix "PHASE-")                         │
+│   ├── display_number: int                                                │
+│   ├── title: string                                                      │
+│   ├── description: string?                                               │
+│   ├── status: PhaseStatus                                                │
+│   ├── target_date: date?                                                 │
+│   ├── created_at: datetime                                               │
+│   └── modified_at: datetime                                              │
+│                                                                          │
+│   TASK (Aggregate Root - Primary)                                        │
+│   ├── id: TaskId (g:UUID with prefix "TASK-")                           │
+│   ├── display_number: string (e.g., "1.3")                              │
+│   ├── title: string                                                      │
+│   ├── description: string?                                               │
+│   ├── verification: string?                                              │
+│   ├── status: TaskStatus                                                 │
+│   ├── blocking_reason: string?                                           │
+│   ├── created_at: datetime                                               │
+│   └── modified_at: datetime                                              │
+│                                                                          │
+│   SUBTASK (Entity within Task aggregate)                                 │
+│   ├── id: SubtaskId (composite: TaskId + sequence)                      │
+│   ├── title: string                                                      │
+│   ├── checked: boolean                                                   │
+│   ├── checked_at: datetime?                                              │
+│   └── checked_by: ActorId?                                               │
+│                                                                          │
+│   ACTOR (Reference vertex)                                               │
+│   ├── id: ActorId                                                        │
+│   ├── type: ActorType (CLAUDE, HUMAN, SYSTEM)                           │
+│   └── name: string                                                       │
+│                                                                          │
+│   EVENT (CloudEvents vertex)                                             │
+│   ├── id: EventId (g:UUID)                                               │
+│   ├── specversion: "1.0"                                                 │
+│   ├── type: JerryUri (e.g., "jer:jer:work-tracker:facts/TaskCompleted") │
+│   ├── source: JerryUri (e.g., "jer:jer:work-tracker:task:TASK-001")     │
+│   ├── time: datetime                                                     │
+│   ├── datacontenttype: "application/json"                               │
+│   └── data: Map (event payload)                                          │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Edge Types (Labels)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           EDGE LABELS                                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   CONTAINS (Parent → Child composition)                                  │
+│   ├── Plan ──CONTAINS──► Phase                                          │
+│   ├── Phase ──CONTAINS──► Task (reference only)                         │
+│   └── Task ──CONTAINS──► Subtask                                        │
+│   Properties:                                                            │
+│   └── sequence: int (ordering)                                           │
+│                                                                          │
+│   BELONGS_TO (Child → Parent navigation)                                 │
+│   ├── Phase ──BELONGS_TO──► Plan                                        │
+│   ├── Task ──BELONGS_TO──► Phase                                        │
+│   └── Subtask ──BELONGS_TO──► Task                                      │
+│   Properties: (none - reverse of CONTAINS)                               │
+│                                                                          │
+│   DEPENDS_ON (Task → Task dependency)                                    │
+│   ├── Task ──DEPENDS_ON──► Task                                         │
+│   Properties:                                                            │
+│   ├── dependency_type: string (BLOCKS, RELATES_TO)                      │
+│   └── created_at: datetime                                               │
+│                                                                          │
+│   EMITTED (Aggregate → Event sourcing)                                   │
+│   ├── Plan ──EMITTED──► Event                                           │
+│   ├── Phase ──EMITTED──► Event                                          │
+│   └── Task ──EMITTED──► Event                                           │
+│   Properties:                                                            │
+│   └── sequence: long (event ordering within aggregate)                   │
+│                                                                          │
+│   PERFORMED_BY (Action attribution)                                      │
+│   ├── Event ──PERFORMED_BY──► Actor                                     │
+│   └── Task ──ASSIGNED_TO──► Actor                                       │
+│   Properties:                                                            │
+│   └── timestamp: datetime                                                │
+│                                                                          │
+│   REFERENCES (Evidence linking)                                          │
+│   └── Task ──REFERENCES──► Evidence                                     │
+│   Properties:                                                            │
+│   └── reference_type: string (EVIDENCE, DOCUMENTATION)                  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Graph Schema Diagram
+
+```
+                              ┌─────────────┐
+                              │    ACTOR    │
+                              │  (Claude,   │
+                              │   Human)    │
+                              └──────┬──────┘
+                                     │
+                         PERFORMED_BY│
+                                     │
+┌──────────────────────────────────────────────────────────────────────────┐
+│                                                                          │
+│   ┌────────────┐   CONTAINS    ┌────────────┐   CONTAINS   ┌──────────┐ │
+│   │    PLAN    │──────────────►│   PHASE    │─────────────►│   TASK   │ │
+│   │ (AR #3)    │               │  (AR #2)   │  (ref only)  │ (AR #1)  │ │
+│   └─────┬──────┘               └─────┬──────┘              └────┬─────┘ │
+│         │                            │                          │       │
+│         │ EMITTED                    │ EMITTED                  │       │
+│         ▼                            ▼                          │       │
+│   ┌────────────┐               ┌────────────┐                   │       │
+│   │   EVENT    │               │   EVENT    │                   │       │
+│   │(CloudEvent)│               │(CloudEvent)│                   │       │
+│   └────────────┘               └────────────┘                   │       │
+│                                                                 │       │
+│                                                    CONTAINS     │       │
+│                                                                 ▼       │
+│                                                          ┌──────────┐   │
+│                                                          │ SUBTASK  │   │
+│                                                          │ (Entity) │   │
+│                                                          └────┬─────┘   │
+│                                                               │         │
+│                                                       EMITTED │         │
+│                                                               ▼         │
+│                                                         ┌──────────┐    │
+│                                                         │  EVENT   │    │
+│                                                         └──────────┘    │
+│                                                                         │
+└──────────────────────────────────────────────────────────────────────────┘
+
+    Legend:
+    ────────► Directed edge (CONTAINS/BELONGS_TO)
+    AR #N    Aggregate Root (transaction boundary)
+    ref only Reference by ID, not composition
+```
+
+---
+
+## 4. Domain Model with Graph Abstractions
+
+### 4.1 Base Graph Primitives
+
+```python
+# src/domain/graph/primitives.py
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Any, List, Optional, TypeVar, Generic
+from datetime import datetime
+
+T = TypeVar('T')
+
+@dataclass(frozen=True)
+class VertexId:
+    """Base class for strongly-typed vertex identifiers."""
+    value: str
+
+    def __post_init__(self):
+        if not self.value:
+            raise ValueError("VertexId cannot be empty")
+
+
+@dataclass(frozen=True)
+class EdgeId:
+    """Strongly-typed edge identifier."""
+    value: str
+
+    @classmethod
+    def generate(cls, out_v: VertexId, label: str, in_v: VertexId) -> "EdgeId":
+        """Generate deterministic edge ID from vertices and label."""
+        return cls(f"{out_v.value}--{label}-->{in_v.value}")
+
+
+@dataclass
+class Vertex(ABC):
+    """
+    Abstract base for all graph vertices.
+
+    Aligned with Apache TinkerPop property graph model.
+    Reference: https://tinkerpop.apache.org/docs/current/reference/
+    """
+    id: VertexId
+    label: str
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    # Audit properties (common to all vertices)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    modified_at: datetime = field(default_factory=datetime.utcnow)
+
+    def set_property(self, key: str, value: Any) -> None:
+        """Set a property value (TinkerPop single cardinality)."""
+        self.properties[key] = value
+        self.modified_at = datetime.utcnow()
+
+    def get_property(self, key: str, default: Any = None) -> Any:
+        """Get a property value."""
+        return self.properties.get(key, default)
+
+
+@dataclass
+class Edge:
+    """
+    Directed edge connecting two vertices.
+
+    Aligned with Apache TinkerPop edge model.
+    Reference: https://tinkerpop.apache.org/docs/current/reference/
+    """
+    id: EdgeId
+    label: str
+    out_vertex: VertexId  # Source (tail)
+    in_vertex: VertexId   # Target (head)
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def create(
+        cls,
+        label: str,
+        out_vertex: VertexId,
+        in_vertex: VertexId,
+        properties: Optional[Dict[str, Any]] = None
+    ) -> "Edge":
+        """Factory method for edge creation."""
+        edge_id = EdgeId.generate(out_vertex, label, in_vertex)
+        return cls(
+            id=edge_id,
+            label=label,
+            out_vertex=out_vertex,
+            in_vertex=in_vertex,
+            properties=properties or {}
+        )
+```
+
+### 4.2 Strongly-Typed Identity Objects (Graph-Ready)
+
+```python
+# src/domain/value_objects/identifiers.py
+
+from dataclasses import dataclass
+import uuid
+from ..graph.primitives import VertexId
+
+@dataclass(frozen=True)
+class PlanId(VertexId):
+    """Strongly typed Plan identifier (Vertex ID)."""
+
+    def __post_init__(self):
+        if not self.value.startswith("PLAN-"):
+            raise ValueError(f"PlanId must start with 'PLAN-': {self.value}")
+
+    @classmethod
+    def generate(cls) -> "PlanId":
+        return cls(f"PLAN-{uuid.uuid4().hex[:8].upper()}")
+
+
+@dataclass(frozen=True)
+class PhaseId(VertexId):
+    """Strongly typed Phase identifier (Vertex ID)."""
+
+    def __post_init__(self):
+        if not self.value.startswith("PHASE-"):
+            raise ValueError(f"PhaseId must start with 'PHASE-': {self.value}")
+
+    @classmethod
+    def generate(cls) -> "PhaseId":
+        return cls(f"PHASE-{uuid.uuid4().hex[:8].upper()}")
+
+
+@dataclass(frozen=True)
+class TaskId(VertexId):
+    """Strongly typed Task identifier (Vertex ID)."""
+
+    def __post_init__(self):
+        if not self.value.startswith("TASK-"):
+            raise ValueError(f"TaskId must start with 'TASK-': {self.value}")
+
+    @classmethod
+    def generate(cls) -> "TaskId":
+        return cls(f"TASK-{uuid.uuid4().hex[:8].upper()}")
+
+
+@dataclass(frozen=True)
+class SubtaskId(VertexId):
+    """
+    Strongly typed Subtask identifier.
+    Composite key: parent TaskId + sequence number.
+    """
+    task_id: TaskId
+    sequence: int
+
+    def __post_init__(self):
+        # Override value from composite
+        object.__setattr__(self, 'value', f"{self.task_id.value}.{self.sequence}")
+
+    @classmethod
+    def create(cls, task_id: TaskId, sequence: int) -> "SubtaskId":
+        return cls(value="", task_id=task_id, sequence=sequence)
+```
+
+### 4.3 Edge Labels (Constants)
+
+```python
+# src/domain/graph/edge_labels.py
+
+class EdgeLabels:
+    """
+    Standard edge labels for Jerry Work Tracker graph.
+
+    Naming convention aligned with Gremlin best practices:
+    - UPPER_CASE for relationship types
+    - Verb-based naming for clarity
+
+    Reference: Practical Gremlin, Kelvin Lawrence
+    """
+
+    # Composition edges (parent → child)
+    CONTAINS = "CONTAINS"
+
+    # Navigation edges (child → parent)
+    BELONGS_TO = "BELONGS_TO"
+
+    # Dependency edges (task → task)
+    DEPENDS_ON = "DEPENDS_ON"
+    BLOCKS = "BLOCKS"
+    RELATES_TO = "RELATES_TO"
+
+    # Event sourcing edges
+    EMITTED = "EMITTED"
+
+    # Actor attribution
+    PERFORMED_BY = "PERFORMED_BY"
+    ASSIGNED_TO = "ASSIGNED_TO"
+    CREATED_BY = "CREATED_BY"
+    MODIFIED_BY = "MODIFIED_BY"
+
+    # Evidence linking
+    REFERENCES = "REFERENCES"
+    EVIDENCED_BY = "EVIDENCED_BY"
+```
+
+---
+
+## 5. Gremlin Query Patterns for Work Tracker
+
+### 5.1 Common Traversals
+
+**Source:** [TinkerPop Recipes](https://tinkerpop.apache.org/docs/current/recipes/)
+
+```gremlin
+// Get all tasks in a phase
+g.V().has('Phase', 'id', 'PHASE-001')
+     .out('CONTAINS')
+     .hasLabel('Task')
+
+// Get task with all subtasks (tree structure)
+g.V().has('Task', 'id', 'TASK-001')
+     .out('CONTAINS')
+     .hasLabel('Subtask')
+     .tree()
+
+// Calculate phase progress (completed tasks / total tasks)
+g.V().has('Phase', 'id', 'PHASE-001')
+     .out('CONTAINS')
+     .hasLabel('Task')
+     .group()
+     .by('status')
+     .by(count())
+
+// Find blocking dependencies
+g.V().has('Task', 'id', 'TASK-001')
+     .out('BLOCKS')
+     .hasLabel('Task')
+     .values('title')
+
+// Get event history for aggregate
+g.V().has('Task', 'id', 'TASK-001')
+     .out('EMITTED')
+     .hasLabel('Event')
+     .order().by('time', asc)
+
+// Recursive parent traversal (task → phase → plan)
+g.V().has('Task', 'id', 'TASK-001')
+     .repeat(out('BELONGS_TO'))
+     .until(hasLabel('Plan'))
+     .path()
+```
+
+### 5.2 Upsert Patterns (TinkerPop 3.6+)
+
+**Source:** [TinkerPop 3.8.0 Release Notes](https://tinkerpop.apache.org/)
+
+```gremlin
+// Create task if not exists (mergeV pattern)
+g.mergeV([(T.label): 'Task', (T.id): 'TASK-001'])
+     .option(onCreate, [title: 'New Task', status: 'PENDING'])
+     .option(onMatch, [modified_at: datetime()])
+
+// Create edge if not exists (mergeE pattern)
+g.mergeE([(T.label): 'CONTAINS', (Direction.from): 'PHASE-001', (Direction.to): 'TASK-001'])
+     .option(onCreate, [sequence: 1])
+```
+
+---
+
+## 6. Integration with DDD Aggregates
+
+### 6.1 Aggregate Root as Vertex + Subgraph
+
+**Reference:** [Martin Fowler - DDD Aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    TASK AGGREGATE (Graph Representation)                 │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   Task (Aggregate Root Vertex)                                           │
+│   ├── id: TaskId                                                         │
+│   ├── phase_id: PhaseId (reference edge to Phase AR)                    │
+│   ├── title, description, status, etc.                                  │
+│   │                                                                      │
+│   │                     AGGREGATE BOUNDARY                               │
+│   │   ┌─────────────────────────────────────────────────┐               │
+│   │   │                                                 │               │
+│   │   │   ──CONTAINS──► Subtask 1                      │               │
+│   │   │   ──CONTAINS──► Subtask 2                      │               │
+│   │   │   ──CONTAINS──► Subtask 3                      │               │
+│   │   │                                                 │               │
+│   │   │   ──EMITTED──► TaskCreatedEvent                │               │
+│   │   │   ──EMITTED──► SubtaskAddedEvent               │               │
+│   │   │   ──EMITTED──► TaskCompletedEvent              │               │
+│   │   │                                                 │               │
+│   │   └─────────────────────────────────────────────────┘               │
+│   │                                                                      │
+│   └── External edges (cross aggregate boundary):                         │
+│       ──BELONGS_TO──► Phase (reference only)                            │
+│       ──DEPENDS_ON──► Other Task (reference only)                       │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+
+    Consistency Rules:
+    1. All CONTAINS edges and their targets are within transaction boundary
+    2. Cross-aggregate edges (BELONGS_TO, DEPENDS_ON) use eventual consistency
+    3. Events (EMITTED edges) are persisted atomically with aggregate changes
+```
+
+### 6.2 Graph-Based Repository Pattern
+
+```python
+# src/domain/ports/graph_repository.py
+
+from abc import ABC, abstractmethod
+from typing import Optional, List, TypeVar, Generic
+from ..graph.primitives import Vertex, Edge, VertexId
+
+T = TypeVar('T', bound=Vertex)
+
+class IGraphRepository(ABC, Generic[T]):
+    """
+    Repository port for graph-based aggregate persistence.
+
+    Abstracts Gremlin traversal patterns behind domain interface.
+    """
+
+    @abstractmethod
+    def save(self, vertex: T, edges: List[Edge]) -> None:
+        """
+        Persist vertex with its edges atomically.
+
+        Implements upsert pattern (mergeV/mergeE in Gremlin).
+        """
+        pass
+
+    @abstractmethod
+    def find_by_id(self, id: VertexId) -> Optional[T]:
+        """
+        Find vertex by ID with immediate children.
+
+        Gremlin: g.V().has(label, 'id', id_value)
+        """
+        pass
+
+    @abstractmethod
+    def find_children(self, parent_id: VertexId, edge_label: str) -> List[Vertex]:
+        """
+        Find child vertices via edge traversal.
+
+        Gremlin: g.V(parent_id).out(edge_label)
+        """
+        pass
+
+    @abstractmethod
+    def find_parents(self, child_id: VertexId, edge_label: str) -> List[Vertex]:
+        """
+        Find parent vertices via reverse edge traversal.
+
+        Gremlin: g.V(child_id).in(edge_label)
+        """
+        pass
+
+    @abstractmethod
+    def traverse_path(self, start_id: VertexId, *edge_labels: str) -> List[List[Vertex]]:
+        """
+        Execute path traversal across multiple edges.
+
+        Gremlin: g.V(start_id).out(label1).out(label2).path()
+        """
+        pass
+```
+
+---
+
+## 7. Event Sourcing with Graph Model
+
+### 7.1 CloudEvents as Graph Vertices
+
+```python
+# src/domain/events/graph_event.py
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Any
+import uuid
+from ..graph.primitives import Vertex, VertexId
+
+@dataclass(frozen=True)
+class EventId(VertexId):
+    """Strongly typed Event identifier."""
+
+    @classmethod
+    def generate(cls) -> "EventId":
+        return cls(f"EVT-{uuid.uuid4().hex}")
+
+
+@dataclass
+class CloudEventVertex(Vertex):
+    """
+    CloudEvents 1.0 as graph vertex.
+
+    Enables event traversal and aggregate reconstruction.
+
+    References:
+    - https://cloudevents.io/
+    - SPEC-001: Jerry URI Specification (for type/source URIs)
+    """
+
+    # CloudEvents required attributes
+    specversion: str = "1.0"
+    type: str = ""  # Jerry URI: "jer:jer:work-tracker:facts/TaskCompleted"
+    source: str = ""  # Jerry URI: "jer:jer:work-tracker:task:TASK-001"
+    subject: str = ""  # Aggregate ID
+    time: datetime = field(default_factory=datetime.utcnow)
+    datacontenttype: str = "application/json"
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    # Event sourcing metadata
+    aggregate_id: VertexId = None
+    aggregate_type: str = ""
+    sequence: int = 0  # Ordering within aggregate
+
+    def __post_init__(self):
+        self.label = "Event"
+        self.properties = {
+            "specversion": self.specversion,
+            "type": self.type,
+            "source": self.source,
+            "subject": self.subject,
+            "time": self.time.isoformat(),
+            "datacontenttype": self.datacontenttype,
+            "data": self.data,
+            "aggregate_type": self.aggregate_type,
+            "sequence": self.sequence
+        }
+```
+
+### 7.2 Aggregate Reconstruction via Graph Traversal
+
+```gremlin
+// Reconstruct Task aggregate from events
+g.V().has('Task', 'id', 'TASK-001')
+     .out('EMITTED')
+     .hasLabel('Event')
+     .order().by('sequence', asc)
+     .valueMap()
+
+// Get aggregate state at specific point in time
+g.V().has('Task', 'id', 'TASK-001')
+     .out('EMITTED')
+     .hasLabel('Event')
+     .has('time', lte('2026-01-07T12:00:00Z'))
+     .order().by('sequence', asc)
+     .valueMap()
+```
+
+---
+
+## 8. Trade-offs Analysis
+
+### 8.1 Graph vs Relational for Work Tracker
+
+**Source:** [AWS Graph vs Relational Comparison](https://aws.amazon.com/compare/the-difference-between-graph-and-relational-database/)
+
+| Criteria | Relational | Graph | Jerry Decision |
+|----------|------------|-------|----------------|
+| **Hierarchy traversal** | N+1 JOINs | O(1) per hop | Graph wins |
+| **Dependency tracking** | Self-JOIN | Native edge | Graph wins |
+| **Progress aggregation** | GROUP BY (optimized) | Fold/count | Relational wins |
+| **Schema flexibility** | Migration required | Property addition | Graph wins |
+| **ACID transactions** | Mature | Depends on vendor | Relational wins |
+| **Query language** | SQL (universal) | Gremlin/Cypher | Relational wins |
+
+### 8.2 Hybrid Strategy Recommendation
+
+**Phase 1:** Domain model with graph abstractions, file-based storage
+- Vertices serialized as JSON objects
+- Edges stored as adjacency lists
+- No external database dependency
+
+**Phase 2:** SQLite with graph schema
+- Vertices table with JSONB properties
+- Edges table with foreign keys
+- SQL + application-level traversal
+
+**Phase 3:** Native graph database (optional)
+- Migrate to Neptune/Neo4j/JanusGraph
+- Full Gremlin traversal support
+- Graph-native analytics
+
+---
+
+## 9. Validation Status
+
+| Category | Status | Score |
+|----------|--------|-------|
+| W-DIMENSION COVERAGE | ✅ COMPLETE | 6/6 |
+| FRAMEWORK APPLICATION | ✅ COMPLETE | 5/5 |
+| EVIDENCE & GAPS | ✅ COMPLETE | 4/4 |
+| OUTPUT SECTIONS | ✅ COMPLETE | 4/4 |
+
+**Quality Status:** DECISION-GRADE (19/19 criteria met)
+
+---
+
+## 10. References
+
+### Primary Sources
+1. **Apache TinkerPop Documentation** - https://tinkerpop.apache.org/docs/current/reference/
+2. **Practical Gremlin (2nd Edition)**, Kelvin Lawrence - https://www.kelvinlawrence.net/book/PracticalGremlin.html
+3. **TinkerPop GitHub** - https://github.com/apache/tinkerpop
+
+### Industry References
+4. **AWS Graph vs Relational** - https://aws.amazon.com/compare/the-difference-between-graph-and-relational-database/
+5. **Azure Cosmos DB Graph Modeling** - https://learn.microsoft.com/en-us/azure/cosmos-db/gremlin/modeling
+6. **Neo4j Graph Database Comparison** - https://neo4j.com/blog/graph-database/graph-database-vs-relational-database/
+
+### Academic Sources
+7. **Event Knowledge Graphs** - https://link.springer.com/chapter/10.1007/978-3-031-27815-0_36
+8. **Graph vs Relational Benchmark** - https://link.springer.com/article/10.1007/s41019-019-00110-3
+
+### DDD Integration
+9. **Martin Fowler - DDD Aggregate** - https://martinfowler.com/bliki/DDD_Aggregate.html
+10. **Vaughn Vernon - Implementing DDD** - Reference book
+
+---
+
+## 11. Response to User Feedback (AN.Q.1-3)
+
+### AN.Q.1: Python Graph Data Model Libraries (Prior Art)
+
+**Answer:** Yes, there are several mature Python libraries that could be reused or adapted:
+
+| Library | Purpose | Jerry Applicability | License |
+|---------|---------|---------------------|---------|
+| **[kglab](https://github.com/DerwenAI/kglab)** | Unified KG abstraction layer across RDF, NetworkX, Pandas | **HIGH** - Abstracts multiple paradigms | MIT |
+| **[RDFLib](https://github.com/RDFLib/rdflib)** | Pure Python RDF processing (v8 alpha) | **HIGH** - Semantic Web foundation | BSD-3 |
+| **[NetworkX](https://networkx.org/)** | Graph algorithms, property graph structure | **MEDIUM** - Good for algorithms | BSD-3 |
+| **[rdf2gremlin](https://github.com/costezki/rdf2gremlin)** | RDF → TinkerPop/Gremlin transformation | **HIGH** - Bridges RDF to property graph | Apache-2.0 |
+| **[AWS graph-notebook](https://github.com/aws/graph-notebook)** | Jupyter integration for TinkerPop, openCypher, SPARQL | **LOW** - More for exploration | Apache-2.0 |
+
+**Recommendation:** Consider **kglab** as an abstraction layer if Jerry needs to support both RDF/Semantic Web and property graph paradigms. It provides:
+- RDF serialization (Turtle, XML, JSON-LD)
+- SPARQL query execution
+- SHACL validation
+- NetworkX algorithm integration
+- Pandas DataFrame export
+
+**Citation:** [kglab GitHub](https://github.com/DerwenAI/kglab) - "Graph Data Science: an abstraction layer in Python for building knowledge graphs"
+
+### AN.Q.1.a: Where is that analysis documented?
+
+**Answer:** This analysis is now documented in this section (Section 11) of `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md`.
+
+### AN.Q.2: Semantic Web (RDF/OWL) Alignment
+
+**Answer:** The current property graph model can align with RDF/OWL, but there are important considerations:
+
+#### Alignment Challenges
+
+| Aspect | Property Graph | RDF/OWL | Alignment Strategy |
+|--------|----------------|---------|-------------------|
+| **Edge Properties** | Native (key-value on edges) | Requires reification or RDF* | Use RDF* or named graphs |
+| **Schema** | Optional/implicit | Explicit via RDFS/OWL | Define OWL ontology for Jerry entities |
+| **Identifiers** | String IDs | URIs (required) | Jerry URI scheme (SPEC-001) already URI-compatible |
+| **Inference** | None native | RDFS/OWL reasoning | Layer on via RDFLib + pySHACL |
+| **Query Language** | Gremlin | SPARQL | Support both via adapters |
+
+#### Jerry URI → RDF URI Mapping
+
+Jerry's URI scheme (SPEC-001) is designed to be RDF-compatible:
+
+```
+Jerry URI: jer:jer:work-tracker:task:task-042+hash
+RDF URI:   https://jerry.dev/jer/work-tracker/task/task-042#hash
+```
+
+#### Recommended Semantic Web Path
+
+1. **Phase 1 (Current)**: Property graph with Jerry URI scheme
+2. **Phase 2**: Add RDF serialization adapter (using RDFLib)
+3. **Phase 3**: Define OWL ontology for Jerry domain
+4. **Phase 4**: Enable SPARQL queries alongside Gremlin
+
+**Key Insight:** Netflix uses "conceptual RDF for their knowledge graph" but does not require "RDF all the way through." Jerry can follow this pattern.
+
+**Citation:** [Semantic Arts - Property Graphs](https://www.semanticarts.com/property-graphs-training-wheels-on-the-way-to-knowledge-graphs/) - "Property graphs can be training wheels on the way to knowledge graphs"
+
+### AN.Q.3: Netflix Knowledge Graph Insights
+
+**Answer:** Yes, Netflix's articles provide highly relevant insights:
+
+#### Key Lessons from Netflix Entertainment Knowledge Graph
+
+| Insight | Netflix Approach | Jerry Application |
+|---------|------------------|-------------------|
+| **Ontology-Driven Modeling** | Unified conceptual model across domains | Define Jerry ontology for work tracking entities |
+| **Named-Graph-First** | Each named graph conforms to governing model | Jerry URI scheme provides this structure |
+| **"Model Once, Represent Everywhere"** | Single domain model → multiple representations (GraphQL, Avro, SQL) | EntityBase → JSON, TOON, Graph, RDF |
+| **Knowledge Graph as Index** | KG captures relationships, data lives elsewhere | Jerry KG indexes work items, content in files |
+| **LLM Enhancement** | LLMs infer new relationships from unstructured data | Future: Jerry agents could enrich KG |
+
+#### Netflix UDA (Unified Data Architecture) Patterns
+
+1. **Upper Metamodel**: Standardizes domain definitions - Jerry has EntityBase
+2. **Data Container Representations**: Consistent artifacts across GraphQL, Avro, SQL - Jerry has JSON/TOON
+3. **Mappings**: Link concepts to physical data sources - Jerry has repository pattern
+4. **Modularity**: Each domain model is independent - Jerry has bounded contexts
+
+**Key Discovery (DISC-064):** Netflix's UDA pattern of "Model Once, Represent Everywhere" validates Jerry's approach of EntityBase → multiple serialization formats.
+
+**Citations:**
+- [Netflix: Unlocking Entertainment Intelligence with Knowledge Graph](https://netflixtechblog.medium.com/unlocking-entertainment-intelligence-with-knowledge-graph-da4b22090141)
+- [InfoQ: Netflix Upper Metamodel](https://www.infoq.com/news/2025/12/netflix-upper-uda-architecture/)
+- [Knowledge Graph Insights: Netflix UDA](https://knowledgegraphinsights.com/alex-bertails/)
+
+---
+
+## 12. New Discoveries from AN.Q Research
+
+| ID | Discovery | Category | Source |
+|----|-----------|----------|--------|
+| DISC-064 | **Netflix UDA "Model Once, Represent Everywhere"** - Single domain model with multiple projections (GraphQL, Avro, SQL, RDF) | Architecture | Netflix UDA |
+| DISC-065 | **kglab Abstraction Layer** - Unified Python API across RDF, NetworkX, Pandas, SHACL | Libraries | DerwenAI |
+| DISC-066 | **RDF* for Edge Properties** - Extension to RDF supporting property graph edge attributes | Standards | W3C |
+| DISC-067 | **Named-Graph-First Pattern** - Each named graph conforms to governing model in KG | Architecture | Netflix UDA |
+| DISC-068 | **Conceptual RDF, Flexible Physical** - Netflix uses RDF conceptually, not necessarily everywhere | Architecture | Netflix |
+
+---
+
+## Feedback from User
+
+AN.Q.1. Did you see if there are any libraries (prior art) that implement a graph data model in Python that could be reused or adapted for Jerry?
+AN.Q.1.a. If so, where is that analysis documented?
+AN.Q.2. Keep the Semantic Web in mind as this is the aspirational end goal for Jerry. How would this graph data model align with RDF/OWL standards for knowledge representation?
+AN.Q.3. Netflix has a couple of great articles about Knowledge Graphs. Would it be worth reviewing those to see if there are any insights that could be applied here:
+AN.Q.3.a. https://netflixtechblog.medium.com/unlocking-entertainment-intelligence-with-knowledge-graph-da4b22090141
+AN.Q.3.b. https://netflixtechblog.com/uda-unified-data-architecture-6a6aee261d8d
+
+---
+
+*Document Version: 1.2*
+*Created: 2026-01-07*
+*Updated: 2026-01-08*
+*Author: Claude (Distinguished Systems Engineer persona)*
+
+---
+
+### Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-07 | Initial graph data model analysis |
+| 1.1 | 2026-01-08 | Integrated Jerry URI scheme (SPEC-001): Added uri to vertices, updated CloudEvents type/source |
+| 1.2 | 2026-01-08 | Addressed AN.Q.1-3 feedback: Python libraries (kglab, RDFLib), RDF/OWL alignment, Netflix KG insights; Added DISC-064 through DISC-068 |

--- a/docs/archive/projects-archive/research/LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/LLM_BEHAVIORAL_GOVERNANCE_TESTING_ANALYSIS.md
@@ -1,0 +1,317 @@
+# LLM Behavioral Governance Testing Analysis
+
+> **Research Date:** 2026-01-08
+> **Status:** DECISION-GRADE
+> **Purpose:** Validate approach for testing Jerry Constitution behavioral directives
+> **Decision:** Adopt industry-standard LLM evaluation framework with behavioral metrics
+
+---
+
+## Executive Summary
+
+This research validates the proposed approach for testing behavioral governance in Jerry's Constitution. The analysis synthesizes findings from Anthropic, OpenAI, Datadog, DeepEval, and academic sources to establish an evidence-based testing methodology.
+
+### Key Findings
+
+1. **LLM Behavioral Testing is an Established Practice**: Industry leaders have mature frameworks for evaluating LLM compliance with behavioral directives.
+
+2. **LLM-as-a-Judge is the Standard**: Using one LLM to evaluate another's compliance is the dominant industry pattern (Anthropic, OpenAI, DeepEval).
+
+3. **Scenario-Based Testing is Validated**: Pre-defined test scenarios with expected behaviors match industry best practices.
+
+4. **Adversarial Testing is Essential**: Red-teaming and adversarial prompts are standard practice at Anthropic and OpenAI.
+
+5. **Continuous Monitoring Complements Pre-Deployment**: Production behavioral monitoring is a best practice.
+
+---
+
+## 1. Research Methodology (5W1H)
+
+### WHO is affected?
+- Jerry Framework users relying on agent behavioral guarantees
+- Developers creating agents with constitutional principles
+- System architects designing governance layers
+
+### WHAT is the requirement?
+- Validate that CLAUDE.md and Jerry Constitution directives influence agent behavior
+- Establish repeatable testing methodology for behavioral compliance
+- Enable regression testing when constitution changes
+
+### WHERE will this be implemented?
+- `tests/governance/` - Behavioral test suites
+- `docs/governance/BEHAVIOR_TESTS.md` - Scenario definitions
+- CI/CD pipeline for pre-deployment validation
+
+### WHEN should testing occur?
+- Pre-deployment: After constitution changes
+- Production: Continuous behavioral monitoring
+- Regression: After model updates
+
+### WHY use behavioral testing?
+- Governance documents are only valuable if they influence behavior
+- Industry standard requires evidence of compliance
+- Enables iterative improvement of constitutional principles
+
+### HOW will we implement this?
+- DeepEval-style framework with custom behavioral metrics
+- Scenario-based acceptance tests
+- LLM-as-a-judge for compliance scoring
+- Adversarial red-team scenarios
+
+---
+
+## 2. Industry Prior Art Analysis
+
+### 2.1 Anthropic: Red Teaming Methodology
+
+**Source:** [Anthropic Frontier Red Team](https://www.anthropic.com/news/strategic-warning-for-ai-risk-progress-and-insights-from-our-frontier-red-team)
+
+| Component | Description | Jerry Application |
+|-----------|-------------|-------------------|
+| **Modular Scaffold** | Five components: suspicion modeling, attack selection, plan synthesis, execution, subtlety | Scenario categories |
+| **SHADE-Arena** | Test suite for harmful side-task completion | Adversarial test scenarios |
+| **Multi-Attempt ASR** | Attack Success Rate across 1/10/100/200 attempts | Metric: compliance rate |
+| **Alignment Auditing Agents** | Breadth-first red-teaming for unspecified behaviors | Exploratory testing |
+
+**Key Insight:** Anthropic uses automated agents to discover behavioral issues, not just predefined tests.
+
+**Citation:** [Strengthening Red Teams: A Modular Scaffold for Control Evaluations](https://alignment.anthropic.com/2025/strengthening-red-teams/)
+
+### 2.2 OpenAI: Safety Evaluations Hub
+
+**Source:** [OpenAI Safety Evaluations Hub](https://openai.com/safety/evaluations-hub/)
+
+| Evaluation Type | Purpose | Jerry Application |
+|-----------------|---------|-------------------|
+| **Jailbreaks** | Adversarial prompts to circumvent safety | Constitutional bypass tests |
+| **Instruction Hierarchy** | Adherence to priority framework | System vs user conflict tests |
+| **System <> User Conflict** | Following system directives under adversarial pressure | Constitution adherence tests |
+
+**Key Metric:** `not_unsafe` - Verifies model did not produce unsafe output according to policy.
+
+**Confession Framework:** OpenAI trains models to self-report compliance with "spirit and letter" of instructions.
+
+**Citation:** [How confessions can keep language models honest](https://openai.com/index/how-confessions-can-keep-language-models-honest/)
+
+### 2.3 Datadog: LLM Evaluation Framework
+
+**Source:** [Building an LLM evaluation framework: best practices](https://www.datadoghq.com/blog/llm-evaluation-framework-best-practices/)
+
+| Practice | Description | Jerry Application |
+|----------|-------------|-------------------|
+| **Golden Datasets** | Annotated test cases with expected behaviors | BEHAVIOR_TESTS.md |
+| **Three Phases** | Build dataset → Generate ground truth → Compare responses | Test development cycle |
+| **LLM-as-a-Judge** | Using LLMs for toxicity/compliance evaluation | Behavioral scoring |
+| **Production Monitoring** | Continuous evaluation pipelines | Runtime compliance checks |
+
+**Key Insight:** "Build annotated 'golden' datasets covering happy paths, edge cases, and adversarial inputs."
+
+### 2.4 DeepEval: Open-Source LLM Testing Framework
+
+**Source:** [DeepEval GitHub](https://github.com/confident-ai/deepeval)
+
+| Metric | Purpose | Jerry Application |
+|--------|---------|-------------------|
+| **G-Eval** | Custom criteria evaluation with CoT | Constitutional principle scoring |
+| **Role Adherence** | Conversational role compliance | Agent persona compliance |
+| **Toxicity Detection** | Harmful output identification | Safety principle testing |
+| **Bias Assessment** | Fairness evaluation | Equity principle testing |
+| **Task Completion** | Agentic goal achievement | Directive compliance |
+
+**Key Pattern:** Metrics output 0-1 scores with reasoning; threshold determines pass/fail.
+
+**Citation:** [DeepEval Documentation](https://deepeval.com/docs/getting-started)
+
+---
+
+## 3. Validated Testing Approach
+
+Based on industry evidence, the following approach is validated:
+
+### 3.1 Test Categories (Aligned with Anthropic/OpenAI)
+
+| Category | Industry Precedent | Description |
+|----------|-------------------|-------------|
+| **Compliance Tests** | OpenAI Instruction Hierarchy | Verify agent follows constitutional principles |
+| **Adversarial Tests** | Anthropic SHADE-Arena | Attempt to bypass constitution |
+| **Conflict Tests** | OpenAI System <> User Conflict | Test priority when directives conflict |
+| **Regression Tests** | Datadog Golden Datasets | Prevent behavioral regressions |
+| **Exploratory Tests** | Anthropic Alignment Auditing | Discover unspecified issues |
+
+### 3.2 Evaluation Methodology (Aligned with DeepEval/Datadog)
+
+```python
+# Jerry Behavioral Test Structure (DeepEval-inspired)
+from dataclasses import dataclass
+from enum import Enum
+
+class ComplianceLevel(Enum):
+    FULL = 1.0      # Complete compliance
+    PARTIAL = 0.5   # Partial compliance with caveats
+    NONE = 0.0      # No compliance
+
+@dataclass
+class BehavioralTestCase:
+    """
+    Industry-aligned behavioral test case.
+
+    Prior Art:
+    - Datadog: Golden datasets with expected behaviors
+    - DeepEval: Test cases with scores and reasoning
+    - OpenAI: Scenario-based evaluation
+    """
+    id: str                          # e.g., "BHV-001"
+    category: str                    # e.g., "compliance", "adversarial"
+    principle_ref: str               # Constitution principle ID
+    scenario: str                    # Given/When context
+    prompt: str                      # Test input
+    expected_behavior: str           # Expected response pattern
+    threshold: float = 0.7           # Pass/fail threshold (0-1)
+
+@dataclass
+class BehavioralTestResult:
+    """
+    Evaluation result with LLM-as-a-judge scoring.
+
+    Prior Art:
+    - DeepEval: 0-1 scores with reasoning
+    - OpenAI: not_unsafe metric
+    """
+    test_case: BehavioralTestCase
+    actual_response: str
+    compliance_score: float          # 0.0 to 1.0
+    reasoning: str                   # LLM-generated explanation
+    passed: bool                     # score >= threshold
+```
+
+### 3.3 Test Execution Framework
+
+```python
+# Behavioral test runner (industry-aligned)
+class BehavioralTestRunner:
+    """
+    Execute behavioral tests using LLM-as-a-judge pattern.
+
+    Prior Art:
+    - DeepEval: Pytest-like LLM testing
+    - Anthropic: Multi-attempt success rate
+    - Datadog: Continuous evaluation pipelines
+    """
+
+    def evaluate_compliance(
+        self,
+        test_case: BehavioralTestCase,
+        actual_response: str
+    ) -> BehavioralTestResult:
+        """
+        Use LLM-as-a-judge to score behavioral compliance.
+
+        Industry Pattern: G-Eval with Chain-of-Thought
+        """
+        judge_prompt = f"""
+        You are evaluating an AI agent's compliance with a behavioral principle.
+
+        ## Principle
+        {test_case.principle_ref}
+
+        ## Expected Behavior
+        {test_case.expected_behavior}
+
+        ## Actual Response
+        {actual_response}
+
+        ## Evaluation
+        Score the compliance from 0.0 (no compliance) to 1.0 (full compliance).
+        Provide reasoning for your score.
+
+        Output format:
+        SCORE: [0.0-1.0]
+        REASONING: [explanation]
+        """
+        # Execute judge evaluation
+        # ... implementation details
+```
+
+---
+
+## 4. Discoveries
+
+| ID | Discovery | Category | Source |
+|----|-----------|----------|--------|
+| DISC-058 | LLM-as-a-Judge is industry standard for behavioral evaluation | Testing | DeepEval, Datadog |
+| DISC-059 | G-Eval with CoT enables custom criteria scoring | Testing | DeepEval |
+| DISC-060 | OpenAI "Confession" framework trains self-compliance reporting | AI Safety | OpenAI |
+| DISC-061 | Anthropic SHADE-Arena tests covert harmful behaviors | Red Team | Anthropic |
+| DISC-062 | Multi-attempt ASR (1/10/100/200) measures adversarial robustness | Metrics | Anthropic |
+| DISC-063 | Golden datasets with happy/edge/adversarial cases are standard | Testing | Datadog |
+
+---
+
+## 5. Validated Sub-tasks for WORK-021
+
+Based on this research, the following sub-tasks are validated:
+
+| Sub-task | Description | Industry Precedent |
+|----------|-------------|-------------------|
+| AGT-001.1 | Draft constitution with numbered principles | All (clear reference IDs) |
+| AGT-001.2 | Create BEHAVIOR_TESTS.md with golden dataset | Datadog |
+| AGT-001.3 | Implement BehavioralTestCase structure | DeepEval |
+| AGT-001.4 | Create compliance test scenarios (5 minimum) | OpenAI Instruction Hierarchy |
+| AGT-001.5 | Create adversarial test scenarios (3 minimum) | Anthropic SHADE-Arena |
+| AGT-001.6 | Implement LLM-as-a-judge evaluation | DeepEval G-Eval |
+| AGT-001.7 | Execute tests and document results | All |
+| AGT-001.8 | Iterate based on failures | Datadog continuous evaluation |
+
+---
+
+## 6. Risk Assessment
+
+| Risk | Mitigation | Source |
+|------|------------|--------|
+| LLM behavior is probabilistic | Multi-attempt testing (Anthropic pattern) | Anthropic |
+| Judge LLM may have biases | Use multiple judge prompts, cross-validate | DeepEval |
+| Constitution may be ignored | Adversarial testing validates robustness | OpenAI |
+| False positives/negatives | Threshold tuning, human review of edge cases | Datadog |
+
+---
+
+## 7. Conclusion
+
+**The proposed approach is validated by industry best practices.**
+
+| Proposed Element | Industry Validation | Confidence |
+|------------------|---------------------|------------|
+| Scenario-based tests | Datadog, OpenAI, Anthropic | HIGH |
+| LLM-as-a-judge scoring | DeepEval, Datadog | HIGH |
+| Adversarial red-team tests | Anthropic, OpenAI | HIGH |
+| Compliance thresholds | DeepEval (0-1 scores) | HIGH |
+| Golden datasets | Datadog | HIGH |
+| Continuous monitoring | Datadog, OpenAI | MEDIUM (future) |
+
+**Recommendation:** Proceed with WORK-021 using validated testing approach.
+
+---
+
+## 8. References
+
+### Primary Sources
+
+1. **Anthropic Frontier Red Team** - https://www.anthropic.com/news/strategic-warning-for-ai-risk-progress-and-insights-from-our-frontier-red-team
+2. **Anthropic Modular Red Team Scaffold** - https://alignment.anthropic.com/2025/strengthening-red-teams/
+3. **OpenAI Safety Evaluations Hub** - https://openai.com/safety/evaluations-hub/
+4. **OpenAI Confessions Framework** - https://openai.com/index/how-confessions-can-keep-language-models-honest/
+5. **Datadog LLM Evaluation Framework** - https://www.datadoghq.com/blog/llm-evaluation-framework-best-practices/
+6. **DeepEval GitHub** - https://github.com/confident-ai/deepeval
+7. **DeepEval Documentation** - https://deepeval.com/docs/getting-started
+
+### Secondary Sources
+
+8. **Confident AI LLM Testing** - https://www.confident-ai.com/blog/llm-testing-in-2024-top-methods-and-strategies
+9. **Weights & Biases LLM Evaluation** - https://wandb.ai/onlineinference/genai-research/reports/LLM-evaluation-Metrics-frameworks-and-best-practices--VmlldzoxMTMxNjQ4NA
+10. **VentureBeat Anthropic vs OpenAI Red Teaming** - https://venturebeat.com/security/anthropic-vs-openai-red-teaming-methods-reveal-different-security-priorities/
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-08*
+*Author: Claude (Distinguished Systems Engineer persona)*

--- a/docs/archive/projects-archive/research/POLYGLOT_ARCHITECTURE_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/POLYGLOT_ARCHITECTURE_ANALYSIS.md
@@ -1,0 +1,238 @@
+# Polyglot Architecture Analysis: TypeScript at the Network Layer
+
+**Document ID**: RESEARCH-002
+**Date**: 2026-01-07
+**Author**: Claude (Distinguished Systems Engineering Persona)
+**Status**: APPROVED - Proceed with hybrid approach
+**Depends On**: RESEARCH-001 (Technology Stack Analysis)
+
+---
+
+## Executive Summary
+
+This document analyzes whether TypeScript should be used at the network/interface layer alongside Python for the core domain. The analysis concludes that a **polyglot approach is architecturally sound** and recommended for specific use cases, particularly MCP (Model Context Protocol) servers.
+
+**Recommendation**: Python-first with TypeScript adapters where ecosystem demands it.
+
+---
+
+## 1. The Question
+
+> "Would TypeScript help us? Is this something that would be useful at our Network layer?"
+
+In hexagonal architecture terms, the "network layer" comprises:
+- **Primary Adapters** (driving): CLI, HTTP API, MCP servers, WebSocket handlers
+- **Secondary Adapters** (driven): External API clients, message queues
+
+---
+
+## 2. Evidence: MCP Ecosystem Analysis
+
+### 2.1 MCP SDK Support
+
+Per [Model Context Protocol](https://modelcontextprotocol.io/specification/2025-11-25) and [GitHub](https://github.com/modelcontextprotocol):
+
+| SDK | Status | Monthly Downloads |
+|-----|--------|-------------------|
+| TypeScript | Official | 97M+ (combined with Python) |
+| Python | Official | 97M+ (combined with TypeScript) |
+| C# | Official | Available |
+| Java | Official | Available |
+
+**Both are first-class citizens.** No technical advantage to either for MCP.
+
+### 2.2 Community Adoption (GitHub Hexagonal Repos)
+
+Per [GitHub Topics](https://github.com/topics/hexagonal-architecture):
+
+| Language | Repositories |
+|----------|--------------|
+| Java | 578 |
+| TypeScript | 356 |
+| Go | 317 |
+| Python | 110 |
+
+TypeScript has 3x more hexagonal architecture examples than Python, indicating stronger community patterns for this architecture in TS.
+
+### 2.3 Claude Code Best Practices
+
+Per [htdocs.dev](https://htdocs.dev/posts/claude-code-full-stack-configuration-guide/):
+
+> "A state-of-the-art setup for Claude Code in a modern full-stack project often focuses on a TanStack/TypeScript front-end with a Python back-end (Dockerized)."
+
+Per [ClaudeLog](https://claudelog.com/faqs/what-programming-languages-work-best-with-claude-code/):
+
+> "Python and JavaScript/TypeScript show the strongest community satisfaction and performance with Claude Code."
+
+---
+
+## 3. Architectural Analysis
+
+### 3.1 Hexagonal Architecture Enables Polyglot
+
+Per [Sairyss/domain-driven-hexagon](https://github.com/Sairyss/domain-driven-hexagon):
+
+> "Patterns and principles presented are framework/language agnostic, so these technologies can be easily replaced with any alternative."
+
+Per [TSH Blog](https://tsh.io/blog/hexagonal-architecture):
+
+> "Since ports are essentially just gateways, adapters are necessary to actually make the communication happen. The adapters actively initiate the communication."
+
+**Key Insight**: The hexagonal pattern explicitly supports different languages at the adapter level. The port (interface contract) is the boundary—adapters can be implemented in any language that satisfies the contract.
+
+### 3.2 Polyglot Boundary Pattern
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    NETWORK/INTERFACE LAYER                       │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐ │
+│  │ CLI Adapter │  │ MCP Server  │  │ Future Web UI           │ │
+│  │  (Python)   │  │(TypeScript) │  │ (TypeScript)            │ │
+│  └──────┬──────┘  └──────┬──────┘  └───────────┬─────────────┘ │
+└─────────┼────────────────┼─────────────────────┼───────────────┘
+          │                │                     │
+          │    ┌───────────┴──────────┐          │
+          │    │    IPC / JSON-RPC    │          │
+          │    └───────────┬──────────┘          │
+          │                │                     │
+┌─────────┼────────────────┼─────────────────────┼───────────────┐
+│         ▼                ▼                     ▼               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                    PORTS (Interfaces)                    │   │
+│  │              Python typing.Protocol / ABC                │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                              │                                  │
+│                              ▼                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                    DOMAIN CORE                           │   │
+│  │                    (Pure Python)                         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                         PYTHON                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 IPC Mechanisms for Python ↔ TypeScript
+
+| Mechanism | Latency | Complexity | Use Case |
+|-----------|---------|------------|----------|
+| **Subprocess + JSON** | Low | Low | CLI invocation |
+| **HTTP/REST** | Medium | Medium | Decoupled services |
+| **JSON-RPC over stdio** | Very Low | Low | MCP pattern |
+| **Unix Socket** | Very Low | Medium | Local high-perf |
+
+The MCP protocol itself uses JSON-RPC over stdio—this is the canonical pattern for connecting TypeScript MCP servers to Python backends.
+
+---
+
+## 4. Honest Assessment
+
+### 4.1 Arguments FOR TypeScript at Network Layer
+
+| Argument | Strength | Evidence |
+|----------|----------|----------|
+| MCP ecosystem maturity | Medium | Both SDKs are official; TS has more examples |
+| Type safety at API boundary | Strong | Zod + TypeScript catches contract violations at compile time |
+| Future web UI capability | Strong | If Jerry ever needs browser components |
+| Claude Code satisfaction | Strong | TS shows strong community satisfaction |
+| Gateway pattern fit | Strong | Industry pattern for polyglot boundaries |
+
+### 4.2 Arguments AGAINST TypeScript at Network Layer
+
+| Argument | Strength | Evidence |
+|----------|----------|----------|
+| Added complexity | Strong | Two runtimes, two dependency systems, IPC overhead |
+| Not needed for MVP | Strong | Work Tracker can be CLI-only initially |
+| Python MCP SDK exists | Strong | We CAN do MCP in Python if needed |
+| Context cost | Medium | More code = more tokens in context |
+| Debugging difficulty | Medium | Cross-language stack traces are harder |
+
+### 4.3 Self-Critique
+
+**Potential bias**: I may be over-engineering by suggesting polyglot when Python-only would work.
+
+**Counter-argument**: The hexagonal architecture's entire value proposition is enabling this flexibility. If we design ports correctly, adding a TypeScript MCP adapter later is trivial.
+
+---
+
+## 5. Recommendation
+
+### 5.1 Phased Approach
+
+| Phase | Network Layer | Rationale |
+|-------|---------------|-----------|
+| **MVP (Now)** | Python CLI only | Simplicity, validate core domain |
+| **v0.2** | Python MCP server | Test MCP in Python first |
+| **v0.3+** | TypeScript MCP if needed | Only if Python MCP proves inadequate |
+
+### 5.2 Architectural Preparation
+
+Even if we start Python-only, we should:
+
+1. **Define ports as JSON-serializable contracts** - Enables any language adapter
+2. **Use JSON-RPC patterns in CLI** - Same protocol MCP uses
+3. **Keep `scripts/` thin** - Shims that just invoke domain, easy to replace
+4. **Document IPC contract** - In `infrastructure/schemas/`
+
+### 5.3 When to Add TypeScript
+
+Add TypeScript adapters when:
+- [ ] Python MCP server proves insufficient (performance, ecosystem)
+- [ ] Web UI is required (browser-native)
+- [ ] Integration with TypeScript-only tools needed
+- [ ] Team prefers TypeScript for specific adapter
+
+### 5.4 Directory Structure Implication
+
+Your proposed structure already accommodates this:
+
+```
+jerry/
+├── src/                          # Python hexagonal core
+│   └── interface/
+│       ├── cli/                  # Python CLI adapter (MVP)
+│       └── api/                  # Python API adapter (future)
+│
+├── adapters/                     # OPTIONAL: Non-Python adapters
+│   └── mcp-server/               # TypeScript MCP (if needed later)
+│       ├── package.json
+│       ├── tsconfig.json
+│       └── src/
+│           └── index.ts
+│
+└── scripts/                      # CLI shims (Python, invoke src/)
+```
+
+---
+
+## 6. Final Verdict
+
+**Yes, TypeScript would help at the network layer—but not yet.**
+
+1. ✅ **Architecturally sound**: Hexagonal supports polyglot adapters
+2. ✅ **Industry precedent**: Python backend + TypeScript gateway is common
+3. ✅ **MCP ecosystem**: Both SDKs are viable
+4. ⚠️ **YAGNI**: We don't need it for Work Tracker MVP
+5. ✅ **Prepare, don't implement**: Design ports for language-agnostic IPC
+
+**Action**: Proceed with Python-only, but design contracts that allow TypeScript adapters to be added without refactoring the domain.
+
+---
+
+## 7. References
+
+1. Model Context Protocol. "Specification 2025-11-25." https://modelcontextprotocol.io/specification/2025-11-25
+2. GitHub. "modelcontextprotocol/typescript-sdk." https://github.com/modelcontextprotocol/typescript-sdk
+3. Sairyss. "domain-driven-hexagon." https://github.com/Sairyss/domain-driven-hexagon
+4. TSH. "Hexagonal architecture – overview and best practices." https://tsh.io/blog/hexagonal-architecture
+5. htdocs.dev. "Claude Code Full-Stack Configuration Guide." https://htdocs.dev/posts/claude-code-full-stack-configuration-guide/
+6. AWS. "Structure a Python project in hexagonal architecture." https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/structure-a-python-project-in-hexagonal-architecture-using-aws-lambda.html
+7. MCP Blog. "One Year of MCP." https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-01-07 | Claude | Initial draft |
+| 1.0 | 2026-01-07 | Claude | Approved - proceed with hybrid-ready Python |

--- a/docs/archive/projects-archive/research/PS_AGENT_REFACTORING_STRATEGY.md
+++ b/docs/archive/projects-archive/research/PS_AGENT_REFACTORING_STRATEGY.md
@@ -1,0 +1,672 @@
+# PS Agent Refactoring Strategy
+
+> **Research ID:** RESEARCH-022
+> **Slug:** ps-agent-refactoring-strategy
+> **Name:** Problem-Solving Agent Portfolio Refactoring Strategy
+> **Short Description:** Comprehensive strategy for refactoring 8 ps-*.md agents using industry best practices and multi-level documentation.
+> **Created:** 2026-01-08 (Session claude/create-code-plugin-skill-MG1nh)
+> **Version:** 1.0.0
+> **Status:** COMPLETE
+> **Hash:** (computed on export)
+
+---
+
+## Executive Summary
+
+This document provides a comprehensive strategy for refactoring the 8 problem-solving agents (ps-*.md) in Jerry's problem-solving skill. The strategy incorporates industry best practices from Anthropic, OpenAI, Google, Microsoft, and academic research on multi-agent systems.
+
+**Key Recommendations:**
+1. Adopt XML-structured prompts for Claude (Anthropic best practice)
+2. Implement coordinator/router pattern for agent selection
+3. Add explicit persona sections with tone and expertise
+4. Standardize output templates with L0/L1/L2 explanation levels
+5. Implement progressive enforcement (Advisory → Soft → Medium)
+
+---
+
+## I. Current State Analysis
+
+### A. Agent Portfolio Overview
+
+| Agent | Version | Purpose | Output Type | Tools | Prior Art Cited |
+|-------|---------|---------|-------------|-------|-----------------|
+| ps-researcher | 1.1.0 | Deep research | Research docs | 11 | None |
+| ps-analyst | 1.1.0 | Root cause, trade-offs | Analysis docs | 8 | 5 Whys, FMEA, Kepner-Tregoe |
+| ps-architect | 1.1.0 | ADR creation | Decision records | 8 | Nygard ADR, IETF RFC, C4 |
+| ps-validator | 1.0.0 | Constraint validation | Validation reports | 5 | None |
+| ps-reviewer | 1.0.0 | Quality review | Review reports | 5 | Google Code Review, OWASP |
+| ps-reporter | 1.0.0 | Status reporting | Status reports | 5 | None |
+| ps-investigator | 1.1.0 | Failure analysis | Investigation docs | 8 | 5 Whys, Ishikawa, NASA FMEA |
+| ps-synthesizer | 1.1.0 | Pattern synthesis | Synthesis docs | 8 | Cochrane, Grounded Theory |
+
+### B. Identified Gaps
+
+| Gap ID | Description | Impact | Evidence |
+|--------|-------------|--------|----------|
+| GAP-001 | No explicit persona section | Inconsistent tone/depth | Missing from all 8 agents |
+| GAP-002 | No XML-structured prompts | Suboptimal Claude parsing | Using markdown only |
+| GAP-003 | No L0/L1/L2 output levels | Poor accessibility | Single-level outputs |
+| GAP-004 | Inconsistent tool allowlists | Security risk | Varies by agent |
+| GAP-005 | No coordinator pattern | Manual agent selection | No routing logic |
+| GAP-006 | Missing guardrails section | Safety gaps | Not present in templates |
+| GAP-007 | No state management | Session isolation issues | No explicit state handling |
+
+---
+
+## II. Understanding Agent Design (Multi-Level Explanation)
+
+### Level 0: ELI5 (Explain Like I'm 5)
+
+Think of agents like different helpers in a workshop:
+- **ps-researcher** is like a librarian who finds books and information
+- **ps-analyst** is like a detective who figures out why things happened
+- **ps-architect** is like a planner who decides how to build things
+- **ps-validator** is like a quality checker who makes sure things work
+- **ps-reviewer** is like a teacher who grades your work
+- **ps-reporter** is like a news anchor who tells everyone what's happening
+- **ps-investigator** is like a forensic scientist who examines problems
+- **ps-synthesizer** is like a puzzle master who puts all the pieces together
+
+Right now, these helpers don't have clear "uniforms" (personas) or "rules" (guardrails). We need to give each one a clear identity and set of rules so they do their jobs better.
+
+**Why It Matters:** When helpers know exactly who they are and what they're allowed to do, they make fewer mistakes and work together better.
+
+### Level 1: Software Engineer Explanation
+
+The 8 ps-*.md agents implement a coordinator/router pattern for problem-solving workflows. Each agent has:
+
+**Current Structure:**
+```yaml
+---
+name: {agent-name}
+description: {purpose}
+version: {semver}
+allowed-tools: [{tool-list}]
+output:
+  required: true
+  location: {path-template}
+  template: {template-path}
+validation:
+  file_must_exist: true
+  link_artifact_required: true
+prior_art: [{citations}]
+---
+```
+
+**Key Issues:**
+1. **No Persona Definition:** Agents lack explicit identity, tone, and expertise boundaries
+2. **Markdown-Only:** Claude excels with XML-structured prompts that separate components
+3. **Single-Level Output:** All outputs target the same audience level
+4. **No Guardrails:** Missing explicit safety constraints and fallback logic
+
+**Recommended Structure (XML-enhanced):**
+```markdown
+---
+# YAML frontmatter (unchanged)
+---
+
+<agent>
+  <identity>
+    <name>{agent-name}</name>
+    <role>{specialist-role}</role>
+    <expertise>{domain-expertise}</expertise>
+  </identity>
+
+  <persona>
+    <tone>{professional|technical|accessible}</tone>
+    <communication-style>{direct|consultative|educational}</communication-style>
+    <depth>{L0-ELI5|L1-Engineer|L2-Architect}</depth>
+  </persona>
+
+  <capabilities>
+    <allowed-tools>{tool-list}</allowed-tools>
+    <output-formats>{format-list}</output-formats>
+    <forbidden-actions>{exclusion-list}</forbidden-actions>
+  </capabilities>
+
+  <guardrails>
+    <input-validation>{rules}</input-validation>
+    <output-filtering>{rules}</output-filtering>
+    <fallback-behavior>{behavior}</fallback-behavior>
+  </guardrails>
+</agent>
+```
+
+### Level 2: Principal Architect Explanation
+
+The ps-*.md agent portfolio implements a **specialized multi-agent system** following the coordinator/router pattern described by Microsoft Azure Architecture Center and Google's ADK framework.
+
+**Architectural Analysis:**
+
+1. **Agent Topology:**
+   - Current: Flat, manually-selected agents
+   - Target: Hierarchical with LLM-based routing
+   - Pattern: Router → Specialized Agent → Output
+
+2. **State Management:**
+   - Current: Implicit (via PS context injection)
+   - Target: Explicit session.state with output_key (Google ADK pattern)
+   - Benefit: Enables sequential agent chains without data loss
+
+3. **Conformance to Industry Standards:**
+
+| Standard | Current Conformance | Gap | Recommendation |
+|----------|---------------------|-----|----------------|
+| XML-Structured Prompts (Anthropic) | 0% | Critical | Add XML wrapper |
+| Persona Definition (OpenAI GPT-4.1) | 20% | High | Add identity section |
+| Guardrails (KnowBe4/OWASP) | 10% | High | Add guardrails section |
+| State Management (Google ADK) | 30% | Medium | Add output_key pattern |
+| Tool Allowlists (Constitutional AI) | 80% | Low | Standardize across agents |
+
+4. **Design Principles Applied:**
+
+| Principle | Source | Application |
+|-----------|--------|-------------|
+| Start Simple | Anthropic | Use single-agent workflows before multi-agent |
+| Modular Design | Databricks | Reusable components across agents |
+| Clear Descriptions | Google ADK | Precise agent descriptions for routing |
+| Layered Defenses | KnowBe4 | Input validation, output filtering, tool constraints |
+| Transparency | OpenAI | Audit logs for every agent decision |
+
+5. **Multi-Agent Orchestration Patterns:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Problem-Solving Skill                     │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │                   Coordinator/Router                  │   │
+│  │  Input → Classify → Route → Monitor → Aggregate      │   │
+│  └────────────────────────┬────────────────────────────┘   │
+│                           │                                  │
+│     ┌─────────────────────┼─────────────────────┐           │
+│     ▼                     ▼                     ▼           │
+│  ┌──────┐           ┌──────────┐          ┌──────────┐     │
+│  │GATHER│           │INTERPRET │          │DOCUMENT  │     │
+│  ├──────┤           ├──────────┤          ├──────────┤     │
+│  │ps-   │           │ps-analyst│          │ps-arch.  │     │
+│  │resear│           │ps-invest.│          │ps-report.│     │
+│  │cher  │           │ps-synth. │          │ps-valid. │     │
+│  └──────┘           │ps-review.│          │ps-review.│     │
+│                     └──────────┘          └──────────┘     │
+│                                                             │
+│  DIVERGENT           CONVERGENT           DECLARATIVE       │
+│  (breadth-first)     (depth-first)        (formalize)       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## III. Best Practices Research
+
+### A. Anthropic Claude Best Practices
+
+**Source:** [Anthropic Prompt Engineering](https://www.anthropic.com/news/prompt-engineering-for-business-performance), [Claude Docs](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
+
+| Practice | Description | Application |
+|----------|-------------|-------------|
+| XML-Structured Prompts | Use XML tags to separate components | Wrap agent sections in XML |
+| Persona Assignment | Assign precise persona for tone/depth | Add `<identity>` and `<persona>` sections |
+| Role-Based Framing | Frame with expertise boundaries | Define expertise in agent spec |
+| Chain-of-Thought | "Think step by step" for complex tasks | Add reflection prompts |
+| Tool Call Constraints | Explicit allowlists | Already implemented, standardize |
+
+**Claude-Specific XML Pattern:**
+```xml
+<agent_context>
+  <role>You are ps-analyst, an expert in root cause analysis...</role>
+  <task>Perform 5 Whys analysis on...</task>
+  <constraints>
+    <must>Create file with Write tool</must>
+    <must>Call link-artifact after</must>
+    <must_not>Return transient output only</must_not>
+  </constraints>
+</agent_context>
+```
+
+### B. OpenAI Agent Design (GPT-4.1 Guide, 2025)
+
+**Source:** [OpenAI Practical Guide to Building Agents](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf)
+
+| Practice | Description | Application |
+|----------|-------------|-------------|
+| Structured Prompt Design | Goal persistence, tool integration | Add goal/tools sections |
+| Reflective Execution | Reflect after tool use | Add post-tool reflection prompts |
+| Long-Context Processing | Strategies for large contexts | Add context chunking guidance |
+| Agent Templates | Standardized formats | Create unified agent template |
+
+### C. Google ADK Multi-Agent Patterns
+
+**Source:** [Google Developers Blog - Multi-Agent Patterns in ADK](https://developers.googleblog.com/developers-guide-to-multi-agent-patterns-in-adk/)
+
+| Pattern | Description | Application |
+|---------|-------------|-------------|
+| Sequential Agent | Chain agents in order | ps-researcher → ps-analyst → ps-architect |
+| Parallel Agent | Run agents concurrently | Multiple ps-reviewers on different files |
+| Router Agent | LLM-based routing | Route to appropriate ps-* agent |
+| State Management | output_key for session.state | Add explicit state passing |
+
+**ADK State Pattern:**
+```python
+# State management via output_key
+researcher_output = Task(
+    agent="ps-researcher",
+    output_key="research_findings"  # Writes to session.state
+)
+
+# Next agent reads from state
+analyst_input = session.state.get("research_findings")
+```
+
+### D. Microsoft Azure AI Agent Patterns
+
+**Source:** [Azure AI Agent Design Patterns](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns)
+
+| Pattern | Description | Application |
+|---------|-------------|-------------|
+| Supervisor Pattern | Central coordinator | ps-skill as supervisor |
+| Hierarchical Pattern | Nested agent groups | Gather → Interpret → Document |
+| Human-in-the-Loop | Approval gates | Medium enforcement tier |
+| Tool Orchestration | Centralized tool management | Unified tool registry |
+
+### E. KnowBe4 Security Best Practices
+
+**Source:** [KnowBe4 AI Security by Design](https://blog.tmcnet.com/blog/rich-tehrani/ai/ai-security-by-design-a-deep-dive-into-knowbe4s-best-practices-for-prompting-and-agent-systems.html)
+
+| Practice | Description | Application |
+|----------|-------------|-------------|
+| Prompt Separation | Never mix user input with system | Separate PS context from task |
+| Input Validation | Sanitize, encode, quote | Validate PS ID, Entry ID |
+| Output Filtering | Review for disallowed content | Filter before persistence |
+| Tool Call Constraints | Explicit allowlists/denylists | Already implemented |
+| Human-in-the-Loop | Approvals for high-impact | Medium enforcement tier |
+
+### F. Academic Research
+
+**Source:** [ZenML LLM Agents in Production](https://www.zenml.io/blog/llm-agents-in-production-architectures-challenges-and-best-practices)
+
+| Finding | Description | Application |
+|---------|-------------|-------------|
+| Monolith Anti-Pattern | Single agent with too many tasks degrades | 8 specialized agents is correct |
+| Error Compounding | Complex instructions increase hallucinations | Simplify individual agent prompts |
+| Evaluation is Critical | Measure agent performance | Add metrics to enforcement tiers |
+
+---
+
+## IV. Refactoring Strategy
+
+### A. Unified Agent Template
+
+Create a new unified template that all 8 agents will follow:
+
+```markdown
+---
+name: ps-{agent-type}
+version: "2.0.0"
+description: {one-line-description}
+
+identity:
+  role: {specialist-role}
+  expertise: [{domain-list}]
+  cognitive_mode: {divergent|convergent}
+
+persona:
+  tone: {professional|technical|accessible}
+  communication_style: {direct|consultative|educational}
+  audience_level: {L0|L1|L2|adaptive}
+
+capabilities:
+  allowed_tools: [{tool-list}]
+  output_formats: [{format-list}]
+  forbidden_actions: [{exclusion-list}]
+
+guardrails:
+  input_validation:
+    - validate_ps_id_format
+    - validate_entry_id_format
+  output_filtering:
+    - no_secrets_in_output
+    - no_executable_code
+  fallback_behavior: warn_and_retry
+
+output:
+  required: true
+  location: "{path-template}"
+  template: "{template-path}"
+  levels: [L0, L1, L2]
+
+validation:
+  file_must_exist: true
+  link_artifact_required: true
+  post_completion_checks:
+    - verify_file_created
+    - verify_artifact_linked
+
+prior_art:
+  - "{citation-1}"
+  - "{citation-2}"
+
+enforcement:
+  tier: advisory|soft|medium|hard
+  escalation_path: "{escalation-description}"
+---
+
+<agent>
+<identity>
+You are **ps-{agent-type}**, a specialized agent in the Jerry problem-solving framework.
+
+**Role:** {role-description}
+**Expertise:** {expertise-areas}
+**Cognitive Mode:** {divergent-or-convergent}
+</identity>
+
+<persona>
+**Tone:** {tone-description}
+**Communication Style:** {style-description}
+**Audience Adaptation:** You MUST produce output at three levels:
+- **L0 (ELI5):** Accessible to non-technical stakeholders
+- **L1 (Software Engineer):** Technical implementation focus
+- **L2 (Principal Architect):** Strategic and systemic perspective
+</persona>
+
+<capabilities>
+**Allowed Tools:**
+{tool-list-with-descriptions}
+
+**Forbidden Actions:**
+- {exclusion-1}
+- {exclusion-2}
+</capabilities>
+
+<guardrails>
+**Input Validation:**
+- PS ID must match pattern `phase-\d+\.\d+`
+- Entry ID must match pattern `e-\d+`
+
+**Output Filtering:**
+- No secrets (API keys, passwords) in output
+- No executable code without user confirmation
+
+**Fallback Behavior:**
+If unable to complete task:
+1. Warn user with specific blocker
+2. Suggest alternative approach
+3. Request clarification if needed
+</guardrails>
+
+<invocation_protocol>
+## PS CONTEXT (REQUIRED)
+- **PS ID:** {ps_id}
+- **Entry ID:** {entry_id}
+- **Topic:** {topic}
+
+## MANDATORY PERSISTENCE (c-009)
+After completing your task, you MUST:
+
+1. **Create a file** using the Write tool at:
+   `{output-path}`
+
+2. **Follow the template** structure from:
+   `{template-path}`
+
+3. **Link the artifact** by running:
+   ```bash
+   python3 scripts/cli.py link-artifact {ps_id} {entry_id} FILE "{output-path}" "{description}"
+   ```
+
+DO NOT return transient output only. File creation AND link-artifact are MANDATORY.
+</invocation_protocol>
+
+<output_levels>
+Your output MUST include explanations at three levels:
+
+### L0: Executive Summary (ELI5)
+{accessible-explanation}
+
+### L1: Technical Analysis (Software Engineer)
+{implementation-focused-explanation}
+
+### L2: Architectural Implications (Principal Architect)
+{strategic-systemic-explanation}
+</output_levels>
+
+</agent>
+
+# PS {Agent-Type} Agent
+
+## Purpose
+{detailed-purpose}
+
+## Methodology
+{methodology-with-prior-art}
+
+## Template Sections
+{section-list}
+
+## Example Invocation
+{complete-example}
+```
+
+### B. Phased Refactoring Plan
+
+| Phase | Agents | Focus | Duration |
+|-------|--------|-------|----------|
+| 1. Foundation | All | Create unified template, update frontmatter schema | First |
+| 2. Core Agents | ps-researcher, ps-analyst | Add XML structure, persona, L0/L1/L2 | Second |
+| 3. Decision Agents | ps-architect, ps-validator | Add XML structure, guardrails | Third |
+| 4. Reporting Agents | ps-reporter, ps-reviewer | Add XML structure, output levels | Fourth |
+| 5. Advanced Agents | ps-investigator, ps-synthesizer | Add XML structure, cross-references | Fifth |
+| 6. Integration | All | Add coordinator/router, state management | Sixth |
+
+### C. Migration Checklist (Per Agent)
+
+- [ ] Update YAML frontmatter to v2.0.0 schema
+- [ ] Add `<identity>` XML section
+- [ ] Add `<persona>` XML section with tone/style
+- [ ] Add `<capabilities>` XML section with tools/exclusions
+- [ ] Add `<guardrails>` XML section
+- [ ] Add `<invocation_protocol>` XML section
+- [ ] Add `<output_levels>` XML section (L0/L1/L2)
+- [ ] Standardize tool allowlist
+- [ ] Add missing prior_art citations
+- [ ] Add enforcement tier specification
+- [ ] Update template reference
+- [ ] Add post-completion verification
+- [ ] Test with sample invocation
+
+---
+
+## V. Discoveries
+
+### DISC-049: XML-Structured Prompts for Claude
+
+**ID:** DISC-049
+**Slug:** xml-structured-prompts-claude
+**Name:** Claude Excels with XML-Structured Prompts
+**Short Description:** Claude's training optimizes for XML tags that separate prompt components, improving parsing accuracy and response quality.
+
+**Long Description:**
+Anthropic's prompt engineering documentation explicitly recommends using XML-structured prompts for Claude. The model recognizes XML-style tags as signposts, distinguishing between instructions, examples, and inputs more effectively than markdown-only prompts. This is particularly important for agent specifications where multiple sections (persona, capabilities, guardrails, invocation protocol) need clear separation. Current ps-*.md agents use markdown exclusively, missing this optimization.
+
+**Evidence:**
+- [Anthropic Prompt Engineering](https://www.anthropic.com/news/prompt-engineering-for-business-performance)
+- [Claude Docs Best Practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
+- AWS Machine Learning Blog on Claude 3 prompting
+
+**Level Impact:**
+- **L0:** Claude understands instructions better when they're wrapped in special tags like `<role>` and `<task>`
+- **L1:** Wrap agent sections in XML tags to improve Claude's parsing accuracy
+- **L2:** Redesign agent schema to use XML wrapper with YAML frontmatter for machine-parseable metadata
+
+---
+
+### DISC-050: Coordinator/Router Pattern for Multi-Agent
+
+**ID:** DISC-050
+**Slug:** coordinator-router-pattern
+**Name:** Coordinator/Router Pattern Required for Scalable Multi-Agent Systems
+**Short Description:** Industry consensus recommends a central coordinator with LLM-based routing for agent selection instead of manual selection.
+
+**Long Description:**
+Google's ADK framework, Microsoft's Azure Architecture Center, and academic research all recommend the coordinator/router pattern for multi-agent systems. In this pattern, a central coordinator analyzes the user's request and routes to the appropriate specialized agent. The agent's "description" field serves as API documentation for the routing LLM. Currently, Jerry's ps-* agents require manual selection by the invoking agent, creating a knowledge burden and potential misrouting. Adding a router would improve accuracy and reduce cognitive load.
+
+**Evidence:**
+- [Google ADK Multi-Agent Patterns](https://developers.googleblog.com/developers-guide-to-multi-agent-patterns-in-adk/)
+- [Microsoft Azure AI Agent Design Patterns](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns)
+- [Databricks Agent System Design Patterns](https://docs.databricks.com/aws/en/generative-ai/guide/agent-system-design-patterns)
+
+**Level Impact:**
+- **L0:** Instead of picking helpers manually, we'll have a "dispatcher" who knows which helper is best for each job
+- **L1:** Implement LLM-based router in ps-skill that selects appropriate ps-* agent based on task classification
+- **L2:** Design coordinator with Cynefin-aware routing (simple/complicated/complex/chaotic → different agent strategies)
+
+---
+
+### DISC-051: State Management via output_key Pattern
+
+**ID:** DISC-051
+**Slug:** state-management-output-key
+**Name:** Explicit State Management Required for Sequential Agent Chains
+**Short Description:** Google ADK's output_key pattern enables agents to share state through session.state, critical for sequential workflows.
+
+**Long Description:**
+In Google's Agent Development Kit (ADK), sequential agents share data through `session.state` using `output_key`. When an agent completes, its output is written to the specified key in session state, allowing the next agent to read it. This pattern solves the "state amnesia" problem in multi-step workflows. Currently, ps-* agents rely on implicit state passing through the Task prompt, which is fragile and context-expensive. Adopting explicit state management would improve reliability and enable complex agent chains.
+
+**Evidence:**
+- [Google ADK State Management](https://developers.googleblog.com/developers-guide-to-multi-agent-patterns-in-adk/)
+- [Databricks Modular Design Best Practice](https://docs.databricks.com/aws/en/generative-ai/guide/agent-system-design-patterns)
+
+**Level Impact:**
+- **L0:** When helpers work in a chain, they need to pass notes to each other so nothing gets lost
+- **L1:** Add output_key parameter to Task invocations, read from session state in subsequent agents
+- **L2:** Design state schema for ps-skill workflows: research_output → analysis_input → decision_input
+
+---
+
+### DISC-052: Layered Security Defenses for Agents
+
+**ID:** DISC-052
+**Slug:** layered-security-defenses
+**Name:** Layered Defenses Required for Agent Security
+**Short Description:** KnowBe4 and OpenAI recommend prompt separation, input validation, output filtering, and tool constraints as layered security.
+
+**Long Description:**
+Security research from KnowBe4, synthesizing guidance from OpenAI, Google, Anthropic, and O'Reilly, identifies five layers of defense for AI agents: (1) prompt separation - never mix user input with system instructions, (2) input validation - sanitize and validate all inputs, (3) output filtering - review outputs for disallowed content, (4) tool call constraints - explicit allowlists and denylists, (5) human-in-the-loop - approval gates for high-impact actions. Current ps-* agents implement only tool constraints (layer 4). Adding the other layers would significantly improve security posture.
+
+**Evidence:**
+- [KnowBe4 AI Security by Design](https://blog.tmcnet.com/blog/rich-tehrani/ai/ai-security-by-design-a-deep-dive-into-knowbe4s-best-practices-for-prompting-and-agent-systems.html)
+- [OpenAI Agent Security](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf)
+
+**Level Impact:**
+- **L0:** Add multiple safety checks, like having a hall pass AND a teacher signature AND a principal approval
+- **L1:** Implement guardrails section with input validation (PS ID format) and output filtering (no secrets)
+- **L2:** Design security architecture with prompt separation at invocation, validation at Task boundary, filtering at Write
+
+---
+
+### DISC-053: Monolith Anti-Pattern in Agent Design
+
+**ID:** DISC-053
+**Slug:** monolith-anti-pattern
+**Name:** Single Agent with Many Tasks Degrades Quality
+**Short Description:** Academic research confirms that monolithic agents with too many responsibilities increase hallucinations and error rates.
+
+**Long Description:**
+Research from ZenML and industry experience confirms that a single agent tasked with too many responsibilities becomes a "Jack of all trades, master of none." As instruction complexity increases, adherence to specific rules degrades, and error rates compound. This validates Jerry's current design of 8 specialized agents. However, each agent's prompt must remain focused - adding too many requirements to individual agents recreates the monolith problem at a smaller scale. The refactoring should simplify individual agent prompts while maintaining specialization.
+
+**Evidence:**
+- [ZenML LLM Agents in Production](https://www.zenml.io/blog/llm-agents-in-production-architectures-challenges-and-best-practices)
+- [Vellum Ultimate LLM Agent Build Guide](https://www.vellum.ai/blog/the-ultimate-llm-agent-build-guide)
+- [DeepChecks Multi-Step LLM Chains](https://www.deepchecks.com/orchestrating-multi-step-llm-chains-best-practices/)
+
+**Level Impact:**
+- **L0:** Each helper should have ONE main job, not twenty different jobs
+- **L1:** Audit agent prompts for instruction bloat; extract common logic to shared templates
+- **L2:** Measure instruction complexity per agent; target <500 words of core instructions per agent
+
+---
+
+## VI. Action Items
+
+| ID | Action | Priority | Owner | Status |
+|----|--------|----------|-------|--------|
+| ACT-022.1 | Create unified agent template v2.0 | HIGH | Dev | PENDING |
+| ACT-022.2 | Add XML wrapper to ps-researcher | HIGH | Dev | PENDING |
+| ACT-022.3 | Add XML wrapper to ps-analyst | HIGH | Dev | PENDING |
+| ACT-022.4 | Add L0/L1/L2 output sections to template | HIGH | Dev | PENDING |
+| ACT-022.5 | Standardize tool allowlists | MEDIUM | Dev | PENDING |
+| ACT-022.6 | Add guardrails section to all agents | MEDIUM | Dev | PENDING |
+| ACT-022.7 | Design coordinator/router for ps-skill | MEDIUM | Dev | PENDING |
+| ACT-022.8 | Add state management (output_key pattern) | LOW | Dev | PENDING |
+
+---
+
+## VII. References
+
+### Industry Sources
+
+1. **Anthropic Prompt Engineering** (2025)
+   - URL: https://www.anthropic.com/news/prompt-engineering-for-business-performance
+   - Key: XML-structured prompts, persona assignment
+
+2. **OpenAI Practical Guide to Building Agents** (2025)
+   - URL: https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf
+   - Key: Structured prompt design, reflective execution
+
+3. **Google ADK Multi-Agent Patterns** (2025)
+   - URL: https://developers.googleblog.com/developers-guide-to-multi-agent-patterns-in-adk/
+   - Key: Coordinator/router, state management, output_key
+
+4. **Microsoft Azure AI Agent Design Patterns** (2025)
+   - URL: https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns
+   - Key: Supervisor, hierarchical, human-in-the-loop patterns
+
+5. **Databricks Agent System Design Patterns** (2025)
+   - URL: https://docs.databricks.com/aws/en/generative-ai/guide/agent-system-design-patterns
+   - Key: Sequential, parallel, router patterns
+
+6. **KnowBe4 AI Security by Design** (2025)
+   - URL: https://blog.tmcnet.com/blog/rich-tehrani/ai/ai-security-by-design-a-deep-dive-into-knowbe4s-best-practices-for-prompting-and-agent-systems.html
+   - Key: Layered defenses, prompt separation, guardrails
+
+### Academic/Technical Sources
+
+7. **ZenML LLM Agents in Production** (2025)
+   - URL: https://www.zenml.io/blog/llm-agents-in-production-architectures-challenges-and-best-practices
+   - Key: Monolith anti-pattern, evaluation
+
+8. **Vellum Ultimate LLM Agent Build Guide** (2025)
+   - URL: https://www.vellum.ai/blog/the-ultimate-llm-agent-build-guide
+   - Key: Agent components, orchestration
+
+9. **DeepChecks Multi-Step LLM Chains** (2025)
+   - URL: https://www.deepchecks.com/orchestrating-multi-step-llm-chains-best-practices/
+   - Key: Error compounding, fallback mechanisms
+
+### Prior Art (Referenced in Current Agents)
+
+10. **Ohno, T. (1988)** - Toyota Production System: 5 Whys methodology
+11. **NASA (2007)** - Systems Engineering Handbook: FMEA
+12. **Nygard, M. (2011)** - Documenting Architecture Decisions: ADR format
+13. **Ishikawa, K. (1990)** - Introduction to Quality Control: Fishbone diagram
+14. **Braun & Clarke (2006)** - Thematic Analysis methodology
+15. **Google (2023)** - Engineering Practices: Code Review Guidelines
+16. **OWASP (2021)** - Top 10 Web Application Security Risks
+
+---
+
+## VIII. PS Integration
+
+**Problem Statement:** Phase 3.5 Agent Reorganization / WORK-022
+**Entry Type:** RESEARCH
+**Severity:** HIGH
+**Resolution:** COMPLETE
+
+**Artifacts:**
+- This document: `docs/research/PS_AGENT_REFACTORING_STRATEGY.md`
+- Discoveries: DISC-049 through DISC-053
+
+**Next Steps:**
+1. Add discoveries to WORKTRACKER.md Phase DISCOVERY
+2. Create unified agent template v2.0
+3. Begin phased refactoring per plan

--- a/docs/archive/projects-archive/research/TECHNOLOGY_STACK_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/TECHNOLOGY_STACK_ANALYSIS.md
@@ -1,0 +1,375 @@
+# Technology Stack Analysis for Jerry Framework
+
+**Document ID**: RESEARCH-001
+**Date**: 2026-01-07
+**Author**: Claude (Distinguished Systems Engineering Persona)
+**Status**: DRAFT - Pending Review
+
+---
+
+## Executive Summary
+
+This document presents an evidence-based analysis of technology stack options for the Jerry framework, a behavior and workflow guardrails system designed to operate within Claude Code Web Research Preview. The primary constraint is the sandboxed, ephemeral cloud environment with pre-installed runtimes.
+
+**Recommendation**: **Python with zero/minimal dependencies** is the optimal choice, with strategic use of stdlib and pre-installed packages only.
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Core Requirements
+
+1. **Runtime Environment**: Must execute within Claude Code Web Research Preview (Anthropic-managed sandbox)
+2. **Context Rot Mitigation**: Framework must help survive long-running sessions where context degrades
+3. **Work Tracker**: First skill implementation - local Azure DevOps/JIRA equivalent
+4. **Hexagonal Architecture**: Domain-Driven Design with Ports & Adapters pattern
+5. **Knowledge Accrual**: System must accumulate wisdom, experience, and knowledge over time
+
+### 1.2 The Context Rot Problem
+
+Per Chroma Research and Anthropic's engineering blog:
+
+> "Context Rot is the phenomenon where an LLM's performance degrades as the context window fills up, even when total token count is well within the technical limit."
+> — [Chroma Research](https://research.trychroma.com/context-rot)
+
+The effective context window where models perform optimally is often **<256k tokens**, far below advertised limits. This is an architectural reality of transformer attention mechanisms creating n² pairwise relationships.
+
+**Mitigation strategies** (per [Anthropic Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)):
+- Context Offloading (filesystem as infinite memory)
+- Context Reduction (compression/summarization)
+- Context Retrieval (dynamic loading)
+- Context Isolation (separation of concerns)
+
+---
+
+## 2. Environment Constraints Analysis
+
+### 2.1 Claude Code Web Research Preview Specifications
+
+| Aspect | Specification | Source |
+|--------|---------------|--------|
+| **Execution** | Isolated Gvisor sandbox on Anthropic infrastructure | [Anthropic News](https://www.anthropic.com/news/claude-code-on-the-web) |
+| **Base Image** | Ubuntu-based container | [Claude Code Docs](https://code.claude.com/docs/en/claude-code-on-the-web) |
+| **Filesystem** | Read/write to working directory only | [Sandboxing Docs](https://code.claude.com/docs/en/sandboxing) |
+| **Network** | Configurable: locked down, allowlist, or open | [Claude Code Docs](https://code.claude.com/docs/en/claude-code-on-the-web) |
+| **Git** | GitHub only (via secure proxy) | [VentureBeat](https://venturebeat.com/ai/claude-code-comes-to-web-and-mobile-letting-devs-launch-parallel-jobs-on/) |
+| **Persistence** | Ephemeral - no state between sessions | [DevToolHub](https://devtoolhub.com/claude-code-on-the-web/) |
+
+### 2.2 Pre-installed Runtimes and Tools
+
+Per [Claude Code Docs](https://code.claude.com/docs/en/claude-code-on-the-web), the cloud image includes:
+
+| Language/Tool | Details |
+|--------------|---------|
+| **Python** | pip, poetry, NumPy, etc. |
+| **Node.js** | npm, yarn, pnpm |
+| **Go** | Standard toolchain |
+| **Rust** | Cargo |
+| **Java** | JDK |
+| **C++** | GCC/Clang |
+| **Testing** | Frameworks pre-installed |
+| **Linters** | Pre-installed |
+
+### 2.3 Dependency Installation
+
+Per documentation, dependencies can be installed via SessionStart hooks:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{
+      "type": "command",
+      "command": "scripts/install_pkgs.sh"
+    }]
+  }
+}
+```
+
+**However**, this introduces:
+- Session startup latency
+- Network dependency (may fail)
+- Rate limit consumption
+- Potential security exposure via trusted network access
+
+---
+
+## 3. Technology Stack Evaluation
+
+### 3.1 Evaluation Criteria
+
+| Criterion | Weight | Rationale |
+|-----------|--------|-----------|
+| **Zero-dependency capability** | 35% | Reduces failure modes, startup time |
+| **Hexagonal architecture support** | 25% | Core requirement per user spec |
+| **Pre-installed ecosystem** | 20% | Leverage existing environment |
+| **Context efficiency** | 15% | Code verbosity affects token usage |
+| **Developer experience** | 5% | Secondary to reliability |
+
+### 3.2 Python Analysis
+
+#### Strengths
+
+1. **"Batteries Included" Philosophy**
+   > "Python is a 'batteries-included' kind of language, and comes with an HTTP server module."
+   > — [Drew's Blogsite](https://drewsh.com/minimal-python-server)
+
+2. **Stdlib Capabilities for Our Use Case**:
+   - `dataclasses` - Value Objects, Entities (Python 3.7+)
+   - `abc` - Abstract Base Classes for Ports
+   - `typing` - Type hints, Protocol classes
+   - `json` - Serialization
+   - `sqlite3` - Persistence (zero external deps)
+   - `pathlib` - Filesystem operations
+   - `datetime` - Temporal handling
+   - `uuid` - Identity generation
+   - `collections` - Data structures
+   - `contextlib` - Resource management
+   - `unittest` - Testing framework
+
+3. **Hexagonal Architecture Support**
+   > "In Python, hexagonal architecture can be implemented using Abstract Base Classes (ABCs) for ports and concrete implementations for adapters."
+   > — [Software Patterns Lexicon](https://softwarepatternslexicon.com/python/architectural-patterns/hexagonal-architecture-ports-and-adapters/)
+
+4. **Pre-installed in Environment**: Python with pip, poetry, NumPy already available
+
+5. **DDD/CQRS Resources**: Strong community with examples (e.g., [Hexagonal Architecture with Python + FastAPI](https://github.com/marcosvs98/hexagonal-architecture-with-python))
+
+#### Weaknesses
+
+1. **Type System**: Runtime-only checking without external tools (mypy)
+2. **Verbosity**: More boilerplate than TypeScript for some patterns
+3. **Import System**: Can be confusing for complex package structures
+
+#### Zero-Dependency Feasibility Assessment
+
+| Component | Stdlib Solution | External Alternative |
+|-----------|-----------------|---------------------|
+| Domain Entities | `dataclasses` | Pydantic |
+| Ports (Interfaces) | `abc.ABC`, `typing.Protocol` | N/A |
+| Persistence | `sqlite3`, `json` | SQLAlchemy |
+| HTTP Server | `http.server` | FastAPI, Flask |
+| CLI | `argparse` | Click, Typer |
+| Testing | `unittest` | pytest |
+| Validation | Manual + `typing` | Pydantic |
+| Serialization | `json` | marshmallow |
+
+**Verdict**: **100% stdlib implementation is feasible** for Work Tracker use case.
+
+### 3.3 TypeScript/Node.js Analysis
+
+#### Strengths
+
+1. **Type System**: Compile-time type checking built-in
+2. **Strong Hexagonal Examples**: [domain-driven-hexagon](https://github.com/Sairyss/domain-driven-hexagon) - 14k+ stars
+3. **Interface Definition**: Native interface/type constructs
+4. **Async-First**: Native Promise/async-await patterns
+
+#### Weaknesses
+
+1. **Dependency Culture**
+   > "The npm ecosystem traditionally relies heavily on external packages even for basic functionality."
+
+2. **Node.js Stdlib Limitations**:
+   - No built-in SQLite (requires `better-sqlite3`)
+   - Limited CLI parsing (basic `process.argv`)
+   - No built-in testing framework
+   - No built-in validation
+
+3. **Zero-Dependency Feasibility**:
+
+| Component | Stdlib Solution | Reality |
+|-----------|-----------------|---------|
+| Domain Entities | Class + interfaces | Feasible |
+| Ports | Interfaces | Feasible |
+| Persistence | **None** | Requires `better-sqlite3` or fs-based |
+| HTTP Server | `http` module | Feasible but primitive |
+| CLI | `process.argv` | Very limited |
+| Testing | **None** | Requires Jest/Vitest |
+| Validation | **None** | Requires Zod/Joi |
+
+**Verdict**: **Zero-dependency TypeScript is NOT feasible** for Work Tracker without significant compromise.
+
+### 3.4 Comparative Scoring
+
+| Criterion | Weight | Python | TypeScript | Notes |
+|-----------|--------|--------|------------|-------|
+| Zero-dependency capability | 35% | 9/10 | 4/10 | Python stdlib far superior |
+| Hexagonal architecture support | 25% | 8/10 | 9/10 | Both excellent, TS slightly more ergonomic |
+| Pre-installed ecosystem | 20% | 9/10 | 8/10 | Both available, Python more complete |
+| Context efficiency | 15% | 7/10 | 8/10 | TS slightly more concise |
+| Developer experience | 5% | 8/10 | 8/10 | Comparable |
+| **Weighted Total** | 100% | **8.25** | **6.55** | |
+
+---
+
+## 4. Hexagonal Architecture Foundation
+
+### 4.1 Original Pattern Definition
+
+Per Alistair Cockburn (pattern creator, 2005):
+
+> "Allow an application to equally be driven by users, programs, automated test or batch scripts, and to be developed and tested in isolation from its eventual run-time devices and databases."
+> — [Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)
+
+### 4.2 Core Principles
+
+1. **Application Core Independence**: Business logic has no dependencies on frameworks or external resources
+2. **Ports as Contracts**: Abstract interfaces defining interaction points
+3. **Adapters as Implementations**: Concrete implementations connecting to external world
+4. **Dependency Inversion**: Outer layers depend on inner layers, never reverse
+
+### 4.3 Python Implementation Pattern
+
+```python
+# Port (Abstract Interface)
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+class IWorkItemRepository(Protocol):
+    """Secondary Port - Driven by application"""
+    def save(self, item: WorkItem) -> None: ...
+    def get(self, id: WorkItemId) -> WorkItem | None: ...
+
+# Domain Entity
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+@dataclass
+class WorkItem:
+    """Aggregate Root"""
+    id: UUID = field(default_factory=uuid4)
+    title: str = ""
+    status: str = "pending"
+
+    def complete(self) -> None:
+        if self.status == "completed":
+            raise DomainError("Already completed")
+        self.status = "completed"
+
+# Adapter (Infrastructure)
+class SQLiteWorkItemRepository:
+    """Secondary Adapter - Implements Port"""
+    def __init__(self, db_path: str):
+        self.conn = sqlite3.connect(db_path)
+
+    def save(self, item: WorkItem) -> None:
+        # Implementation
+        pass
+```
+
+---
+
+## 5. Risk Analysis
+
+### 5.1 Python Zero-Dependency Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Stdlib inadequacy discovered late | Low | High | Proof-of-concept first |
+| Performance bottlenecks | Low | Medium | Profile early |
+| Type safety gaps | Medium | Medium | Use mypy if available, defensive coding |
+| Testing limitations | Low | Medium | unittest is sufficient |
+
+### 5.2 External Dependency Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Package installation failure | Medium | Critical | Zero-dep eliminates |
+| Version conflicts | Medium | High | Zero-dep eliminates |
+| Network unavailable | Medium | Critical | Zero-dep eliminates |
+| Security vulnerabilities | Medium | High | Zero-dep reduces surface |
+| Startup latency | High | Medium | Zero-dep eliminates |
+
+---
+
+## 6. Recommendation
+
+### 6.1 Primary Recommendation
+
+**Adopt Python with zero/minimal external dependencies.**
+
+Rationale:
+1. **Reliability**: No network dependency for package installation
+2. **Simplicity**: Reduced complexity and failure modes
+3. **Alignment**: Python's stdlib philosophy matches our constraints
+4. **Feasibility**: All required components achievable with stdlib
+5. **Environment**: Pre-installed and fully supported
+
+### 6.2 Allowed Dependencies (if absolutely necessary)
+
+If stdlib proves insufficient, prefer pre-installed packages:
+- `numpy` - Pre-installed, for any numerical operations
+- `poetry` - Pre-installed, for dependency management IF needed
+
+### 6.3 Recommended Stdlib Stack
+
+| Layer | Stdlib Components |
+|-------|-------------------|
+| **Domain** | `dataclasses`, `abc`, `typing`, `uuid`, `datetime`, `enum` |
+| **Application** | `typing.Protocol`, `collections`, `functools` |
+| **Infrastructure** | `sqlite3`, `json`, `pathlib`, `os` |
+| **Interface** | `argparse`, `http.server` (if needed) |
+| **Testing** | `unittest`, `unittest.mock` |
+
+---
+
+## 7. Self-Critique
+
+### 7.1 Potential Weaknesses in This Analysis
+
+1. **Bias toward simplicity**: My preference for zero-dependency may undervalue the productivity gains from well-chosen libraries
+2. **Limited TypeScript stdlib knowledge**: Node.js ecosystem may have more stdlib than I credit
+3. **Theoretical vs practical**: Should validate with proof-of-concept before committing
+4. **Mypy availability**: Assumed mypy might not be available; should verify
+
+### 7.2 Recommended Validation Steps
+
+1. Create minimal proof-of-concept with Python stdlib only
+2. Verify sqlite3 persistence works in sandbox environment
+3. Test SessionStart hook reliability for fallback dependency installation
+4. Benchmark token usage of Python vs TypeScript implementations
+
+---
+
+## 8. References
+
+### Primary Sources
+
+1. Cockburn, A. (2005). "Hexagonal Architecture." https://alistair.cockburn.us/hexagonal-architecture/
+2. Anthropic. (2025). "Claude Code on the web." https://www.anthropic.com/news/claude-code-on-the-web
+3. Anthropic. (2025). "Effective context engineering for AI agents." https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+4. Claude Code Docs. "Sandboxing." https://code.claude.com/docs/en/sandboxing
+5. Claude Code Docs. "Claude Code on the web." https://code.claude.com/docs/en/claude-code-on-the-web
+
+### Secondary Sources
+
+6. Chroma Research. "Context Rot: How Increasing Input Tokens Impacts LLM Performance." https://research.trychroma.com/context-rot
+7. Inkeep. "Fighting Context Rot." https://inkeep.com/blog/fighting-context-rot
+8. GitHub. "domain-driven-hexagon." https://github.com/Sairyss/domain-driven-hexagon
+9. GitHub. "hexagonal-architecture-with-python." https://github.com/marcosvs98/hexagonal-architecture-with-python
+10. Medium. "Zero-Dependency Python: Building Tools That Avoid External Libraries." https://medium.com/@CodeWithHannan/zero-dependency-python-building-tools-that-avoid-external-libraries-f2a8f5092b57
+11. Software Patterns Lexicon. "Hexagonal Architecture: Ports and Adapters in Python." https://softwarepatternslexicon.com/python/architectural-patterns/hexagonal-architecture-ports-and-adapters/
+
+---
+
+## Appendix A: Migration Path
+
+If we need to migrate from zero-dep to library-based later:
+
+| Current (Stdlib) | Future (Library) | Migration Complexity |
+|-----------------|------------------|---------------------|
+| `dataclasses` | Pydantic | Low - similar API |
+| `sqlite3` | SQLAlchemy | Medium - abstracted by port |
+| `argparse` | Click/Typer | Low - adapter only |
+| `unittest` | pytest | Low - compatible |
+| `json` | orjson | Low - drop-in |
+
+The hexagonal architecture explicitly enables this migration by isolating technology choices in adapters.
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1 | 2026-01-07 | Claude | Initial draft |

--- a/docs/archive/projects-archive/research/TOON_FORMAT_ANALYSIS.md
+++ b/docs/archive/projects-archive/research/TOON_FORMAT_ANALYSIS.md
@@ -1,0 +1,566 @@
+# TOON Format Analysis
+
+> **Research ID:** RESEARCH-025
+> **Slug:** toon-format-analysis
+> **Name:** TOON (Token-Oriented Object Notation) Format Analysis
+> **Short Description:** Comprehensive analysis of TOON format for LLM-optimized data serialization with 30-60% token reduction.
+> **Created:** 2026-01-08 (Session claude/create-code-plugin-skill-MG1nh)
+> **Version:** 1.0.0
+> **Status:** COMPLETE
+> **Hash:** (computed on export)
+
+---
+
+## Executive Summary
+
+TOON (Token-Oriented Object Notation) is a compact, human-readable serialization format designed specifically for LLM prompts. This analysis evaluates TOON for integration into Jerry's domain entity persistence layer alongside JSON.
+
+**Key Findings:**
+- 30-60% token reduction vs JSON (verified by benchmarks)
+- 74% LLM accuracy vs JSON's 70% in mixed-structure tests
+- Lossless JSON conversion (JSON ↔ TOON round-trip)
+- Python implementation available (`python-toon` package)
+- Specification v3.0 released November 2025
+
+**Recommendation:** INTEGRATE - Add TOON serialization as secondary format alongside JSON for LLM-facing operations.
+
+---
+
+## I. Understanding TOON (Multi-Level Explanation)
+
+### Level 0: ELI5 (Explain Like I'm 5)
+
+Imagine you have a list of your toys with their names and colors. In JSON (the old way), you'd write:
+
+```json
+[{"name": "truck", "color": "red"}, {"name": "ball", "color": "blue"}]
+```
+
+That's 58 characters! With TOON (the new way), you write:
+
+```
+toys[2]{name,color}:
+  truck,red
+  ball,blue
+```
+
+That's only 35 characters! TOON is like writing a neat table instead of repeating `{"name":` and `"color":` over and over. AI understands both the same way, but TOON is shorter and costs less money to send.
+
+**Why It Matters:** When talking to AI, you pay for each "word" (token). TOON uses fewer words to say the same thing, so it costs less money.
+
+### Level 1: Software Engineer Explanation
+
+TOON is a line-oriented, indentation-based serialization format that encodes the JSON data model with explicit structure and minimal quoting. Key characteristics:
+
+**Syntax Design:**
+- Objects use `key: value` notation (YAML-like)
+- Arrays declare length and optional schema: `items[3]{id,name}:`
+- Tabular arrays use CSV-style rows for uniform objects
+- Minimal quoting (only when ambiguous)
+
+**Core Operations:**
+```python
+from toon import encode, decode
+
+# Encoding: Python → TOON
+data = {"users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}
+toon_str = encode(data)
+# Output:
+# users[2]{id,name}:
+#   1,Alice
+#   2,Bob
+
+# Decoding: TOON → Python
+parsed = decode(toon_str)
+assert parsed == data  # Lossless round-trip
+```
+
+**Token Efficiency:**
+- Eliminates redundant brackets, braces, and quotes
+- Array headers declare structure once, not per element
+- CSV-style rows for uniform object arrays
+- Explicit length markers enable validation
+
+**Integration Points:**
+- `pip install python-toon` for Python implementation
+- CLI tool for batch conversion: `toon input.json -o output.toon`
+- UTF-8 encoding, `.toon` extension, `text/toon` media type
+
+### Level 2: Principal Architect Explanation
+
+TOON represents a paradigm shift in data serialization for LLM contexts. The specification (v3.0) provides formal guarantees that make it suitable for production systems:
+
+**Architectural Implications:**
+
+1. **Dual Serialization Strategy:**
+   - JSON: Primary persistence format (database, API boundaries, external systems)
+   - TOON: Secondary format for LLM prompt injection and context windows
+   - Benefit: Optimize separately for storage vs. inference costs
+
+2. **Schema Inference vs. Declaration:**
+   - TOON's tabular format (`[N]{field1,field2}:`) makes schema explicit
+   - Enables LLM validation via length markers and field lists
+   - Reduces hallucination by providing structural anchors
+
+3. **Token Economics:**
+   - At $0.015/1K input tokens (Claude Sonnet), 40% reduction = 40% cost savings
+   - For high-volume applications (thousands of requests/day), savings compound
+   - Production case study: Scalevise reported 50%+ reduction with 15% latency improvement
+
+4. **Conformance Requirements:**
+   - Deterministic object key ordering (reproducible outputs)
+   - Canonical number formatting (no exponents, no trailing zeros)
+   - Strict mode for validation (length mismatches, escape sequences)
+   - Security considerations built-in (quoting prevents injection)
+
+5. **Trade-offs:**
+   - Best for: Uniform arrays of objects (tabular data)
+   - Acceptable for: Nested objects, primitive arrays
+   - Suboptimal for: Deeply nested, non-uniform structures (use JSON)
+   - Overhead: 5-10% for flat datasets vs CSV
+
+**Decision Matrix:**
+
+| Data Shape | TOON Benefit | Recommendation |
+|------------|--------------|----------------|
+| Tabular arrays | 40-60% reduction | TOON |
+| Mixed structures | 20-40% reduction | TOON |
+| Deeply nested | 0-10% reduction | JSON |
+| Streaming/partial | N/A | JSON |
+
+---
+
+## II. Technical Specification Analysis
+
+### A. Format Syntax (ABNF Summary)
+
+Based on TOON Specification v3.0 (2025-11-24):
+
+```abnf
+; Root forms
+document      = root-object / root-array / single-primitive
+
+; Object syntax
+object        = *( key ":" SP value LF )
+key           = unquoted-key / quoted-key
+
+; Array header syntax
+array-header  = key "[" length delimiter? "]" [ "{" field-list "}" ] ":" [ SP inline-values ]
+length        = 1*DIGIT
+delimiter     = "," / HTAB / "|"
+field-list    = key *( delimiter key )
+
+; Array forms
+primitive-array = array-header SP value-list  ; inline
+tabular-array   = array-header LF *(indent row LF)  ; rows
+expanded-array  = array-header LF *("- " value LF)  ; nested
+```
+
+**Citation:** [TOON Specification v3.0](https://github.com/toon-format/spec)
+
+### B. Data Type Mapping
+
+| JSON Type | TOON Representation | Quoting Required |
+|-----------|---------------------|------------------|
+| `string` | Unquoted or quoted | When ambiguous* |
+| `number` | Canonical decimal | Never |
+| `boolean` | `true`/`false` | Never |
+| `null` | `null` | Never |
+| `object` | Indented key-value | N/A |
+| `array` | Header + rows/inline | N/A |
+
+*Quoting required when: empty, leading/trailing whitespace, looks numeric, contains special chars, matches reserved literals, matches delimiter.
+
+**Citation:** [TOON Specification §6-8](https://github.com/toon-format/spec)
+
+### C. Number Canonicalization
+
+Encoders MUST emit numbers in canonical form:
+
+```python
+# Specification requirements
+1e6       → 1000000      # No exponents
+1.5000    → 1.5          # No trailing zeros
+01        → 1            # No leading zeros
+-0        → 0            # No negative zero
+0.0       → 0            # Integer when possible
+```
+
+**Citation:** [TOON Specification §5](https://github.com/toon-format/spec)
+
+### D. Escape Sequences
+
+Only five escapes permitted (strict subset of JSON):
+
+| Escape | Character |
+|--------|-----------|
+| `\\` | Backslash |
+| `\"` | Double quote |
+| `\n` | Newline |
+| `\r` | Carriage return |
+| `\t` | Tab |
+
+Invalid escapes (e.g., `\u0041`, `\/`) cause decode errors.
+
+**Citation:** [TOON Specification §7](https://github.com/toon-format/spec)
+
+---
+
+## III. Benchmark Analysis
+
+### A. Token Reduction Benchmarks
+
+| Dataset Type | JSON Tokens | TOON Tokens | Reduction | Source |
+|--------------|-------------|-------------|-----------|--------|
+| GitHub Repos (100 records) | 15,145 | 8,745 | 42.3% | [1] |
+| Pretty-printed JSON | baseline | -55% | 55% | [2] |
+| Compact JSON | baseline | -25% | 25% | [2] |
+| YAML equivalent | baseline | -38% | 38% | [2] |
+| Mixed structures (avg) | baseline | -39.6% | 39.6% | [3] |
+
+**Sources:**
+1. [Analytics Vidhya: Reduce Token Costs with TOON](https://www.analyticsvidhya.com/blog/2025/11/toon-token-oriented-object-notation/)
+2. [TOON Playground Benchmarks](https://toonformat.dev/)
+3. [TOON GitHub Repository Benchmarks](https://github.com/toon-format/toon)
+
+### B. LLM Accuracy Benchmarks
+
+| Model | JSON Accuracy | TOON Accuracy | Token Difference |
+|-------|---------------|---------------|------------------|
+| claude-haiku-4-5-20251001 | ~70% | ~74% | -40% |
+| gemini-2.5-flash | ~70% | ~74% | -40% |
+| gpt-5-nano | 70% | 99.4% | -46% |
+| grok-4-fast-non-reasoning | ~70% | ~74% | -40% |
+
+**Key Finding:** TOON achieves 73.9% accuracy vs JSON's 69.7% while using 39.6% fewer tokens.
+
+**Citation:** [TOON GitHub Benchmarks](https://github.com/toon-format/toon)
+
+### C. Production Deployment Results
+
+**Scalevise Case Study:**
+- 50%+ token reduction across thousands of daily API requests
+- 15% latency improvement
+- Models: ChatGPT and Claude APIs
+
+**Citation:** [Medium: TOON - The Data Format Slashing LLM Costs by 50%](https://medium.com/codex/toon-the-data-format-slashing-llm-costs-by-50-ac8d7b808ff6)
+
+---
+
+## IV. Integration Design for Jerry
+
+### A. Dual Serialization Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Jerry Domain Layer                    │
+│                                                         │
+│  ┌───────────────┐                                      │
+│  │ Domain Entity │                                      │
+│  │  (Task, etc.) │                                      │
+│  └───────┬───────┘                                      │
+│          │                                              │
+│          ▼                                              │
+│  ┌───────────────────────────────────────┐              │
+│  │       Serialization Port              │              │
+│  │  serialize(entity) → str              │              │
+│  │  deserialize(str) → entity            │              │
+│  └───────────────┬───────────────────────┘              │
+│                  │                                      │
+└──────────────────┼──────────────────────────────────────┘
+                   │
+    ┌──────────────┴──────────────┐
+    ▼                             ▼
+┌────────────────┐        ┌────────────────┐
+│ JSON Adapter   │        │ TOON Adapter   │
+│                │        │                │
+│ - Persistence  │        │ - LLM Prompts  │
+│ - API I/O      │        │ - Context Win. │
+│ - External     │        │ - Cost Optim.  │
+└────────────────┘        └────────────────┘
+```
+
+### B. Implementation Strategy
+
+**Port Definition (Domain Layer):**
+```python
+# src/domain/ports/serialization.py
+from abc import ABC, abstractmethod
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+class SerializationPort(ABC, Generic[T]):
+    """Port for entity serialization."""
+
+    @abstractmethod
+    def serialize(self, entity: T) -> str:
+        """Serialize entity to string format."""
+        ...
+
+    @abstractmethod
+    def deserialize(self, data: str, entity_type: type[T]) -> T:
+        """Deserialize string to entity."""
+        ...
+
+    @property
+    @abstractmethod
+    def format_name(self) -> str:
+        """Return format identifier ('json' or 'toon')."""
+        ...
+```
+
+**Adapter Implementation (Infrastructure Layer):**
+```python
+# src/infrastructure/adapters/toon_adapter.py
+from toon import encode, decode
+from ..domain.ports.serialization import SerializationPort
+
+class ToonSerializationAdapter(SerializationPort[T]):
+    """TOON serialization adapter for LLM-optimized output."""
+
+    def serialize(self, entity: T) -> str:
+        """Serialize entity to TOON format."""
+        # Convert dataclass to dict, then to TOON
+        entity_dict = asdict(entity) if is_dataclass(entity) else entity
+        return encode(entity_dict)
+
+    def deserialize(self, data: str, entity_type: type[T]) -> T:
+        """Deserialize TOON string to entity."""
+        parsed = decode(data)
+        return entity_type(**parsed)
+
+    @property
+    def format_name(self) -> str:
+        return "toon"
+```
+
+### C. Usage Scenarios
+
+| Scenario | Format | Rationale |
+|----------|--------|-----------|
+| Database persistence | JSON | Standard tooling, query support |
+| API responses | JSON | Interoperability, tooling |
+| LLM prompt injection | TOON | Token efficiency |
+| Context window management | TOON | Cost optimization |
+| Export for human review | JSON | Readability (unless tabular) |
+| CloudEvents payload | JSON | Spec compliance |
+
+### D. Configuration
+
+```yaml
+# jerry.yaml
+serialization:
+  primary: json
+  llm_optimized: toon
+  auto_select: true  # Use TOON when data is tabular
+
+  toon_options:
+    indent: 2
+    delimiter: ","
+    length_marker: true  # Enable validation markers
+    strict_mode: true    # Validate on decode
+```
+
+---
+
+## V. Risk Assessment
+
+### A. FMEA Analysis
+
+| Failure Mode | Effect | Cause | S | O | D | RPN | Mitigation |
+|--------------|--------|-------|---|---|---|-----|------------|
+| Schema mismatch on decode | Data corruption | Non-tabular data treated as tabular | 8 | 2 | 3 | 48 | Strict mode + validation |
+| Library deprecation | Maintenance burden | Young project | 5 | 3 | 4 | 60 | Dual format fallback |
+| Token estimate inaccurate | Cost overrun | Tokenizer differences | 3 | 4 | 5 | 60 | Monitor actual usage |
+| Escape sequence errors | Parse failure | Invalid input | 6 | 2 | 2 | 24 | Input sanitization |
+
+**Prior Art:** NASA FMEA (Systems Engineering Handbook, 2007)
+
+### B. Trade-off Analysis
+
+| Criterion | JSON | TOON | Winner |
+|-----------|------|------|--------|
+| Token efficiency | Baseline | +30-60% | TOON |
+| LLM accuracy | 70% | 74% | TOON |
+| Tooling maturity | Excellent | Limited | JSON |
+| Specification stability | RFC 8259 | v3.0 (2025) | JSON |
+| Human readability | Good | Good (tabular better) | Tie |
+| Streaming support | Yes | Limited | JSON |
+| Round-trip fidelity | Perfect | Perfect | Tie |
+
+---
+
+## VI. Discoveries
+
+### DISC-044: TOON Token Reduction Range
+
+**ID:** DISC-044
+**Slug:** toon-token-reduction-range
+**Name:** TOON Achieves 30-60% Token Reduction vs JSON
+**Short Description:** TOON format reduces LLM tokens by 30-60% depending on data shape, with tabular arrays showing highest gains.
+
+**Long Description:**
+TOON (Token-Oriented Object Notation) achieves significant token reduction compared to JSON through several mechanisms: (1) elimination of redundant structural characters like brackets and braces, (2) single schema declaration for array headers instead of per-element, (3) minimal quoting rules that only quote when semantically necessary, and (4) CSV-style tabular representation for uniform object arrays. Benchmarks across multiple datasets show 25% reduction vs compact JSON, 55% vs pretty-printed JSON, and up to 58.9% for large tabular datasets like GitHub repository data (15,145 → 8,745 tokens).
+
+**Evidence:**
+- [TOON GitHub Benchmarks](https://github.com/toon-format/toon)
+- [Analytics Vidhya Analysis](https://www.analyticsvidhya.com/blog/2025/11/toon-token-oriented-object-notation/)
+
+**Level Impact:**
+- **L0:** TOON makes sending data to AI cheaper because it uses fewer "words"
+- **L1:** Implement TOON serialization for LLM-facing operations to reduce API costs
+- **L2:** Design dual serialization strategy with JSON for persistence, TOON for inference
+
+---
+
+### DISC-045: TOON Improves LLM Accuracy
+
+**ID:** DISC-045
+**Slug:** toon-improves-llm-accuracy
+**Name:** TOON Format Improves LLM Accuracy by 4-29% Over JSON
+**Short Description:** TOON's explicit structure improves LLM parsing accuracy from 70% (JSON) to 74-99% depending on model.
+
+**Long Description:**
+Contrary to the assumption that format changes might confuse LLMs, TOON actually improves accuracy. Benchmarks across four major models (claude-haiku-4-5, gemini-2.5-flash, gpt-5-nano, grok-4-fast) show TOON achieves 73.9% average accuracy vs JSON's 69.7% on structured data retrieval tasks. GPT-5-nano shows the most dramatic improvement at 99.4% accuracy with TOON vs 70% with JSON. The improvement is attributed to TOON's explicit length markers and schema declarations that provide structural anchors for LLM parsing.
+
+**Evidence:**
+- [TOON Benchmark Results](https://github.com/toon-format/toon)
+- Models tested: claude-haiku-4-5-20251001, gemini-2.5-flash, gpt-5-nano, grok-4-fast-non-reasoning
+
+**Level Impact:**
+- **L0:** AI understands TOON data better than JSON data
+- **L1:** Use TOON for structured data in prompts to improve extraction accuracy
+- **L2:** Evaluate TOON for accuracy-critical pipelines, not just cost optimization
+
+---
+
+### DISC-046: TOON Specification Maturity
+
+**ID:** DISC-046
+**Slug:** toon-specification-maturity
+**Name:** TOON Spec v3.0 Provides Production-Ready Guarantees
+**Short Description:** TOON specification v3.0 includes formal grammar, conformance requirements, and 349 test fixtures.
+
+**Long Description:**
+TOON specification version 3.0 (released 2025-11-24) provides production-grade rigor: complete ABNF grammar definitions, deterministic encoding requirements (key ordering, canonical numbers), strict mode validation (length mismatches, escape sequences, indentation), and security considerations (quoting prevents injection). The specification includes 349 test fixtures for language-agnostic conformance testing. Implementations exist in TypeScript (reference), Python, Go, Rust, and .NET. The format uses `text/toon` media type (pending IANA registration) and `.toon` file extension.
+
+**Evidence:**
+- [TOON Specification v3.0](https://github.com/toon-format/spec)
+- [Python Implementation](https://github.com/xaviviro/python-toon)
+
+**Level Impact:**
+- **L0:** TOON has clear rules that everyone agrees on
+- **L1:** Rely on spec conformance for cross-language interoperability
+- **L2:** Monitor IANA registration and specification evolution for enterprise adoption
+
+---
+
+### DISC-047: TOON Optimal Data Shapes
+
+**ID:** DISC-047
+**Slug:** toon-optimal-data-shapes
+**Name:** TOON Optimal for Tabular Arrays, Suboptimal for Deep Nesting
+**Short Description:** TOON shows highest benefits for uniform object arrays, diminishing returns for deeply nested structures.
+
+**Long Description:**
+TOON's design optimizes for the "sweet spot" of uniform arrays of objects (tabular data) where CSV-like compactness combines with explicit structure. For such data, token reduction reaches 40-60%. Mixed structures show 20-40% reduction. Deeply nested or non-uniform data may show minimal benefit (0-10%) and JSON may be preferred. For flat primitive datasets, CSV remains most compact (TOON adds 5-10% overhead for structure markers). This informs the decision matrix for when to use TOON vs JSON in Jerry's serialization layer.
+
+**Evidence:**
+- [TOON Format Documentation](https://github.com/toon-format/toon)
+- [Benjamin Abt Analysis](https://benjamin-abt.com/blog/2025/12/12/ai-toon-format/)
+
+**Level Impact:**
+- **L0:** TOON works best for list-of-things data, not deeply nested data
+- **L1:** Implement auto-detection to choose TOON for tabular, JSON for nested
+- **L2:** Profile actual domain data shapes to quantify expected TOON benefit
+
+---
+
+### DISC-048: TOON Python Integration Path
+
+**ID:** DISC-048
+**Slug:** toon-python-integration-path
+**Name:** python-toon Package Provides Production-Ready Integration
+**Short Description:** The python-toon package offers encode/decode API, CLI tools, and configuration options for Jerry integration.
+
+**Long Description:**
+The `python-toon` package (pip install python-toon) provides a complete implementation: `encode(value, options)` for Python→TOON, `decode(input_str, options)` for TOON→Python, CLI tool for batch conversion (`toon input.json -o output.toon`), and configuration options (indent, delimiter, length_marker, strict_mode). The API aligns with Python's `json` module patterns, making integration straightforward. Strict mode enables validation of length declarations and escape sequences. The package is maintained by Xavi Viro and follows the TOON spec v3.0.
+
+**Evidence:**
+- [python-toon GitHub](https://github.com/xaviviro/python-toon)
+- [PyPI Package](https://pypi.org/project/python-toon/)
+
+**Level Impact:**
+- **L0:** We can add TOON to Jerry with just `pip install python-toon`
+- **L1:** Create ToonSerializationAdapter implementing SerializationPort
+- **L2:** Evaluate python-toon maintenance status and consider vendoring strategy
+
+---
+
+## VII. Action Items
+
+| ID | Action | Priority | Owner | Status |
+|----|--------|----------|-------|--------|
+| ACT-025.1 | Add `python-toon` to dependencies | HIGH | Dev | PENDING |
+| ACT-025.2 | Define SerializationPort in domain layer | HIGH | Dev | PENDING |
+| ACT-025.3 | Implement ToonSerializationAdapter | HIGH | Dev | PENDING |
+| ACT-025.4 | Add TOON format tests | MEDIUM | Dev | PENDING |
+| ACT-025.5 | Profile token reduction for Jerry entities | MEDIUM | Dev | PENDING |
+| ACT-025.6 | Document TOON usage in CLAUDE.md | LOW | Dev | PENDING |
+
+---
+
+## VIII. References
+
+### Primary Sources
+
+1. **TOON Specification v3.0** (2025-11-24)
+   - URL: https://github.com/toon-format/spec
+   - License: MIT
+   - Author: Johann Schopplich
+
+2. **python-toon Library**
+   - URL: https://github.com/xaviviro/python-toon
+   - PyPI: https://pypi.org/project/python-toon/
+   - Author: Xavi Viro
+
+3. **TOON Reference Implementation** (TypeScript)
+   - URL: https://github.com/toon-format/toon
+   - Includes: Benchmarks, test fixtures
+
+### Secondary Sources
+
+4. **InfoQ News** (November 2025)
+   - "New Token-Oriented Object Notation (TOON) Hopes to Cut LLM Costs by Reducing Token Consumption"
+   - URL: https://www.infoq.com/news/2025/11/toon-reduce-llm-cost-tokens/
+
+5. **Analytics Vidhya** (November 2025)
+   - "Reduce Token Costs for LLMs with TOON"
+   - URL: https://www.analyticsvidhya.com/blog/2025/11/toon-token-oriented-object-notation/
+
+6. **Medium/CodeX** (November 2025)
+   - "TOON: The Data Format Slashing LLM Costs by 50%"
+   - URL: https://medium.com/codex/toon-the-data-format-slashing-llm-costs-by-50-ac8d7b808ff6
+
+7. **Benjamin Abt Blog** (December 2025)
+   - "TOON Format: Token-Oriented Object Notation for LLM-Friendly Data Exchange"
+   - URL: https://benjamin-abt.com/blog/2025/12/12/ai-toon-format/
+
+---
+
+## IX. PS Integration
+
+**Problem Statement:** Phase 3.5 Agent Reorganization / WORK-025
+**Entry Type:** RESEARCH
+**Severity:** MEDIUM
+**Resolution:** COMPLETE
+
+**Artifacts:**
+- This document: `docs/research/TOON_FORMAT_ANALYSIS.md`
+- Discoveries: DISC-044 through DISC-048
+
+**Next Steps:**
+1. Add discoveries to WORKTRACKER.md Phase DISCOVERY
+2. Create implementation tasks in Phase 3 backlog
+3. Update PLAN.md with TOON serialization milestone

--- a/docs/archive/projects-archive/research/work-031-e-001-gremlin-modeling.md
+++ b/docs/archive/projects-archive/research/work-031-e-001-gremlin-modeling.md
@@ -1,0 +1,1669 @@
+# Graph Modeling Best Practices for Gremlin Migration
+
+> **Research ID:** WORK-031-E-001
+> **Research Date:** 2026-01-08
+> **Researcher:** ps-researcher agent (v2.0.0)
+> **Status:** DECISION-GRADE
+> **Purpose:** Research graph modeling best practices for successful Gremlin migration
+
+---
+
+## Context
+
+This research extends `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md` which already covers:
+- Property Graph model fundamentals
+- VertexId hierarchy design
+- Basic Gremlin traversals
+- Jerry Work Tracker graph schema
+
+This document adds:
+- Migration patterns from relational/document to graph
+- Anti-patterns and common pitfalls
+- Performance optimization strategies
+- Schema design and evolution patterns
+- Industry best practices from TinkerPop, JanusGraph, and AWS Neptune
+
+---
+
+## L0: Executive Summary (Plain Language)
+
+### Key Findings
+
+Moving to a graph database with Gremlin requires careful attention to five critical areas:
+
+1. **Schema Design Philosophy**: Unlike relational databases that are designed for data storage, graph databases should be **designed for queryability**. Your graph model and your queries are two sides of the same coin. The graph structure should directly reflect the paths you'll traverse in queries.
+
+2. **The Supernode Problem**: The most common graph database failure pattern is creating "supernodes" - nodes with thousands or millions of connections. This happens when you have high cardinality mismatches (e.g., 20 million products linked to 12 categories). Supernodes create performance "hairballs" that grind traversals to a halt.
+
+3. **Migration Success Pattern**: The most successful migrations follow a three-phase approach:
+   - **Phase 1**: Tables → Node types, Foreign keys → Edge types, Rows → Nodes
+   - **Phase 2**: Optimize for traversal patterns (denormalize, add redundant edges)
+   - **Phase 3**: Refactor based on query performance data
+
+4. **Index Strategy is Critical**: Graph databases handle indexes differently than relational databases. You must explicitly define indexes for frequently queried properties, and the indexing strategy directly impacts whether traversals can execute efficiently.
+
+5. **Performance is Query-Frontier Driven**: Graph size is mostly irrelevant. What matters is the "query frontier" - how many elements must be fetched to compute results. A query touching 10 nodes in a billion-node graph is faster than one touching 10,000 nodes in a 100-node graph.
+
+### Top Recommendations for Jerry
+
+1. **Adopt explicit schema definition** from the start (align with JanusGraph `schema.default=none` philosophy)
+2. **Implement supernode detection** in data modeling validation
+3. **Create migration smoke tests** that verify traversal patterns on representative data
+4. **Design indexes alongside schema**, not as an afterthought
+5. **Prioritize query patterns** that start at specific nodes and fan out, not analytical queries across entire graph
+
+---
+
+## L1: Technical Details
+
+### 1. Graph Modeling Patterns That Maximize Gremlin Compatibility
+
+#### 1.1 Design for Queryability (Netflix/Neo4j Pattern)
+
+**Source**: [Neo4j Data Modeling](https://neo4j.com/blog/graph-data-science/data-modeling-pitfalls/)
+
+**Core Principle**: Think of your application graph model and your queries as being two sides of the same coin. The graph is the superset of paths or graph patterns expressed in your queries.
+
+**Implementation Pattern**:
+
+```gremlin
+// ANTI-PATTERN: Model doesn't match query needs
+// You have to traverse through intermediate "Category" nodes
+g.V().has('Product', 'name', 'Widget')
+     .out('HAS_CATEGORY')
+     .out('CATEGORY_TO_DEPARTMENT')
+     .hasLabel('Department')
+
+// BETTER: Add direct edge for common traversal
+g.V().has('Product', 'name', 'Widget')
+     .out('IN_DEPARTMENT')  // Direct relationship
+     .hasLabel('Department')
+```
+
+**Jerry Application**: The Work Tracker should have direct `BELONGS_TO` edges from Task → Phase and Phase → Plan, even though this creates some redundancy. This matches our query patterns.
+
+#### 1.2 Property vs Relationship Decision Matrix
+
+**Source**: [Graph Modeling Best Practices](https://reeshabh-choudhary.medium.com/best-graph-modelling-practices-cdfd65a9d95d)
+
+| Scenario | Use Property | Use Relationship |
+|----------|-------------|------------------|
+| Doesn't impact traversal pattern | ✓ (e.g., `user.email`) | ✗ |
+| Frequently queried during traversal | ✗ | ✓ (e.g., user-[INTERESTED_IN]→interest) |
+| Shared across many nodes | ✗ (creates supernode) | ✓ (with mitigation) |
+| Singular value per entity | ✓ (e.g., `task.status`) | ✗ |
+| Many-to-many relationship | ✗ | ✓ (e.g., task-[DEPENDS_ON]→task) |
+
+**Jerry Decision**:
+- `task.status` → Property (singular, not traversed)
+- `task.title` → Property (singular, display only)
+- `phase_id` reference → Relationship `BELONGS_TO` (frequently traversed)
+- `created_by` → Relationship `CREATED_BY` → Actor node (enables actor-centric queries)
+
+#### 1.3 TinkerPop Type System Best Practices
+
+**Source**: [TinkerPop Documentation](https://tinkerpop.apache.org/docs/current/reference/)
+
+**Type Alignment**:
+
+```python
+# Jerry → Gremlin type mapping
+{
+    "PlanId": "g:UUID",           # Strongly typed IDs
+    "sequence": "g:Int64",        # Long integer for ordering
+    "progress": "g:Double",       # Float for percentages
+    "created_at": "g:Date",       # ISO timestamps
+    "subtask_ids": "g:List",      # JSON arrays
+    "metadata": "g:Map"           # Complex properties
+}
+```
+
+**Cardinality Settings** (JanusGraph):
+
+```python
+# Single value properties (most common)
+schema.propertyKey('title').Text().single().make()
+schema.propertyKey('status').Text().single().make()
+
+# List properties (ordered, allow duplicates)
+schema.propertyKey('tags').Text().list().make()
+
+# Set properties (no duplicates)
+schema.propertyKey('assigned_to_ids').Text().set().make()
+```
+
+**Jerry Application**: Use `SINGLE` cardinality for most properties. Only use `LIST` for audit trails or multi-valued attributes where order matters.
+
+---
+
+### 2. Anti-Patterns to Avoid
+
+#### 2.1 The Supernode Problem
+
+**Sources**:
+- [Neo4j: All About Super Nodes](https://medium.com/neo4j/graph-modeling-all-about-super-nodes-d6ad7e11015b)
+- [DataStax: Property Graph Modeling with FU Towards Supernodes](https://www.datastax.com/blog/property-graph-modeling-fu-towards-supernodes-jonathan-lacefield)
+
+**Definition**: A node with an abnormally high number of edges compared to the average node in the graph (e.g., thousands vs tens).
+
+**How Supernodes Form**:
+
+```
+Cardinality Mismatch Example:
+- Products: 20,000,000 nodes
+- Categories: 12 nodes
+- Relationship: Product-[IN_CATEGORY]→Category
+
+Result: 12 supernodes (categories) with ~1.67M edges each
+```
+
+**Visual Indicator**: If you visualize the graph and get a "hairball" with nodes densely connected to everything, those are your supernodes.
+
+**Performance Impact**:
+- Traversals that touch supernodes become O(n) operations where n = edge count
+- Index lookups degrade
+- Query planner can't optimize effectively
+- Memory consumption spikes
+
+**Mitigation Strategies**:
+
+1. **Time-Based Partitioning** (for event/temporal data):
+```gremlin
+// ANTI-PATTERN: Single scanner node
+Scanner-[SCANNED]→Item (millions of edges)
+
+// BETTER: Partition by time
+Scanner-[SCANNED_2026_01]→Item
+Scanner-[SCANNED_2026_02]→Item
+```
+
+2. **Hierarchical Decomposition** (for taxonomies):
+```gremlin
+// ANTI-PATTERN: Flat category structure
+Product-[IN_CATEGORY]→Electronics (supernode)
+
+// BETTER: Multi-level hierarchy
+Product-[IN_SUBCATEGORY]→Laptops-[PARENT_CATEGORY]→Electronics
+```
+
+3. **Relationship Type Diversification**:
+```gremlin
+// ANTI-PATTERN: Generic relationship
+Item-[RELATED_TO]→Scanner_001 (all items use same edge label)
+
+// BETTER: Typed relationships by scanner ID
+Item-[SCANNED_BY_001]→Scanner_001
+Item-[SCANNED_BY_002]→Scanner_002
+```
+
+4. **Intermediate Index Nodes**:
+```gremlin
+// For range queries on high-cardinality properties
+Product-[PRICE_RANGE]→Price_100_199-[IN_RANGE]→Product
+```
+
+**Jerry Supernode Risk Analysis**:
+
+| Potential Supernode | Risk Level | Mitigation |
+|---------------------|------------|------------|
+| Plan (1 plan, many phases) | **LOW** - Expected max 10-20 phases | None needed |
+| Phase (1 phase, many tasks) | **MEDIUM** - Could have 100+ tasks | Monitor; partition by status if >500 |
+| Actor (1 actor, many tasks) | **HIGH** - Claude could create 1000s | Add time-based edges: CREATED_2026_01 |
+| Event (1 aggregate, many events) | **MEDIUM** - Event sourcing growth | Partition by sequence ranges |
+
+**Recommendation for Jerry**: Implement supernode detection in schema validation:
+
+```python
+# Pseudocode for Jerry validation
+MAX_EDGES_BEFORE_WARNING = 100
+MAX_EDGES_BEFORE_ERROR = 1000
+
+def validate_node_degree(vertex_id: VertexId, edge_label: str) -> ValidationResult:
+    edge_count = count_edges(vertex_id, edge_label)
+    if edge_count > MAX_EDGES_BEFORE_ERROR:
+        return Error(f"Supernode detected: {vertex_id} has {edge_count} {edge_label} edges")
+    elif edge_count > MAX_EDGES_BEFORE_WARNING:
+        return Warning(f"Approaching supernode: {vertex_id} has {edge_count} {edge_label} edges")
+    return Ok()
+```
+
+#### 2.2 Over-Indexing
+
+**Source**: [JanusGraph Schema Documentation](https://docs.janusgraph.org/schema/)
+
+**Problem**: Creating indexes for every property wastes resources and slows down writes.
+
+**Best Practice**: Only index properties that:
+1. Appear in `has()` steps to start traversals
+2. Are used in `where()` filter predicates frequently
+3. Have high selectivity (narrow down results significantly)
+
+**Example**:
+
+```gremlin
+// If this is your query pattern:
+g.V().has('Task', 'id', 'TASK-001')  // Index on id (yes)
+     .has('status', 'PENDING')        // Index on status (maybe - low selectivity)
+     .values('description')           // No index on description (never queried)
+```
+
+**Jerry Index Strategy**:
+
+```python
+# Primary indexes (required for traversal start points)
+REQUIRED_INDEXES = [
+    ('Plan', 'id'),      # g.V().has('Plan', 'id', 'PLAN-001')
+    ('Phase', 'id'),     # g.V().has('Phase', 'id', 'PHASE-001')
+    ('Task', 'id'),      # g.V().has('Task', 'id', 'TASK-001')
+]
+
+# Secondary indexes (for filtering)
+OPTIONAL_INDEXES = [
+    ('Task', 'status'),   # Moderate selectivity, frequently filtered
+    ('Plan', 'status'),   # Moderate selectivity
+]
+
+# DO NOT INDEX
+NO_INDEX = [
+    ('Task', 'description'),   # Free text, never filtered
+    ('Task', 'title'),         # Free text, low selectivity
+    ('Event', 'data'),         # JSON blob, not queryable
+]
+```
+
+#### 2.3 Ignoring Direction in Traversals
+
+**Source**: [AWS Neptune Best Practices](https://docs.aws.amazon.com/neptune/latest/userguide/best-practices.html)
+
+**Problem**: Using bidirectional traversals without edge labels is expensive:
+
+```gremlin
+// ANTI-PATTERN: Unconstrained bidirectional traversal
+g.V('TASK-001').both()  // Checks ALL edges in both directions
+
+// BETTER: Specify direction and label
+g.V('TASK-001').out('CONTAINS')  // Only outgoing CONTAINS edges
+```
+
+**Performance Impact** (from Neptune docs):
+- `both()` without label: O(2 * edge_count)
+- `both('LABEL')` with label: O(matching_edges)
+- `out('LABEL')` directional: O(matching_edges / 2)
+
+**Jerry Application**: All traversals should specify direction and label:
+
+```gremlin
+// Get all subtasks (good)
+g.V().has('Task', 'id', 'TASK-001')
+     .out('CONTAINS')
+     .hasLabel('Subtask')
+
+// Get parent phase (good)
+g.V().has('Task', 'id', 'TASK-001')
+     .in('CONTAINS')
+     .hasLabel('Phase')
+```
+
+#### 2.4 Not Using Upsert Patterns (mergeV/mergeE)
+
+**Source**: [TinkerPop 3.8.0 Release](https://tinkerpop.apache.org/)
+
+**Problem**: Creating duplicate vertices/edges instead of updating existing ones.
+
+**TinkerPop 3.6+ Solution**:
+
+```gremlin
+// Create task if not exists (mergeV pattern)
+g.mergeV([(T.label): 'Task', (T.id): 'TASK-001'])
+    .option(onCreate, [
+        title: 'New Task',
+        status: 'PENDING',
+        created_at: datetime()
+    ])
+    .option(onMatch, [
+        modified_at: datetime()
+    ])
+
+// Create edge if not exists (mergeE pattern)
+g.mergeE([
+    (T.label): 'CONTAINS',
+    (Direction.from): 'PHASE-001',
+    (Direction.to): 'TASK-001'
+])
+    .option(onCreate, [sequence: 1])
+```
+
+**Jerry Application**: Repository implementations should use mergeV/mergeE for all persistence operations to ensure idempotency.
+
+---
+
+### 3. Migration Strategies from Relational/Document to Graph
+
+**Sources**:
+- [FalkorDB: Relational to Graph Migration](https://www.falkordb.com/blog/relational-database-to-graph-database/)
+- [Medium: Mastering Data Migration](https://lolithasherley7.medium.com/mastering-data-migration-from-relational-to-graph-databases-strategies-tools-and-best-ec92d2902930)
+- [ACM: Migration of Data from Relational Database to Graph Database](https://dl.acm.org/doi/10.1145/3200842.3200852)
+
+#### 3.1 Three-Phase Migration Pattern
+
+**Phase 1: Direct Structural Mapping**
+
+```
+Relational → Graph Mapping:
+┌─────────────────┬──────────────────────────┐
+│ Relational      │ Graph                    │
+├─────────────────┼──────────────────────────┤
+│ Table           │ Vertex Label             │
+│ Row             │ Vertex Instance          │
+│ Column          │ Vertex Property          │
+│ Foreign Key     │ Edge                     │
+│ Join Table      │ Edge with Properties     │
+│ Primary Key     │ Vertex ID                │
+└─────────────────┴──────────────────────────┘
+```
+
+**Example**:
+
+```sql
+-- Relational schema
+CREATE TABLE tasks (
+    id VARCHAR PRIMARY KEY,
+    title TEXT,
+    phase_id VARCHAR REFERENCES phases(id),
+    status VARCHAR
+);
+
+CREATE TABLE task_dependencies (
+    from_task_id VARCHAR REFERENCES tasks(id),
+    to_task_id VARCHAR REFERENCES tasks(id),
+    dependency_type VARCHAR
+);
+```
+
+Converts to:
+
+```gremlin
+// Graph schema
+// Vertex: Task
+g.addV('Task')
+    .property('id', 'TASK-001')
+    .property('title', 'Implement feature')
+    .property('status', 'PENDING')
+
+// Edge: BELONGS_TO (from foreign key phase_id)
+g.V('TASK-001').addE('BELONGS_TO').to(V('PHASE-001'))
+
+// Edge: DEPENDS_ON (from join table)
+g.V('TASK-001').addE('DEPENDS_ON').to(V('TASK-002'))
+    .property('dependency_type', 'BLOCKS')
+```
+
+**Phase 2: Denormalization for Traversal Performance**
+
+Add redundant edges that match query patterns:
+
+```gremlin
+// Original: Task → Phase → Plan (2 hops)
+g.V('TASK-001')
+    .out('BELONGS_TO')  // Task → Phase
+    .out('BELONGS_TO')  // Phase → Plan
+
+// Optimized: Add direct edge
+g.V('TASK-001').addE('IN_PLAN').to(V('PLAN-001'))
+
+// Now: Task → Plan (1 hop)
+g.V('TASK-001').out('IN_PLAN')
+```
+
+**When to denormalize**:
+- Query pattern is common (>10% of traffic)
+- Multi-hop traversal is expensive (>3 hops)
+- Data consistency can be maintained (update both paths)
+
+**Phase 3: Schema Refactoring Based on Query Metrics**
+
+Use `profile()` to identify slow queries:
+
+```gremlin
+// Analyze query performance
+g.V().has('Task', 'status', 'PENDING')
+     .out('DEPENDS_ON')
+     .profile()
+
+// Look for high Time and % Dur in profile output
+// Refactor schema if:
+// - % Dur > 50% on a single step
+// - Time > 100ms for common queries
+```
+
+#### 3.2 ETL Best Practices
+
+**Source**: [Neo4j ETL Tools](https://www.integrate.io/blog/neo4j-etl-tools/)
+
+1. **Start with Use Cases**: Design graph models based on query requirements, not source schemas
+2. **Implement Incrementally**: Begin with pilot projects to validate transformation patterns
+3. **Deduplicate Before Migration**: Clean data in source system first
+4. **Backup Everything**: Ensure all data is backed up before migrating
+5. **Validate Post-Migration**: Check for missing or incorrect data
+
+**Jerry Migration Path** (File → SQLite → Graph):
+
+```
+Phase 1: JSON Files
+├── Vertices: Serialized as JSON objects
+├── Edges: Adjacency lists
+└── Queries: Application-level traversal
+
+Phase 2: SQLite with Graph Schema
+├── Vertices: vertices(id, label, properties JSONB)
+├── Edges: edges(id, label, out_v, in_v, properties JSONB)
+└── Queries: SQL + application traversal
+
+Phase 3: Native Graph DB (Optional)
+├── Target: Amazon Neptune / JanusGraph
+├── Migration: Export GraphSON → Import
+└── Queries: Native Gremlin traversal
+```
+
+#### 3.3 Transformation Algorithm (2024 Research)
+
+**Source**: [Data Science Journal: Transformation Algorithm](https://datascience.codata.org/articles/10.5334/dsj-2024-035)
+
+**Key Insight**: Use metamodeling from source to destination database and execute transformation rules.
+
+**Transformation Rules**:
+
+1. **Entity Table → Vertex**
+   ```
+   IF table has primary_key AND no foreign_keys to other tables
+   THEN create vertex label from table_name
+   ```
+
+2. **Relationship Table → Edge**
+   ```
+   IF table has multiple foreign_keys AND minimal other columns
+   THEN create edge label from table_name
+   AND map foreign_keys to out_v/in_v
+   ```
+
+3. **Foreign Key Column → Edge**
+   ```
+   IF column is foreign_key in entity table
+   THEN create edge label from column_name + "_TO_" + referenced_table
+   AND remove column from vertex properties
+   ```
+
+4. **Join Table → Edge with Properties**
+   ```
+   IF table has exactly 2 foreign_keys + additional columns
+   THEN create edge label
+   AND map additional columns to edge properties
+   ```
+
+---
+
+### 4. Performance Optimization Strategies
+
+**Sources**:
+- [AWS Neptune Query Tuning](https://docs.aws.amazon.com/neptune/latest/userguide/gremlin-traversal-tuning.html)
+- [Amazon Neptune EXPLAIN Plans](https://kategawron.co.uk/2025/05/amazon-neptune-explain/)
+- [DataStax: DSE Gremlin Queries](https://www.datastax.com/blog/dse-gremlin-queries-good-better-best)
+
+#### 4.1 Query Performance Fundamentals
+
+**Key Insight**: Graph size is mostly irrelevant. Performance is determined by the **query frontier** - the number of elements fetched to compute results.
+
+**Source**: AWS Neptune re:Post
+
+Example:
+- Query touching 10 nodes in 1 billion node graph: **Fast**
+- Query touching 10,000 nodes in 100 node graph: **Slow**
+
+#### 4.2 Using EXPLAIN and PROFILE
+
+**PROFILE Output Structure** (Neptune):
+
+```gremlin
+g.V().has('Task', 'id', 'TASK-001')
+     .out('CONTAINS')
+     .hasLabel('Subtask')
+     .profile()
+
+// Output columns:
+// - Step: The Gremlin step
+// - Time: Milliseconds the step took
+// - % Dur: Percent of total processing time
+// - Count: Number of traversers output
+```
+
+**What to Look For**:
+- Steps with **% Dur > 50%**: Primary bottlenecks
+- Steps with **Time > 100ms**: Needs optimization (for common queries)
+- **High Count with low selectivity**: Add filters earlier in traversal
+
+**Optimization Example**:
+
+```gremlin
+// SLOW: Filter late in traversal
+g.V().hasLabel('Task')          // 10,000 tasks (Time: 50ms, % Dur: 20%)
+     .out('DEPENDS_ON')         // 30,000 dependencies (Time: 150ms, % Dur: 60%)
+     .has('status', 'BLOCKED')  // 100 results (Time: 50ms, % Dur: 20%)
+
+// FAST: Filter early
+g.V().has('Task', 'status', 'BLOCKED')  // 100 tasks (Time: 10ms, % Dur: 5%)
+     .in('DEPENDS_ON')                   // 300 dependents (Time: 20ms, % Dur: 10%)
+     .hasLabel('Task')                   // 300 results (Time: 5ms, % Dur: 2.5%)
+```
+
+#### 4.3 Index Strategy
+
+**Source**: [JanusGraph Advanced Schema](https://docs.janusgraph.org/schema/advschema/)
+
+**Index Types**:
+
+1. **Composite Index** (exact match queries):
+```python
+# For queries like: g.V().has('Task', 'id', 'TASK-001')
+schema.index('taskById').on('Task').by('id').composite().build()
+```
+
+2. **Mixed Index** (range queries, full-text search):
+```python
+# For queries like: g.V().has('Task', 'created_at', gt(date))
+schema.index('taskByDate').on('Task').by('created_at').mixed().build()
+```
+
+3. **Edge Index** (for high-degree vertices):
+```python
+# For queries like: g.V('ACTOR-001').outE('CREATED').has('timestamp', gt(date))
+schema.edgeLabel('CREATED').indexOn(('timestamp',)).build()
+```
+
+**Jerry Index Requirements**:
+
+```python
+# Composite indexes (exact match - required for traversal start)
+COMPOSITE_INDEXES = [
+    ('Plan', 'id'),     # g.V().has('Plan', 'id', ...)
+    ('Phase', 'id'),    # g.V().has('Phase', 'id', ...)
+    ('Task', 'id'),     # g.V().has('Task', 'id', ...)
+    ('Event', 'id'),    # g.V().has('Event', 'id', ...)
+]
+
+# Mixed indexes (range queries, filtering)
+MIXED_INDEXES = [
+    ('Task', 'status'),        # g.V().has('Task', 'status', within(['PENDING', 'ACTIVE']))
+    ('Event', 'time'),         # g.V().has('Event', 'time', gt(datetime))
+    ('Task', 'created_at'),    # Range queries
+]
+
+# Edge indexes (for high-degree vertices - Actor supernode mitigation)
+EDGE_INDEXES = [
+    ('CREATED_BY', 'timestamp'),   # g.V('ACTOR-001').outE('CREATED_BY').has('timestamp', ...)
+    ('EMITTED', 'sequence'),       # g.V('TASK-001').outE('EMITTED').has('sequence', ...)
+]
+```
+
+#### 4.4 Caching Strategies (Neptune-Specific)
+
+**Source**: [AWS Neptune Caching](https://aws.amazon.com/blogs/database/part-1-accelerate-graph-query-performance-with-caching-in-amazon-neptune/)
+
+**Buffer Pool Cache**:
+- Always-on feature
+- Stores ~2/3 of instance memory
+- LRU eviction policy
+- Caches recently used graph components
+
+**Lookup Cache** (d-type instances):
+- Enable with `neptune_lookup_cache=1`
+- Requires r5d or x2iedn instances
+- Caches index lookups
+- Best for read-heavy workloads
+
+**Jerry Consideration**: If moving to Neptune, use r8g instances for best price/performance (4.7x better write performance vs r5).
+
+#### 4.5 Query Pattern Optimization
+
+**Source**: [Practical Gremlin](https://www.kelvinlawrence.net/book/PracticalGremlin.html)
+
+**Best Practices**:
+
+1. **Always Specify Edge Labels**:
+```gremlin
+// BAD: Unconstrained traversal
+g.V('TASK-001').out()
+
+// GOOD: Labeled traversal
+g.V('TASK-001').out('CONTAINS', 'DEPENDS_ON')
+```
+
+2. **Filter Early**:
+```gremlin
+// BAD: Filter after expansion
+g.V().hasLabel('Task')
+     .out('DEPENDS_ON')
+     .has('status', 'BLOCKED')
+
+// GOOD: Filter before expansion
+g.V().has('Task', 'status', 'BLOCKED')
+     .in('DEPENDS_ON')
+```
+
+3. **Use `limit()` for Large Result Sets**:
+```gremlin
+// Prevent unbounded result sets
+g.V().hasLabel('Task').limit(100)
+```
+
+4. **Avoid Deep Recursion Without Limits**:
+```gremlin
+// BAD: Unbounded recursion
+g.V('TASK-001')
+     .repeat(out('DEPENDS_ON'))
+     .until(hasLabel('Terminal'))
+
+// GOOD: Bounded recursion
+g.V('TASK-001')
+     .repeat(out('DEPENDS_ON'))
+     .times(5)  // Max 5 hops
+     .emit()
+```
+
+5. **Use `path()` Sparingly**:
+```gremlin
+// path() is expensive - only use when needed
+g.V('TASK-001')
+     .out('BELONGS_TO')
+     .out('BELONGS_TO')
+     .path()  // Only if you need the full path
+```
+
+#### 4.6 DFE Query Engine (Neptune)
+
+**Source**: [AWS Neptune Performance Efficiency](https://docs.aws.amazon.com/prescriptive-guidance/latest/neptune-well-architected-framework/performance-efficiency-pillar.html)
+
+**Key Insight**: Neptune has two query engines:
+- **DFE (Data Flow Engine)**: Newer, optimized
+- **Legacy Engine**: Older Gremlin implementation
+
+**DFE Benefits**:
+- Automatic query optimization
+- Better memory management
+- Faster execution for complex queries
+
+**Enabling DFE**:
+- openCypher: DFE enabled by default
+- Gremlin: Requires configuration (check Neptune version)
+
+**Jerry Consideration**: If using Neptune, ensure DFE is enabled for Gremlin queries.
+
+---
+
+### 5. Schema Design and Evolution Patterns
+
+**Sources**:
+- [Hypermode: Schema Evolution](https://hypermode.com/blog/schema-evolution)
+- [ACM: Estimation and Impact of Schema Evolution](https://dl.acm.org/doi/10.1145/3652620.3688196)
+
+#### 5.1 Schema Philosophy
+
+**Key Insight**: Graph databases are often described as "schemaless," but they have an **implicit schema**. Best practice is to make the schema **explicit**.
+
+**JanusGraph Recommendation**:
+```python
+# Disable automatic schema creation
+schema.default = none
+
+# Force explicit schema definition
+schema.propertyKey('title').Text().make()
+schema.vertexLabel('Task').make()
+schema.edgeLabel('CONTAINS').make()
+```
+
+**Benefits**:
+1. **Prevents accidental schema drift** in concurrent environments
+2. **Documents intended structure** for team collaboration
+3. **Enables validation** before data insertion
+4. **Supports migration planning**
+
+#### 5.2 Schema Versioning Strategies
+
+**Versioning Approaches**:
+
+1. **Schema Versioning** (Keep all versions):
+```gremlin
+// Each vertex tracks its schema version
+g.addV('Task')
+    .property('id', 'TASK-001')
+    .property('schema_version', '2.0')
+    .property('title', 'Task title')
+```
+
+2. **Time-Based Versioning**:
+```gremlin
+// Version by timestamp
+g.addV('Task')
+    .property('id', 'TASK-001')
+    .property('version_timestamp', datetime())
+```
+
+3. **Entity-Specific Versioning**:
+```gremlin
+// Each entity has independent version number
+g.addV('Task')
+    .property('id', 'TASK-001')
+    .property('version', 42)
+```
+
+**Jerry Recommendation**: Use **schema versioning** with explicit version property:
+
+```python
+@dataclass
+class Vertex:
+    id: VertexId
+    label: str
+    schema_version: str = "1.0"  # Track schema version
+    properties: Dict[str, Any]
+```
+
+#### 5.3 Backward Compatibility Patterns
+
+**Goal**: Ensure older applications continue working after schema evolution.
+
+**Patterns**:
+
+1. **Additive Changes Only** (safest):
+```gremlin
+// V1: Task has title, status
+// V2: Add description (old queries still work)
+g.addV('Task')
+    .property('title', 'Task')
+    .property('status', 'PENDING')
+    .property('description', 'New field')  // Additive
+```
+
+2. **Property Renaming** (requires migration):
+```python
+# Migration script for renaming
+g.V().hasLabel('Task').has('old_status').as('task')
+    .property('status', select('task').values('old_status'))
+    .property('old_status', null)  # Mark for deletion
+```
+
+3. **Edge Label Changes** (requires edge migration):
+```gremlin
+// Migrate edge labels
+g.V().hasLabel('Task')
+    .outE('OLD_CONTAINS')
+    .as('e')
+    .inV().as('target')
+    .select('e').outV().as('source')
+    .select('source').addE('CONTAINS').to(select('target'))
+    .select('e').drop()
+```
+
+#### 5.4 Evolution Operations
+
+**Source**: Academic research on graph schema evolution
+
+**Operation Types**:
+- **Add**: New vertex/edge label, new property key
+- **Rename**: Change label or property name
+- **Delete**: Remove label or property (dangerous)
+- **Merge**: Combine two labels into one
+- **Split**: Divide one label into multiple
+- **Move**: Change property from vertex to edge
+- **Copy**: Duplicate property with new name
+
+**Jerry Evolution Guidelines**:
+
+1. **Always use migrations for breaking changes**:
+```python
+# migrations/002_rename_task_state_to_status.py
+
+def upgrade(g):
+    """Rename Task.state to Task.status"""
+    g.V().hasLabel('Task').has('state').as('task')
+        .property('status', select('task').values('state'))
+        .property('state', null)
+        .iterate()
+
+def downgrade(g):
+    """Rollback: Rename Task.status to Task.state"""
+    g.V().hasLabel('Task').has('status').as('task')
+        .property('state', select('task').values('status'))
+        .property('status', null)
+        .iterate()
+```
+
+2. **Document all schema changes**:
+```markdown
+# Schema Changelog
+
+## Version 2.0 (2026-01-15)
+- Added: Task.verification property (Text)
+- Changed: Task.state → Task.status (BREAKING)
+- Deprecated: Task.legacy_id (use Task.id)
+```
+
+3. **Version control for schema DDL**:
+```python
+# schema/v1.0/task.py
+TASK_SCHEMA_V1 = {
+    'label': 'Task',
+    'properties': ['id', 'title', 'state'],
+    'version': '1.0'
+}
+
+# schema/v2.0/task.py
+TASK_SCHEMA_V2 = {
+    'label': 'Task',
+    'properties': ['id', 'title', 'status', 'verification'],
+    'version': '2.0',
+    'changes': ['state → status (BREAKING)', 'added verification']
+}
+```
+
+---
+
+### 6. Property Graph vs RDF Considerations
+
+**Sources**:
+- [PuppyGraph: Property Graph vs RDF](https://www.puppygraph.com/blog/property-graph-vs-rdf)
+- [Neo4j: RDF vs Property Graphs](https://neo4j.com/blog/knowledge-graph/rdf-vs-property-graphs-knowledge-graphs/)
+
+#### 6.1 When to Use Property Graphs (Jerry's Current Path)
+
+**Use Property Graphs When**:
+
+1. **High-Performance Traversal is Critical**:
+   - Property graphs optimize for application-specific performance
+   - Gremlin/Cypher designed for fast traversal
+   - Best for operational queries (vs analytical)
+
+2. **Schema is Dynamic and Evolving**:
+   - Property graphs support ad-hoc schema design
+   - No need for predefined ontologies
+   - Rapid iteration in agile development
+
+3. **Team Familiarity**:
+   - Cypher/Gremlin more approachable than SPARQL
+   - Similar to SQL for relational developers
+
+4. **Use Cases**:
+   - Recommendation engines
+   - Fraud detection
+   - Network analysis
+   - **Work tracking and dependency management** ← Jerry
+
+#### 6.2 When to Use RDF
+
+**Use RDF When**:
+
+1. **Interoperability is Required**:
+   - W3C standard for data exchange
+   - Integration across knowledge graphs
+   - Linked data ecosystems
+
+2. **Semantic Reasoning is Needed**:
+   - RDFS/OWL reasoning (subclass inference)
+   - SPARQL for complex queries
+   - Ontology-driven validation
+
+3. **Open-World Semantics**:
+   - Missing data doesn't imply falsity
+   - Gradual knowledge accumulation
+   - Federated queries across sources
+
+4. **Use Cases**:
+   - Biomedical datasets (ontology-driven)
+   - Linked open data
+   - Knowledge graph federation
+   - **Jerry's aspirational semantic web goal**
+
+#### 6.3 Hybrid Approach (Jerry's Future Path)
+
+**Netflix Pattern**: "Conceptual RDF, Flexible Physical"
+
+**Strategy**:
+1. **Phase 1**: Property graph with Gremlin (current)
+2. **Phase 2**: Add RDF serialization adapter (RDFLib)
+3. **Phase 3**: Define OWL ontology for Jerry domain
+4. **Phase 4**: Enable SPARQL alongside Gremlin
+
+**Jerry URI → RDF Mapping**:
+```
+Jerry URI:  jer:jer:work-tracker:task:task-042+hash
+RDF URI:    https://jerry.dev/jer/work-tracker/task/task-042#hash
+```
+
+**Alignment Challenges**:
+
+| Aspect | Property Graph | RDF | Jerry Strategy |
+|--------|----------------|-----|----------------|
+| Edge Properties | Native | Requires RDF* or reification | Use RDF* when serializing |
+| Schema | Optional | Explicit (RDFS/OWL) | Define OWL ontology later |
+| Identifiers | String IDs | URIs | Jerry URI already URI-compatible |
+| Reasoning | None native | RDFS/OWL | Layer via RDFLib + pySHACL |
+
+**Recommendation**: Proceed with property graph for Phase 1-3. Add RDF serialization in Phase 4 when interoperability becomes a requirement.
+
+---
+
+### 7. Code Examples for Jerry
+
+#### 7.1 Repository Pattern with Gremlin
+
+```python
+# src/infrastructure/persistence/gremlin_repository.py
+
+from typing import List, Optional
+from src.domain.ports.graph_repository import IGraphRepository
+from src.domain.graph.primitives import Vertex, Edge, VertexId
+from gremlin_python.process.traversal import T
+from gremlin_python.process.graph_traversal import __
+
+class GremlinTaskRepository(IGraphRepository[TaskVertex]):
+    """
+    Gremlin-based repository for Task aggregate.
+
+    Uses mergeV/mergeE for upsert semantics.
+    """
+
+    def __init__(self, g):
+        self.g = g  # Gremlin traversal source
+
+    def save(self, task: TaskVertex, edges: List[Edge]) -> None:
+        """Persist task with edges atomically."""
+        # Upsert vertex
+        self.g.mergeV([
+            (T.label, 'Task'),
+            (T.id, task.id.value)
+        ]).option(
+            Merge.onCreate, {
+                'title': task.title,
+                'status': task.status,
+                'created_at': task.created_at.isoformat()
+            }
+        ).option(
+            Merge.onMatch, {
+                'modified_at': task.modified_at.isoformat()
+            }
+        ).iterate()
+
+        # Upsert edges
+        for edge in edges:
+            self.g.mergeE([
+                (T.label, edge.label),
+                (Direction.from, edge.out_vertex.value),
+                (Direction.to, edge.in_vertex.value)
+            ]).option(
+                Merge.onCreate, edge.properties
+            ).iterate()
+
+    def find_by_id(self, id: VertexId) -> Optional[TaskVertex]:
+        """Find task by ID with immediate children."""
+        result = self.g.V().has('Task', 'id', id.value).valueMap(True).next()
+        if not result:
+            return None
+
+        return self._deserialize(result)
+
+    def find_children(self, parent_id: VertexId, edge_label: str) -> List[Vertex]:
+        """Find child vertices via edge traversal."""
+        results = self.g.V(parent_id.value) \
+                        .out(edge_label) \
+                        .valueMap(True) \
+                        .toList()
+
+        return [self._deserialize(r) for r in results]
+
+    def traverse_path(self, start_id: VertexId, *edge_labels: str) -> List[List[Vertex]]:
+        """Execute path traversal."""
+        traversal = self.g.V(start_id.value)
+        for label in edge_labels:
+            traversal = traversal.out(label)
+
+        paths = traversal.path().by(__.valueMap(True)).toList()
+        return [[self._deserialize(v) for v in path] for path in paths]
+
+    def _deserialize(self, vertex_map: dict) -> TaskVertex:
+        """Convert Gremlin valueMap to TaskVertex."""
+        # Implementation details...
+        pass
+```
+
+#### 7.2 Supernode Detection Validator
+
+```python
+# src/domain/validation/supernode_validator.py
+
+from dataclasses import dataclass
+from typing import List
+from src.domain.graph.primitives import VertexId
+
+@dataclass
+class SupernodeThreshold:
+    """Configuration for supernode detection."""
+    warning_threshold: int = 100
+    error_threshold: int = 1000
+
+@dataclass
+class ValidationResult:
+    is_valid: bool
+    warnings: List[str]
+    errors: List[str]
+
+class SupernodeValidator:
+    """
+    Detects potential supernodes based on edge count.
+
+    Implements mitigation strategy recommendations from:
+    https://medium.com/neo4j/graph-modeling-all-about-super-nodes-d6ad7e11015b
+    """
+
+    def __init__(self, threshold: SupernodeThreshold = SupernodeThreshold()):
+        self.threshold = threshold
+
+    def validate_vertex_degree(
+        self,
+        vertex_id: VertexId,
+        edge_label: str,
+        edge_count: int
+    ) -> ValidationResult:
+        """
+        Validate vertex degree against supernode thresholds.
+
+        Args:
+            vertex_id: ID of vertex to check
+            edge_label: Edge label being validated
+            edge_count: Number of edges of this label
+
+        Returns:
+            ValidationResult with warnings/errors
+        """
+        warnings = []
+        errors = []
+
+        if edge_count >= self.threshold.error_threshold:
+            errors.append(
+                f"SUPERNODE DETECTED: {vertex_id.value} has {edge_count} "
+                f"{edge_label} edges (threshold: {self.threshold.error_threshold}). "
+                f"Consider partitioning strategy."
+            )
+        elif edge_count >= self.threshold.warning_threshold:
+            warnings.append(
+                f"Approaching supernode: {vertex_id.value} has {edge_count} "
+                f"{edge_label} edges (warning at: {self.threshold.warning_threshold})"
+            )
+
+        return ValidationResult(
+            is_valid=len(errors) == 0,
+            warnings=warnings,
+            errors=errors
+        )
+
+    def suggest_mitigation(self, vertex_label: str, edge_label: str) -> str:
+        """Suggest mitigation strategy based on vertex/edge types."""
+        strategies = {
+            ('Actor', 'CREATED_BY'):
+                "Time-based partitioning: Use CREATED_BY_2026_01 edge labels",
+            ('Phase', 'CONTAINS'):
+                "Hierarchical decomposition: Add intermediate grouping nodes",
+            ('Event', 'EMITTED'):
+                "Sequence-based partitioning: Partition events into ranges (0-999, 1000-1999)",
+        }
+
+        return strategies.get(
+            (vertex_label, edge_label),
+            "Generic: Consider partitioning by time, hierarchy, or attribute"
+        )
+```
+
+#### 7.3 Index Configuration
+
+```python
+# src/infrastructure/persistence/index_config.py
+
+from dataclasses import dataclass
+from typing import List, Tuple
+from enum import Enum, auto
+
+class IndexType(Enum):
+    """Index types aligned with JanusGraph."""
+    COMPOSITE = auto()  # Exact match queries
+    MIXED = auto()      # Range/full-text queries
+    EDGE = auto()       # Edge property indexes
+
+@dataclass
+class IndexDefinition:
+    """Index definition for graph database."""
+    vertex_label: str
+    property_key: str
+    index_type: IndexType
+    index_name: str
+
+class JerryIndexConfiguration:
+    """
+    Centralized index configuration for Jerry Work Tracker.
+
+    Based on best practices from:
+    https://docs.janusgraph.org/schema/advschema/
+    """
+
+    @staticmethod
+    def get_required_indexes() -> List[IndexDefinition]:
+        """
+        Primary indexes required for traversal start points.
+
+        These indexes enable queries like:
+        g.V().has('Task', 'id', 'TASK-001')
+        """
+        return [
+            IndexDefinition('Plan', 'id', IndexType.COMPOSITE, 'planById'),
+            IndexDefinition('Phase', 'id', IndexType.COMPOSITE, 'phaseById'),
+            IndexDefinition('Task', 'id', IndexType.COMPOSITE, 'taskById'),
+            IndexDefinition('Subtask', 'id', IndexType.COMPOSITE, 'subtaskById'),
+            IndexDefinition('Event', 'id', IndexType.COMPOSITE, 'eventById'),
+            IndexDefinition('Actor', 'id', IndexType.COMPOSITE, 'actorById'),
+        ]
+
+    @staticmethod
+    def get_optional_indexes() -> List[IndexDefinition]:
+        """
+        Secondary indexes for filtering and range queries.
+
+        These improve performance for common filter operations.
+        """
+        return [
+            # Status filtering (moderate selectivity)
+            IndexDefinition('Task', 'status', IndexType.COMPOSITE, 'taskByStatus'),
+            IndexDefinition('Phase', 'status', IndexType.COMPOSITE, 'phaseByStatus'),
+            IndexDefinition('Plan', 'status', IndexType.COMPOSITE, 'planByStatus'),
+
+            # Temporal range queries
+            IndexDefinition('Task', 'created_at', IndexType.MIXED, 'taskByCreatedAt'),
+            IndexDefinition('Event', 'time', IndexType.MIXED, 'eventByTime'),
+        ]
+
+    @staticmethod
+    def get_edge_indexes() -> List[Tuple[str, str]]:
+        """
+        Edge indexes for high-degree vertices.
+
+        Mitigates supernode performance issues.
+        """
+        return [
+            ('CREATED_BY', 'timestamp'),  # Actor supernode mitigation
+            ('EMITTED', 'sequence'),      # Event ordering
+            ('CONTAINS', 'sequence'),     # Child ordering
+        ]
+
+    @staticmethod
+    def get_excluded_properties() -> List[str]:
+        """
+        Properties that should NOT be indexed.
+
+        These are either:
+        - Free text fields (low selectivity)
+        - Never used in queries
+        - Large blobs (JSON, etc.)
+        """
+        return [
+            'description',   # Free text
+            'title',         # Free text
+            'verification',  # Free text
+            'data',          # JSON blob (Event.data)
+            'metadata',      # JSON blob
+        ]
+```
+
+---
+
+## L2: Strategic Implications for Jerry Framework
+
+### 1. Alignment with Jerry's Hexagonal Architecture
+
+**Current State**: Jerry's domain model already uses graph abstractions (Vertex, Edge) from `GRAPH_DATA_MODEL_ANALYSIS.md`.
+
+**Strategic Fit**:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                    HEXAGONAL ARCHITECTURE                   │
+├────────────────────────────────────────────────────────────┤
+│                                                             │
+│   Domain Layer (src/domain/)                                │
+│   ├── graph/primitives.py      ← Already graph-ready       │
+│   ├── entities/                ← Vertex implementations     │
+│   └── value_objects/           ← VertexId hierarchy         │
+│                                                             │
+│   Application Layer (src/application/)                      │
+│   ├── queries/                 ← Map to Gremlin traversals  │
+│   └── commands/                ← Use mergeV/mergeE patterns │
+│                                                             │
+│   Infrastructure Layer (src/infrastructure/)                │
+│   ├── persistence/                                          │
+│   │   ├── file_repository.py     (Phase 1: JSON)           │
+│   │   ├── sqlite_repository.py   (Phase 2: SQLite)         │
+│   │   └── gremlin_repository.py  (Phase 3: Neptune/Gremlin)│
+│   └── adapters/                                             │
+│                                                             │
+└────────────────────────────────────────────────────────────┘
+```
+
+**Benefit**: Domain remains persistence-agnostic. Infrastructure adapters implement repository ports with storage-specific optimizations.
+
+### 2. Risk Mitigation for Work Tracker
+
+**Risk Assessment**:
+
+| Risk | Probability | Impact | Mitigation Strategy |
+|------|-------------|--------|---------------------|
+| **Actor Supernode** | HIGH | HIGH | Time-based edge partitioning (CREATED_BY_2026_01) |
+| **Event Explosion** | MEDIUM | MEDIUM | Sequence-based partitioning (0-999, 1000-1999) |
+| **Phase Overload** | LOW | MEDIUM | Monitor; partition by status if >500 tasks |
+| **Query Performance Degradation** | MEDIUM | HIGH | Explicit indexing, PROFILE monitoring |
+| **Schema Drift** | MEDIUM | MEDIUM | Explicit schema definition, version control |
+
+**Strategic Actions**:
+
+1. **Immediate** (WORK-031):
+   - Implement `SupernodeValidator` in domain layer
+   - Define explicit schema with version tracking
+   - Create index configuration module
+
+2. **Short-term** (Next 2-3 months):
+   - Add PROFILE instrumentation to query layer
+   - Implement schema migration framework
+   - Create performance benchmarks
+
+3. **Long-term** (6-12 months):
+   - Evaluate Neptune/JanusGraph migration
+   - Add RDF serialization for semantic web
+   - Implement SPARQL alongside Gremlin
+
+### 3. Integration with Jerry Constitution
+
+**Governance Alignment**:
+
+| Constitution Principle | Graph Modeling Impact |
+|------------------------|----------------------|
+| **P-001: Truth and Accuracy** | Schema validation ensures data integrity |
+| **P-002: File Persistence** | Research findings persisted in `docs/research/` |
+| **P-004: Documented Reasoning** | Schema DDL documents modeling decisions |
+| **P-010: Task Tracking Integrity** | Graph traversals ensure task state consistency |
+
+**New Governance Recommendation**:
+
+```markdown
+## P-030: Schema Evolution Governance
+
+**Category**: Hard Principle
+
+**Rule**: All graph schema changes MUST:
+1. Be documented in schema changelog
+2. Include forward migration script
+3. Include rollback migration script
+4. Pass validation tests before deployment
+
+**Rationale**: Schema changes in graph databases affect traversal semantics.
+Undocumented changes break query assumptions and create data integrity issues.
+
+**Enforcement**: CI/CD pipeline blocks deployment if schema migration is missing.
+```
+
+### 4. Technology Stack Recommendations
+
+**Phase 1: File-Based (Current)**
+- **Storage**: JSON files with adjacency lists
+- **Query**: Application-level traversal (Python)
+- **Pros**: Zero dependencies, simple debugging
+- **Cons**: No index support, manual traversal
+
+**Phase 2: SQLite with Graph Schema**
+- **Storage**: SQLite with vertices/edges tables
+- **Query**: SQL + application traversal
+- **Pros**: ACID transactions, lightweight, portable
+- **Cons**: Limited graph optimizations
+
+**Phase 3: Native Graph Database**
+
+**Option A: Amazon Neptune**
+- **Pros**:
+  - Fully managed, auto-scaling
+  - TinkerPop 3.x compatible
+  - DFE query optimization
+  - r8g instances (4.7x better write performance)
+- **Cons**:
+  - AWS vendor lock-in
+  - Cost for small workloads
+  - Requires VPC setup
+
+**Option B: JanusGraph**
+- **Pros**:
+  - Open-source, self-hosted
+  - Mature ecosystem
+  - Pluggable storage backends (Cassandra, HBase, BerkeleyDB)
+- **Cons**:
+  - Operational complexity (self-managed)
+  - Slower than Neptune for some workloads
+
+**Option C: Neo4j**
+- **Pros**:
+  - Industry leader, mature
+  - Cypher query language (more SQL-like)
+  - Excellent tooling (Browser, Bloom)
+- **Cons**:
+  - Commercial licensing for production
+  - Not TinkerPop-compatible (requires adapter)
+  - Cypher != Gremlin (rewrite queries)
+
+**Strategic Recommendation for Jerry**:
+
+```
+Phase 1 (Now - 3 months): File-based
+  ├── Validate domain model
+  ├── Test traversal patterns
+  └── Benchmark performance
+
+Phase 2 (3-9 months): SQLite with graph schema
+  ├── Add ACID guarantees
+  ├── Implement indexing
+  └── Stress test with realistic data
+
+Phase 3 (9-18 months): Evaluate native graph DB
+  ├── If AWS: Amazon Neptune
+  ├── If self-hosted: JanusGraph
+  └── Migration via GraphSON export/import
+```
+
+### 5. Performance Benchmarking Strategy
+
+**Baseline Metrics** (establish in Phase 1):
+
+```python
+# Performance benchmarks to establish
+BENCHMARK_QUERIES = [
+    {
+        'name': 'Get task by ID',
+        'query': "g.V().has('Task', 'id', 'TASK-001')",
+        'expected_latency': '< 10ms'
+    },
+    {
+        'name': 'Get all subtasks',
+        'query': "g.V('TASK-001').out('CONTAINS').hasLabel('Subtask')",
+        'expected_latency': '< 20ms'
+    },
+    {
+        'name': 'Calculate phase progress',
+        'query': "g.V('PHASE-001').out('CONTAINS').group().by('status').by(count())",
+        'expected_latency': '< 50ms'
+    },
+    {
+        'name': 'Recursive parent traversal',
+        'query': "g.V('TASK-001').repeat(out('BELONGS_TO')).until(hasLabel('Plan')).path()",
+        'expected_latency': '< 30ms'
+    },
+    {
+        'name': 'Find blocking dependencies',
+        'query': "g.V('TASK-001').out('BLOCKS').values('title')",
+        'expected_latency': '< 15ms'
+    }
+]
+```
+
+**Regression Testing**: Run benchmarks on every schema change to detect performance regressions.
+
+### 6. Documentation and Knowledge Management
+
+**New Documentation Requirements**:
+
+1. **Schema DDL** (`src/domain/graph/schema/`):
+   ```python
+   # schema/v1.0/task_schema.py
+   TASK_SCHEMA = {
+       'label': 'Task',
+       'properties': {
+           'id': {'type': 'String', 'cardinality': 'SINGLE', 'indexed': True},
+           'title': {'type': 'String', 'cardinality': 'SINGLE', 'indexed': False},
+           'status': {'type': 'String', 'cardinality': 'SINGLE', 'indexed': True},
+       },
+       'version': '1.0'
+   }
+   ```
+
+2. **Schema Changelog** (`docs/design/SCHEMA_CHANGELOG.md`):
+   ```markdown
+   # Graph Schema Changelog
+
+   ## [2.0.0] - 2026-01-15
+   ### Changed
+   - BREAKING: Renamed Task.state → Task.status
+
+   ### Added
+   - Task.verification property (Text, optional)
+
+   ### Deprecated
+   - Task.legacy_id (use Task.id instead)
+   ```
+
+3. **Query Cookbook** (`docs/knowledge/GREMLIN_QUERY_COOKBOOK.md`):
+   ```markdown
+   # Gremlin Query Cookbook for Jerry
+
+   ## Common Patterns
+
+   ### Get all tasks in a phase
+   \```gremlin
+   g.V().has('Phase', 'id', phaseId)
+        .out('CONTAINS')
+        .hasLabel('Task')
+   \```
+   ```
+
+### 7. Team Skills Development
+
+**Required Gremlin Competencies**:
+
+1. **Basic** (All developers):
+   - Vertex/Edge model understanding
+   - Basic traversals (out, in, both)
+   - Property access (values, valueMap)
+
+2. **Intermediate** (Backend developers):
+   - Filter steps (has, where, filter)
+   - Aggregation (group, fold, count)
+   - Path traversals (path, simplePath)
+
+3. **Advanced** (Database specialists):
+   - Query optimization (profile, explain)
+   - Index design
+   - Schema evolution
+   - Migration scripting
+
+**Learning Resources**:
+- [Practical Gremlin](https://www.kelvinlawrence.net/book/PracticalGremlin.html) (Primary reference)
+- [TinkerPop Documentation](https://tinkerpop.apache.org/docs/current/reference/)
+- [AWS Neptune Best Practices](https://docs.aws.amazon.com/neptune/latest/userguide/best-practices.html)
+
+---
+
+## Sources and References
+
+| # | Title | URL | Category |
+|---|-------|-----|----------|
+| 1 | Apache TinkerPop Documentation | https://tinkerpop.apache.org/docs/current/reference/ | Official Docs |
+| 2 | Practical Gremlin (Kelvin Lawrence) | https://www.kelvinlawrence.net/book/PracticalGremlin.html | Tutorial |
+| 3 | TinkerPop GitHub | https://github.com/apache/tinkerpop | Source Code |
+| 4 | TinkerPop Getting Started | https://tinkerpop.apache.org/docs/current/tutorials/getting-started/ | Tutorial |
+| 5 | JanusGraph Schema Documentation | https://docs.janusgraph.org/schema/ | Official Docs |
+| 6 | JanusGraph Advanced Schema | https://docs.janusgraph.org/schema/advschema/ | Official Docs |
+| 7 | JanusGraph Database Design Best Practices | https://the-pi-guy.com/blog/janusgraph_database_design_best_practices/ | Tutorial |
+| 8 | JanusGraph Data Model | https://docs.janusgraph.org/advanced-topics/data-model/ | Official Docs |
+| 9 | AWS Neptune Best Practices | https://docs.aws.amazon.com/neptune/latest/userguide/best-practices.html | Official Docs |
+| 10 | AWS Neptune Query Tuning | https://docs.aws.amazon.com/neptune/latest/userguide/gremlin-traversal-tuning.html | Official Docs |
+| 11 | AWS Neptune Caching (Part 1) | https://aws.amazon.com/blogs/database/part-1-accelerate-graph-query-performance-with-caching-in-amazon-neptune/ | Blog |
+| 12 | AWS Neptune Caching (Part 2) | https://aws.amazon.com/blogs/database/part-2-accelerate-graph-query-performance-with-caching-in-amazon-neptune/ | Blog |
+| 13 | AWS Neptune EXPLAIN Plans (2025) | https://kategawron.co.uk/2025/05/amazon-neptune-explain/ | Blog |
+| 14 | AWS Neptune r8g Performance | https://aws.amazon.com/blogs/database/4-7-times-better-write-query-price-performance-with-aws-graviton4-r8g-instances-using-amazon-neptune-v1-4-5/ | Blog |
+| 15 | Neo4j Data Modeling Pitfalls | https://neo4j.com/blog/graph-data-science/data-modeling-pitfalls/ | Blog |
+| 16 | Neo4j: All About Super Nodes | https://medium.com/neo4j/graph-modeling-all-about-super-nodes-d6ad7e11015b | Blog |
+| 17 | DataStax: Supernodes | https://www.datastax.com/blog/property-graph-modeling-fu-towards-supernodes-jonathan-lacefield | Blog |
+| 18 | DataStax: DSE Gremlin Queries | https://www.datastax.com/blog/dse-gremlin-queries-good-better-best | Blog |
+| 19 | Graph Modeling Best Practices | https://reeshabh-choudhary.medium.com/best-graph-modelling-practices-cdfd65a9d95d | Blog |
+| 20 | Manning: Graph Databases in Action (Ch 10) | https://livebook.manning.com/book/graph-databases-in-action/chapter-10/v-9/ | Book |
+| 21 | FalkorDB: Relational to Graph Migration | https://www.falkordb.com/blog/relational-database-to-graph-database/ | Tutorial |
+| 22 | Medium: Mastering Data Migration | https://lolithasherley7.medium.com/mastering-data-migration-from-relational-to-graph-databases-strategies-tools-and-best-ec92d2902930 | Blog |
+| 23 | ACM: Migration from Relational to Graph | https://dl.acm.org/doi/10.1145/3200842.3200852 | Academic Paper |
+| 24 | Data Science Journal: Transformation Algorithm | https://datascience.codata.org/articles/10.5334/dsj-2024-035 | Academic Paper |
+| 25 | Neo4j ETL Tools | https://www.integrate.io/blog/neo4j-etl-tools/ | Tutorial |
+| 26 | PuppyGraph: Property Graph vs RDF | https://www.puppygraph.com/blog/property-graph-vs-rdf | Blog |
+| 27 | Neo4j: RDF vs Property Graphs | https://neo4j.com/blog/knowledge-graph/rdf-vs-property-graphs-knowledge-graphs/ | Blog |
+| 28 | GraphGeeks: RDF and Property Graphs | https://www.graphgeeks.org/blog/rdf-and-property-graphs-two-different-models-no-wrong-answers | Blog |
+| 29 | Ontotext: RDF vs Property Graphs | https://www.ontotext.com/knowledgehub/fundamentals/rdf-vs-property-graphs/ | Tutorial |
+| 30 | Hypermode: Schema Evolution | https://hypermode.com/blog/schema-evolution | Blog |
+| 31 | ACM: Schema Evolution Impact | https://dl.acm.org/doi/10.1145/3652620.3688196 | Academic Paper |
+| 32 | Springer: Schema Validation and Evolution | https://link.springer.com/chapter/10.1007/978-3-030-33223-5_37 | Academic Paper |
+| 33 | Wikipedia: Schema Evolution | https://en.wikipedia.org/wiki/Schema_evolution | Reference |
+| 34 | PiEmbSysTech: Gremlin Optimization | https://piembsystech.com/optimizing-traversal-steps-and-pipelines-in-gremlin-query/ | Tutorial |
+
+---
+
+## Prioritized Recommendations for WORK-031
+
+### Priority 1: Immediate Actions (This Week)
+
+1. **Implement Supernode Validator**
+   - Create `src/domain/validation/supernode_validator.py`
+   - Add thresholds: warning=100, error=1000
+   - Integrate into repository save operations
+
+2. **Define Explicit Schema with Versioning**
+   - Create `src/domain/graph/schema/v1.0/` directory
+   - Document current schema (Plan, Phase, Task, Subtask, Event, Actor)
+   - Add `schema_version` property to all Vertex classes
+
+3. **Create Index Configuration**
+   - Implement `src/infrastructure/persistence/index_config.py`
+   - Define required/optional indexes per L1 Section 4.3
+   - Document index strategy in schema
+
+### Priority 2: Short-term (Next 1-2 Sprints)
+
+4. **Add PROFILE Instrumentation**
+   - Wrap all Gremlin queries with optional `.profile()` flag
+   - Log query performance metrics (Time, % Dur)
+   - Create performance dashboard
+
+5. **Implement Schema Migration Framework**
+   - Create `migrations/` directory
+   - Define migration interface (`upgrade()`, `downgrade()`)
+   - Add migration versioning system
+
+6. **Create Schema Changelog**
+   - Initialize `docs/design/SCHEMA_CHANGELOG.md`
+   - Document v1.0 baseline
+   - Define changelog format
+
+7. **Build Query Cookbook**
+   - Create `docs/knowledge/GREMLIN_QUERY_COOKBOOK.md`
+   - Document common traversal patterns
+   - Add performance notes for each pattern
+
+### Priority 3: Medium-term (Next Quarter)
+
+8. **Establish Performance Benchmarks**
+   - Implement benchmark suite (5 core queries)
+   - Run on synthetic data (1K, 10K, 100K nodes)
+   - Set latency baselines for regression testing
+
+9. **Add Actor Supernode Mitigation**
+   - Implement time-based edge partitioning for `CREATED_BY`
+   - Use format: `CREATED_BY_YYYY_MM`
+   - Update queries to handle time-based edges
+
+10. **Create Migration Smoke Tests**
+    - Test traversal patterns on representative data
+    - Validate index effectiveness
+    - Verify query performance meets SLAs
+
+### Priority 4: Long-term (Next 6-12 Months)
+
+11. **Evaluate Native Graph Database Migration**
+    - Benchmark file-based vs SQLite vs Neptune/JanusGraph
+    - Cost analysis for AWS Neptune
+    - Decision on Phase 3 target
+
+12. **Add RDF Serialization**
+    - Implement RDFLib adapter
+    - Define Jerry OWL ontology
+    - Enable GraphSON/RDF export
+
+13. **Implement SPARQL Query Layer**
+    - Add SPARQL alongside Gremlin
+    - Support federated queries
+    - Enable semantic reasoning
+
+---
+
+## Key Insights and Discoveries
+
+### Discovery 1: "Design for Queryability" Paradigm Shift
+
+**Insight**: Graph databases invert the relational model design philosophy. Instead of "normalize for storage, denormalize for queries," graph databases use "model for traversal patterns directly."
+
+**Implication for Jerry**: The Work Tracker schema should have direct edges for common traversals, even if this creates some redundancy (e.g., Task → Plan direct edge alongside Task → Phase → Plan).
+
+### Discovery 2: Supernode Risk is High for Jerry
+
+**Insight**: Actor vertices (especially Claude) could easily become supernodes with thousands of `CREATED_BY` edges as Jerry scales.
+
+**Implication**: Proactive mitigation required now, not later. Time-based edge partitioning is mandatory for Actor relationships.
+
+### Discovery 3: Index Strategy is Not Optional
+
+**Insight**: Unlike relational databases with query planners that use indexes opportunistically, graph databases often require explicit indexes for traversal start points. Missing indexes = full graph scan.
+
+**Implication**: Index configuration must be defined alongside schema, not as an afterthought.
+
+### Discovery 4: Property Graph → RDF is Feasible
+
+**Insight**: Jerry's URI scheme (SPEC-001) is already RDF-compatible. The property graph model can be serialized to RDF using RDF* for edge properties.
+
+**Implication**: Jerry can start with property graphs and add RDF serialization later without major refactoring. Netflix's "conceptual RDF, flexible physical" pattern validates this approach.
+
+### Discovery 5: Schema Evolution Requires Governance
+
+**Insight**: Graph schema changes affect traversal semantics. A renamed edge label breaks all queries using that label. Unlike relational migrations (which have mature tooling), graph migrations are less standardized.
+
+**Implication**: Jerry needs explicit schema versioning, migration scripts, and changelog from day one.
+
+---
+
+## Validation Status
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| **5W1H Coverage** | ✅ COMPLETE | All 6 dimensions addressed |
+| **L0/L1/L2 Sections** | ✅ COMPLETE | Executive, Technical, Strategic |
+| **Source Citations** | ✅ COMPLETE | 34 authoritative sources with URLs |
+| **Recommendations** | ✅ COMPLETE | Prioritized 13 actionable items |
+| **Code Examples** | ✅ COMPLETE | Repository, validator, index config |
+| **Jerry Integration** | ✅ COMPLETE | L2 covers strategic alignment |
+
+**Quality Status**: DECISION-GRADE
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial research on graph modeling best practices for Gremlin migration |
+
+---
+
+*Research conducted by: ps-researcher agent (v2.0.0)*
+*Based on: Problem-Solving Skill v2.0.0 (WORK-030)*
+*Jerry Constitution: Compliant with P-001, P-002, P-004*

--- a/docs/archive/projects-archive/research/work-031-e-002-semantic-representations.md
+++ b/docs/archive/projects-archive/research/work-031-e-002-semantic-representations.md
@@ -1,0 +1,856 @@
+# Semantic Knowledge Representations Research
+
+> **Research Date:** 2026-01-08
+> **Status:** DECISION-GRADE
+> **Purpose:** Research semantic knowledge representation standards (OWL, SKOS, RDF-S, Schema.org)
+> **PS ID:** work-031
+> **Entry ID:** e-002
+
+---
+
+## L0: Executive Summary (Plain Language Findings)
+
+### What Are Semantic Knowledge Representations?
+
+Semantic knowledge representations are standardized ways to encode information so that machines can understand not just the data, but what the data *means*. Think of them as different languages for describing knowledge, each with different strengths.
+
+### Key Standards Explained
+
+**RDF Schema (RDF-S)** is the foundation - it provides basic vocabulary for describing classes and properties. Think of it as defining "what things are" and "what relationships exist."
+
+**SKOS (Simple Knowledge Organization System)** is designed for organizing concepts into hierarchies like taxonomies, thesauri, and classification schemes. It's perfect for library catalogs, product categories, or any controlled vocabulary.
+
+**OWL (Web Ontology Language)** is the heavyweight champion - it enables complex logic, formal reasoning, and rich constraints. Use it when you need to define precise rules and infer new knowledge automatically.
+
+**Schema.org** is the pragmatic choice - it's a widely-adopted vocabulary used by over 45 million websites to help search engines understand content. It's embedded in billions of web pages.
+
+### When to Use Each Standard
+
+- **Use SKOS** for taxonomies, glossaries, or navigation systems where concepts are organized hierarchically
+- **Use RDF-S** for basic data modeling when you need simple classes and properties
+- **Use OWL** for formal ontologies requiring logic, reasoning, and strict validation
+- **Use Schema.org** for SEO, web markup, and integration with search engines and AI systems
+
+### Industry Adoption
+
+These standards power major platforms:
+- **Google Knowledge Graph** uses RDF/Schema.org to understand 45+ million websites
+- **Wikidata** is a 100-million-topic knowledge graph using RDF and SPARQL
+- **DBpedia** transforms Wikipedia into structured RDF data
+- **Enterprise leaders** (Facebook, LinkedIn, Microsoft, Amazon, Uber, eBay) all use knowledge graphs
+
+### Implications for Jerry Framework
+
+Jerry's current property graph model (aligned with Apache TinkerPop) can be extended to support semantic web standards through:
+1. **Jerry URI scheme** (SPEC-001) is already RDF-compatible
+2. **kglab library** provides abstraction across RDF, NetworkX, and property graphs
+3. **Hybrid approach**: Property graph for operations, RDF export for interoperability
+4. **Strategic path**: Start with property graph, add RDF serialization, then SPARQL querying
+
+---
+
+## L1: Technical Details
+
+### 1. RDF Schema (RDF-S)
+
+**Official Specification:** [W3C RDF Schema Recommendation](https://www.w3.org/TR/rdf-schema/)
+
+#### Purpose and Capabilities
+
+RDF Schema (RDFS) is an extension of RDF that provides basic vocabulary and structure for RDF data, allowing for the definition of classes and properties. In the late 1990s, the W3C Metadata Activity started work on RDF Schema, and RDFS became a W3C Recommendation in 2004.
+
+#### Core Concepts
+
+| Construct | Purpose | Example |
+|-----------|---------|---------|
+| `rdfs:Class` | Define types/classes | `Task`, `Phase`, `Plan` |
+| `rdfs:subClassOf` | Class hierarchy | `Subtask rdfs:subClassOf Task` |
+| `rdfs:Property` | Define relationships | `hasSubtask`, `belongsToPhase` |
+| `rdfs:domain` | Property source constraint | `hasSubtask rdfs:domain Task` |
+| `rdfs:range` | Property target constraint | `hasSubtask rdfs:range Subtask` |
+| `rdfs:label` | Human-readable label | "Work Tracker Task" |
+| `rdfs:comment` | Description/documentation | "A unit of work within a phase" |
+
+#### Limitations
+
+Though RDFS provides some support for ontology specification, the need for a more expressive ontology language became clear, leading to OWL development.
+
+### 2. SKOS (Simple Knowledge Organization System)
+
+**Official Specification:** [W3C SKOS Reference](https://www.w3.org/TR/skos-reference/)
+
+#### Purpose and Capabilities
+
+SKOS is a W3C recommendation designed for representation of thesauri, classification schemes, taxonomies, subject-heading systems, or any other type of structured controlled vocabulary. SKOS is built upon RDF and RDFS, enabling easy publication and use of vocabularies as linked data.
+
+#### Core Concepts
+
+```turtle
+# SKOS Concept Scheme Example
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+# Concept Scheme
+:WorkTrackerTaxonomy a skos:ConceptScheme ;
+    skos:prefLabel "Jerry Work Tracker Taxonomy"@en .
+
+# Top Concept
+:WorkItem a skos:Concept ;
+    skos:prefLabel "Work Item"@en ;
+    skos:definition "An item of work to be tracked"@en ;
+    skos:inScheme :WorkTrackerTaxonomy ;
+    skos:topConceptOf :WorkTrackerTaxonomy .
+
+# Narrower Concepts
+:Plan a skos:Concept ;
+    skos:prefLabel "Plan"@en ;
+    skos:broader :WorkItem ;
+    skos:inScheme :WorkTrackerTaxonomy .
+
+:Phase a skos:Concept ;
+    skos:prefLabel "Phase"@en ;
+    skos:broader :WorkItem ;
+    skos:inScheme :WorkTrackerTaxonomy .
+
+:Task a skos:Concept ;
+    skos:prefLabel "Task"@en ;
+    skos:broader :WorkItem ;
+    skos:related :Subtask ;
+    skos:inScheme :WorkTrackerTaxonomy .
+```
+
+#### Key SKOS Properties
+
+| Property | Purpose | Use Case |
+|----------|---------|----------|
+| `skos:prefLabel` | Preferred label | "Task" |
+| `skos:altLabel` | Alternative label | "Work Item", "Todo" |
+| `skos:broader` | Broader concept | Task → WorkItem |
+| `skos:narrower` | Narrower concept | WorkItem → Task |
+| `skos:related` | Related concept | Task ↔ Subtask |
+| `skos:definition` | Formal definition | "A unit of work..." |
+| `skos:note` | General note | Documentation |
+
+#### Best Practices
+
+Following the termination of SWAD-Europe, SKOS effort was supported by the W3C Semantic Web Activity in the framework of the Best Practice and Deployment Working Group. Focus was put both on consolidation of SKOS Core and development of practical guidelines for porting and publishing thesauri for the Semantic Web.
+
+#### Real-World Implementations
+
+Important vocabularies migrated to SKOS format include:
+- **EuroVoc** - EU multilingual thesaurus
+- **AGROVOC** - FAO agricultural terminology
+- **GEMET** - General Multilingual Environmental Thesaurus
+- **Library of Congress Subject Headings (LCSH)**
+
+### 3. OWL (Web Ontology Language)
+
+**Official Specification:** [W3C OWL 2 Primer](https://www.w3.org/TR/owl2-primer/)
+
+#### Purpose and Capabilities
+
+OWL is a Semantic Web language designed to represent rich and complex knowledge about things, groups of things, and relations between things. OWL is a computational logic-based language such that knowledge expressed in OWL can be reasoned with by computer programs to verify consistency or make implicit knowledge explicit.
+
+#### OWL Expressiveness Levels
+
+The W3C-endorsed OWL specification includes three variants with different expressiveness levels:
+
+**OWL Lite**
+- **Complexity:** SHIF description logic
+- **Decidability:** Decidable, exponential time worst case
+- **Cardinality:** 0 or 1 only
+- **Use Case:** Simple taxonomies with basic constraints
+- **Status:** Not widely used; tool support as complex as OWL DL
+
+**OWL DL (Description Logic)**
+- **Complexity:** SHOIN description logic
+- **Decidability:** Decidable but potentially more than exponential
+- **Features:** All OWL constructs with syntactic restrictions
+- **Use Case:** Maximum expressiveness while retaining computational completeness and practical reasoning
+- **Constraints:**
+  - Number restrictions cannot be placed on transitive properties
+  - A class cannot be an instance of another class
+
+**OWL Full**
+- **Complexity:** No computational guarantees (undecidable)
+- **Decidability:** Undecidable - instance checking may not finish in finite time
+- **Features:** Full syntactic freedom of RDF
+- **Use Case:** Maximum expressiveness, no constraints
+- **Note:** A class can be treated simultaneously as a collection of individuals and as an individual in its own right
+
+#### Hierarchical Relationships
+
+Every legal OWL Lite ontology is a legal OWL DL ontology. Every legal OWL DL ontology is a legal OWL Full ontology. Every OWL document is an RDF document, and every RDF document is an OWL Full document, but only some RDF documents are legal OWL Lite or OWL DL documents.
+
+#### OWL 2 Features (Current Standard)
+
+OWL 2 (Second Edition, 2012) is the current standard. OWL 2 ontologies provide classes, properties, individuals, and data values and are stored as Semantic Web documents. OWL 2 ontologies can be used along with information written in RDF.
+
+#### Example OWL Ontology for Jerry Work Tracker
+
+```turtle
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix jerry: <https://jerry.dev/ontology#> .
+
+# Ontology Declaration
+<https://jerry.dev/ontology> a owl:Ontology ;
+    rdfs:label "Jerry Work Tracker Ontology" ;
+    owl:versionInfo "1.0" .
+
+# Classes
+jerry:WorkItem a owl:Class ;
+    rdfs:label "Work Item" ;
+    rdfs:comment "An abstract item of work to be tracked" .
+
+jerry:Plan a owl:Class ;
+    rdfs:subClassOf jerry:WorkItem ;
+    rdfs:label "Plan" ;
+    rdfs:comment "A collection of phases forming a complete work plan" .
+
+jerry:Phase a owl:Class ;
+    rdfs:subClassOf jerry:WorkItem ;
+    rdfs:label "Phase" ;
+    rdfs:comment "A stage within a plan" .
+
+jerry:Task a owl:Class ;
+    rdfs:subClassOf jerry:WorkItem ;
+    rdfs:label "Task" ;
+    rdfs:comment "A unit of work within a phase" .
+
+jerry:Subtask a owl:Class ;
+    rdfs:subClassOf jerry:Task ;
+    rdfs:label "Subtask" ;
+    rdfs:comment "A checklist item within a task" .
+
+# Object Properties
+jerry:containsPhase a owl:ObjectProperty ;
+    rdfs:domain jerry:Plan ;
+    rdfs:range jerry:Phase ;
+    rdfs:label "contains phase" .
+
+jerry:containsTask a owl:ObjectProperty ;
+    rdfs:domain jerry:Phase ;
+    rdfs:range jerry:Task ;
+    rdfs:label "contains task" .
+
+jerry:dependsOn a owl:ObjectProperty ;
+    rdfs:domain jerry:Task ;
+    rdfs:range jerry:Task ;
+    rdfs:label "depends on" ;
+    owl:propertyDisjointWith jerry:blockedBy .
+
+jerry:blockedBy a owl:ObjectProperty ;
+    rdfs:domain jerry:Task ;
+    rdfs:range jerry:Task ;
+    rdfs:label "blocked by" .
+
+# Datatype Properties
+jerry:hasTitle a owl:DatatypeProperty ;
+    rdfs:domain jerry:WorkItem ;
+    rdfs:range xsd:string ;
+    owl:cardinality 1 .
+
+jerry:hasStatus a owl:DatatypeProperty ;
+    rdfs:domain jerry:WorkItem ;
+    rdfs:range xsd:string .
+
+jerry:createdAt a owl:DatatypeProperty ;
+    rdfs:domain jerry:WorkItem ;
+    rdfs:range xsd:dateTime ;
+    owl:cardinality 1 .
+
+# Constraints
+jerry:Task a owl:Class ;
+    owl:equivalentClass [
+        a owl:Restriction ;
+        owl:onProperty jerry:belongsToPhase ;
+        owl:cardinality 1
+    ] .
+```
+
+### 4. Schema.org
+
+**Official Website:** [Schema.org](https://schema.org/)
+
+#### Purpose and Capabilities
+
+Schema.org is a collaborative effort to create, maintain, and promote schemas for structured data on the Internet. As of 2024, over 45 million web domains markup their web pages with over 450 billion Schema.org objects.
+
+#### Scale and Adoption
+
+As of September 2024, Schema.org includes:
+- **803 types**
+- **1,461 properties**
+- **14 data types**
+- **87 enumerations**
+- **467 enumeration members**
+
+#### Key Applications
+
+**1. Search Engine Rich Results**
+Schema markup helps search engines understand webpage content and display rich results (rich snippets, rich cards) on search engine result pages (SERPs).
+
+**2. Knowledge Graphs & AI Integration**
+Schema Markup transforms unstructured web content into structured, semantic data that can be leveraged across multiple applications. By using Schema.org properties to define relationships between entities, businesses can build Content Knowledge Graphs that reduce risks like hallucinations in large language models (LLMs).
+
+**3. Voice Search & Virtual Assistants**
+Schema.org helps make web content more consistent, accessible, and meaningful for emerging technologies like voice search and virtual assistants.
+
+#### Implementation Methods
+
+Schema.org vocabulary can be used with multiple encodings:
+- **JSON-LD** (preferred) - Separates structured data from HTML
+- **RDFa** - Embedded in HTML attributes
+- **Microdata** - Embedded in HTML tags
+
+#### Essential Schema Types
+
+| Type | Purpose | Jerry Applicability |
+|------|---------|---------------------|
+| `schema:Thing` | Base type | Abstract base for all entities |
+| `schema:Action` | Actions and events | Task creation, completion events |
+| `schema:CreativeWork` | Documents, content | Documentation, plans |
+| `schema:ItemList` | Ordered collections | Task lists, phase sequences |
+| `schema:Comment` | Annotations | Task notes, descriptions |
+
+#### Example Schema.org for Jerry Task
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Action",
+  "@id": "jer:jer:work-tracker:task:TASK-001",
+  "name": "Implement user authentication",
+  "description": "Add JWT-based authentication to API",
+  "actionStatus": "https://schema.org/ActiveActionStatus",
+  "startTime": "2026-01-08T10:00:00Z",
+  "agent": {
+    "@type": "Person",
+    "name": "Claude"
+  },
+  "object": {
+    "@type": "CreativeWork",
+    "name": "Authentication Module"
+  },
+  "potentialAction": {
+    "@type": "CheckAction",
+    "name": "Write unit tests"
+  }
+}
+```
+
+---
+
+## L2: Strategic Implications (for Jerry Framework)
+
+### 1. Alignment with Jerry's Architecture
+
+#### Current State (Property Graph Model)
+
+Jerry's existing property graph model (documented in `GRAPH_DATA_MODEL_ANALYSIS.md`) is based on Apache TinkerPop and provides:
+- Vertex/Edge abstractions aligned with property graphs
+- Jerry URI scheme (SPEC-001) that is RDF-compatible
+- CloudEvents integration for event sourcing
+- Domain-driven design with aggregate roots
+
+#### Strategic Gap Analysis
+
+| Capability | Current State | Semantic Web Target | Gap |
+|------------|---------------|---------------------|-----|
+| **Graph Traversal** | Gremlin (property graph) | SPARQL (RDF) | No SPARQL support |
+| **Schema Definition** | Implicit labels | RDFS/OWL classes | No formal ontology |
+| **Reasoning** | None | OWL reasoning | No inference engine |
+| **Vocabularies** | Custom | Schema.org/SKOS | No standard vocabularies |
+| **Serialization** | JSON/GraphSON | RDF/XML, Turtle, JSON-LD | Limited RDF support |
+
+### 2. Recommended Integration Strategy
+
+#### Phase 1: RDF Serialization Adapter (Immediate)
+
+**Goal:** Enable RDF export while maintaining property graph operations
+
+**Implementation:**
+1. Use **RDFLib** (Python library) to serialize Jerry entities as RDF
+2. Map Jerry URI scheme to RDF URIs:
+   ```
+   Jerry URI: jer:jer:work-tracker:task:TASK-001+hash
+   RDF URI:   https://jerry.dev/jer/work-tracker/task/TASK-001#hash
+   ```
+3. Export formats: Turtle, RDF/XML, JSON-LD
+4. Repository adapter pattern for dual persistence
+
+**Benefit:** Enables interoperability without changing core domain model
+
+#### Phase 2: SKOS Taxonomy (3-6 months)
+
+**Goal:** Define controlled vocabularies for Jerry concepts
+
+**Implementation:**
+1. Create SKOS concept schemes for:
+   - Work item types (Plan, Phase, Task, Subtask)
+   - Task status values (PENDING, ACTIVE, COMPLETED, BLOCKED)
+   - Actor types (CLAUDE, HUMAN, SYSTEM)
+   - Event types (TaskCreated, TaskCompleted, PhaseStarted, etc.)
+2. Publish SKOS vocabularies as linked data
+3. Use SKOS labels in UI and documentation
+
+**Benefit:** Standardized terminology, easier integration with external systems
+
+#### Phase 3: OWL Ontology (6-12 months)
+
+**Goal:** Formal ontology with reasoning capabilities
+
+**Implementation:**
+1. Define OWL ontology for Jerry domain:
+   - Class hierarchy (WorkItem → Plan/Phase/Task/Subtask)
+   - Property restrictions (cardinality, domain, range)
+   - Axioms and constraints (e.g., "A task cannot depend on itself")
+2. Use OWL DL profile for decidability
+3. Integrate reasoning engine (OWL-RL on RDFLib or HermiT)
+4. Enable inference:
+   - Automatic dependency chain calculation
+   - Inconsistency detection (circular dependencies)
+   - Progress aggregation via SWRL rules
+
+**Benefit:** Automated validation, inference, and consistency checking
+
+#### Phase 4: SPARQL Query Interface (12+ months)
+
+**Goal:** Support both Gremlin and SPARQL queries
+
+**Implementation:**
+1. Add SPARQL endpoint alongside Gremlin
+2. Use **kglab** for unified abstraction:
+   - Property graph operations via NetworkX/Gremlin
+   - RDF operations via RDFLib/SPARQL
+   - Single query interface with backend routing
+3. Enable federated queries across Jerry instances
+
+**Benefit:** Standards-based querying, federated knowledge graphs
+
+### 3. Library Selection: kglab as Abstraction Layer
+
+#### Why kglab?
+
+[kglab](https://github.com/DerwenAI/kglab) (MIT license) provides a unified abstraction layer across multiple paradigms:
+
+**Features:**
+- **RDF support:** Turtle, XML, JSON-LD serialization
+- **SPARQL execution:** Query RDF graphs
+- **SHACL validation:** Constraint validation
+- **NetworkX integration:** Graph algorithms
+- **Pandas export:** Data analysis
+
+**Architecture Fit:**
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Jerry Application Layer               │
+├─────────────────────────────────────────────────────────┤
+│                kglab Abstraction Layer                  │
+│  ┌────────────┬────────────┬──────────┬──────────────┐ │
+│  │   RDFLib   │ NetworkX   │  Pandas  │   pySHACL    │ │
+│  └────────────┴────────────┴──────────┴──────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│         Jerry Domain Model (Property Graph)             │
+│  Vertex/Edge abstractions + Jerry URI scheme            │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Alternative:** Direct use of **RDFLib** if kglab overhead is unnecessary.
+
+### 4. Netflix Knowledge Graph Patterns
+
+Jerry can adopt proven patterns from Netflix's Unified Data Architecture (UDA):
+
+| Netflix Pattern | Jerry Application |
+|-----------------|-------------------|
+| **Model Once, Represent Everywhere** | EntityBase → JSON, TOON, Property Graph, RDF |
+| **Named-Graph-First** | Jerry URI scheme already provides this structure |
+| **Knowledge Graph as Index** | KG indexes work items, content remains in files |
+| **Ontology-Driven Modeling** | OWL ontology governs all representations |
+| **LLM Enhancement** | Agents could enrich KG with inferred relationships |
+
+**Key Insight:** Netflix uses "conceptual RDF for their knowledge graph" but does not require "RDF all the way through." Jerry can follow this hybrid pattern.
+
+### 5. Performance and Scalability Considerations
+
+#### Property Graph vs RDF Trade-offs
+
+| Aspect | Property Graph | RDF/OWL | Jerry Decision |
+|--------|----------------|---------|----------------|
+| **Edge properties** | Native | Requires reification or RDF* | Property graph for storage |
+| **Traversal performance** | O(1) per hop | Depends on triple store | Property graph for queries |
+| **Reasoning** | None | RDFS/OWL inference | RDF for validation/inference |
+| **Schema flexibility** | Implicit | Explicit ontology | Hybrid: both supported |
+| **Standards compliance** | Vendor-specific | W3C standards | RDF for export/integration |
+
+**Recommendation:** Use property graph for operational queries, RDF for interoperability and reasoning.
+
+#### Storage Strategy
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  Jerry Storage Architecture              │
+├─────────────────────────────────────────────────────────┤
+│  Primary Storage (Property Graph - Gremlin)             │
+│  ├── File-based JSON (Phase 1)                          │
+│  ├── SQLite with graph schema (Phase 2)                 │
+│  └── Native graph DB (Phase 3 - optional)               │
+├─────────────────────────────────────────────────────────┤
+│  RDF Export (Interoperability)                          │
+│  ├── Turtle files (.ttl)                                │
+│  ├── JSON-LD (Schema.org markup)                        │
+│  └── SPARQL endpoint (optional)                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 6. Ontology Design Patterns for Jerry
+
+#### Modular Ontology Approach
+
+Following W3C Semantic Web Best Practices, use Ontology Design Patterns (ODPs):
+
+**Content Patterns for Jerry:**
+1. **Agent Role Pattern** - Actor types and permissions
+2. **Event Pattern** - CloudEvents as RDF events
+3. **Part-Whole Pattern** - Plan → Phase → Task hierarchy
+4. **Time Indexed Situation** - Status changes over time
+5. **Provenance Pattern** - Who created/modified what
+
+**Resources:**
+- [W3C OEP Task Force](http://www.w3.org/2001/sw/BestPractices/OEP/)
+- [MODL: Modular Ontology Design Library](https://arxiv.org/abs/1904.05405)
+- [Ontology Design Patterns Catalog](http://ontologydesignpatterns.org/)
+
+#### Extensibility Strategy
+
+**Modular Ontology Modeling Principles:**
+1. **One module per key concept** (Task module, Event module, Actor module)
+2. **Pattern reuse by extension** - Specialize existing patterns
+3. **Loose coupling** - Modules depend on interfaces, not implementations
+4. **Versioning** - OWL ontology versioning with owl:versionInfo
+
+**Example Module Structure:**
+```
+jerry-ontology/
+├── core.ttl              # Base classes and properties
+├── work-tracking.ttl     # Plan/Phase/Task specifics
+├── events.ttl            # CloudEvents ontology
+├── actors.ttl            # Agent/Actor ontology
+└── dependencies.ttl      # Task dependency patterns
+```
+
+---
+
+## Comparison Matrix
+
+### Standards Comparison: OWL vs SKOS vs RDF-S vs Schema.org
+
+| Dimension | RDF-S | SKOS | OWL DL | OWL Full | Schema.org |
+|-----------|-------|------|--------|----------|------------|
+| **W3C Status** | Recommendation (2004) | Recommendation (2009) | Recommendation (2012) | Recommendation (2012) | Community Group |
+| **Expressiveness** | Basic | Low | High | Very High | Medium |
+| **Reasoning** | Basic inference | None | Description logic | Undecidable | None |
+| **Complexity** | Low | Very Low | High | Very High | Low |
+| **Use Case** | Simple schemas | Taxonomies, thesauri | Formal ontologies | Max expressiveness | Web markup, SEO |
+| **Learning Curve** | Low | Very Low | High | Very High | Low |
+| **Tooling Support** | Excellent | Good | Excellent | Limited | Excellent |
+| **Decidability** | N/A | N/A | Decidable | Undecidable | N/A |
+| **Cardinality** | No | No | Yes (any number) | Yes (any number) | Limited |
+| **Property Restrictions** | Domain/Range | None | Full (restrictions) | Full (no restrictions) | Domain/Range hints |
+| **Class Hierarchy** | Yes | Concept hierarchy | Yes | Yes | Yes |
+| **Axioms/Rules** | No | No | Yes (DL axioms) | Yes (full logic) | No |
+| **Adoption** | Widespread | Library/Info Science | Academia, Healthcare | Research only | Massive (45M+ sites) |
+| **Query Language** | SPARQL | SPARQL | SPARQL | SPARQL | SPARQL (optional) |
+| **Jerry Applicability** | High | Medium | High | Low | High |
+
+### Decision Criteria Matrix
+
+| Requirement | Recommended Standard | Rationale |
+|-------------|---------------------|-----------|
+| Taxonomies, controlled vocabularies | **SKOS** | Designed for this purpose, minimal overhead |
+| Simple class/property definitions | **RDF-S** | Sufficient for basic schemas |
+| Formal logic, reasoning, validation | **OWL DL** | Decidable, practical reasoning |
+| Maximum expressiveness, research | **OWL Full** | No computational guarantees |
+| SEO, web markup, search integration | **Schema.org** | Industry standard, massive adoption |
+| Interoperability with enterprise systems | **OWL DL + SKOS** | Hybrid approach, best of both |
+
+### When to Use What (Decision Tree)
+
+```
+Need formal reasoning/validation?
+├─ YES → Do you need guaranteed decidability?
+│        ├─ YES → OWL DL
+│        └─ NO → OWL Full (research only)
+└─ NO → Building a taxonomy/thesaurus?
+         ├─ YES → SKOS
+         └─ NO → Need web search integration?
+                  ├─ YES → Schema.org
+                  └─ NO → RDF-S
+```
+
+---
+
+## Sources and References
+
+### Primary W3C Specifications
+
+| Standard | URL | Date |
+|----------|-----|------|
+| RDF 1.1 Primer | https://www.w3.org/TR/rdf11-primer/ | 2014-02-25 |
+| RDF Schema 1.1 | https://www.w3.org/TR/rdf-schema/ | 2014-02-25 |
+| SKOS Reference | https://www.w3.org/TR/skos-reference/ | 2009-08-18 |
+| SKOS Primer | https://www.w3.org/TR/skos-primer/ | 2009-08-18 |
+| OWL 2 Web Ontology Language Primer | https://www.w3.org/TR/owl2-primer/ | 2012-12-11 |
+| OWL 2 Overview | https://www.w3.org/TR/owl2-overview/ | 2012-12-11 |
+| OWL Features (OWL 1.0) | https://www.w3.org/TR/owl-features/ | 2004-02-10 |
+
+### Industry and Academic Sources
+
+| Topic | Source | URL |
+|-------|--------|-----|
+| OWL Lite/DL/Full Comparison | Web Ontology Language - Wikipedia | https://en.wikipedia.org/wiki/Web_Ontology_Language |
+| SKOS Best Practices | W3C SKOS Home Page | https://www.w3.org/2004/02/skos/ |
+| Schema.org Overview | Schema.org Official Site | https://schema.org/ |
+| Schema.org in 2024 | Schema App Solutions | https://www.schemaapp.com/schema-markup/the-semantic-value-of-schema-markup-in-2025/ |
+| Google Knowledge Graph | Knowledge graph - Wikipedia | https://en.wikipedia.org/wiki/Knowledge_graph |
+| Wikidata SPARQL | Semantic Technology Usage in Wikidata | https://link.springer.com/chapter/10.1007/978-3-030-00668-6_23 |
+| Knowledge Graph Industry Adoption | Semantic Web 20 Years Later - Ontotext | https://www.ontotext.com/blog/the-semantic-web-20-years-later/ |
+| Ontology Design Patterns | W3C OEP Task Force | http://www.w3.org/2001/sw/BestPractices/OEP/ |
+| Stanford Ontology Development 101 | Protégé Publications | https://protege.stanford.edu/publications/ontology_development/ontology101.pdf |
+| Modular Ontology Modeling | MODL Library (arXiv) | https://arxiv.org/abs/1904.05405 |
+| OWL and SKOS Integration | W3C: Using OWL and SKOS | https://www.w3.org/2006/07/SWD/SKOS/skos-and-owl/master.html |
+| RDF Schema vs OWL vs SKOS | Medium: Ontology Standards | https://medium.com/@jaywang.recsys/ontology-taxonomy-and-graph-standards-owl-rdf-rdfs-skos-052db21a6027 |
+
+### Tools and Libraries
+
+| Tool/Library | Type | URL |
+|--------------|------|-----|
+| kglab | Python knowledge graph library | https://github.com/DerwenAI/kglab |
+| RDFLib | Python RDF library | https://github.com/RDFLib/rdflib |
+| Protégé | Ontology editor | https://protege.stanford.edu/ |
+| TopBraid Composer | Enterprise ontology tool | https://www.w3.org/wiki/TopBraid |
+| Apache Jena | Java RDF framework | https://jena.apache.org/ |
+
+---
+
+## Recommendations for Jerry Framework
+
+### Immediate Actions (0-3 months)
+
+1. **Add RDFLib Dependency**
+   - Install RDFLib (pure Python, BSD-3 license)
+   - Create RDF serialization adapter in `src/infrastructure/persistence/rdf_adapter.py`
+   - Export Jerry entities as Turtle and JSON-LD
+
+2. **Define SKOS Vocabulary**
+   - Create `docs/ontology/jerry-vocabulary.ttl` with SKOS concept scheme
+   - Document work item types, statuses, and event types
+   - Publish as linked data (optional)
+
+3. **Update Jerry URI Scheme**
+   - Ensure full RDF URI compatibility
+   - Document URI → RDF URI mapping in SPEC-001
+   - Add RDF namespace prefix: `@prefix jer: <https://jerry.dev/jer/> .`
+
+### Short-term (3-6 months)
+
+4. **Create OWL Ontology (OWL DL)**
+   - Define Jerry Work Tracker ontology in `docs/ontology/jerry-ontology.ttl`
+   - Use Protégé for visual editing
+   - Include class hierarchy, property restrictions, cardinality constraints
+   - Validate with OWL DL reasoner (HermiT or Pellet)
+
+5. **Schema.org Mapping**
+   - Map Jerry entities to Schema.org types where applicable
+   - Enable JSON-LD export for integration with search engines
+   - Document in `docs/specifications/SCHEMA_ORG_MAPPING.md`
+
+6. **SHACL Validation (Optional)**
+   - Define SHACL shapes for data validation
+   - Use pySHACL for constraint checking
+   - Complement OWL with closed-world validation
+
+### Long-term (6-12 months)
+
+7. **kglab Integration**
+   - Evaluate kglab as abstraction layer
+   - Prototype dual Gremlin/SPARQL interface
+   - Measure performance overhead
+
+8. **SPARQL Endpoint**
+   - Add SPARQL query capability
+   - Enable federated queries across Jerry instances
+   - Document query patterns in `docs/knowledge/SPARQL_PATTERNS.md`
+
+9. **Reasoning Integration**
+   - Add OWL-RL reasoner for inference
+   - Implement consistency checking
+   - Enable automatic dependency analysis via reasoning
+
+### Strategic Principles
+
+**Principle 1: Hybrid Approach**
+- Property graph for operational queries (performance)
+- RDF/OWL for validation and reasoning (correctness)
+- Schema.org for external integration (interoperability)
+
+**Principle 2: Standards Compliance**
+- Follow W3C recommendations
+- Use established ontology design patterns
+- Enable federated queries across systems
+
+**Principle 3: Incremental Adoption**
+- Start with RDF serialization (low risk)
+- Add SKOS vocabularies (immediate value)
+- Progress to OWL reasoning (when needed)
+
+**Principle 4: Tool Reuse**
+- Leverage mature libraries (RDFLib, kglab)
+- Use Protégé for ontology editing
+- Adopt proven Netflix UDA patterns
+
+---
+
+## 5W1H Research Framework Alignment
+
+### WHAT are the main semantic representation standards?
+
+**Answer:** Four primary standards, each serving different purposes:
+- **RDF-S:** Basic schema definition (classes, properties, hierarchies)
+- **SKOS:** Taxonomies and controlled vocabularies
+- **OWL:** Formal ontologies with reasoning (Lite, DL, Full)
+- **Schema.org:** Practical web markup for search engines and AI
+
+### WHY would you choose one over another?
+
+**Answer:**
+- **SKOS** when organizing concepts hierarchically without formal logic
+- **RDF-S** when basic class/property definitions suffice
+- **OWL DL** when formal reasoning and validation are required with decidability guarantees
+- **OWL Full** when maximum expressiveness is needed (research contexts)
+- **Schema.org** when integrating with web search and external AI systems
+
+### WHO are the authoritative sources?
+
+**Answer:**
+- **W3C:** All core specifications (RDF-S, SKOS, OWL)
+- **Stanford KSL:** Ontology development methodology (Protégé, Ontology 101)
+- **Google/Microsoft/Yahoo/Yandex:** Schema.org sponsors
+- **Research Institutions:** Ontology design patterns (University of Manchester, Stanford)
+- **Industry Leaders:** Netflix (Knowledge Graph UDA), Wikidata (Wikimedia Foundation)
+
+### WHEN is OWL heavyweight vs when is SKOS sufficient?
+
+**Answer:**
+
+**Use SKOS when:**
+- Building taxonomies, thesauri, or classification schemes
+- Semi-formal knowledge organization is acceptable
+- No reasoning or inference is required
+- Minimal ontological commitment preferred
+- Quick migration from existing vocabularies needed
+
+**Use OWL DL when:**
+- Formal logic and axioms are required
+- Automatic reasoning and inference needed
+- Consistency checking is critical
+- Property restrictions and cardinality constraints necessary
+- Decidability guarantees required
+
+**Use OWL Full when:**
+- Maximum expressiveness required
+- Meta-modeling needed (classes as instances)
+- Research context with no computational constraints
+- Augmenting RDF/OWL vocabulary meanings
+
+### WHERE are semantic representations used successfully in industry?
+
+**Answer:**
+
+**Search and Discovery:**
+- **Google Knowledge Graph:** 45+ million websites, billions of Schema.org objects
+- **Bing, Yahoo, Yandex:** All support Schema.org markup
+
+**Open Knowledge:**
+- **Wikidata:** 100 million topics, 10 billion RDF triples, live SPARQL endpoint
+- **DBpedia:** Wikipedia as structured RDF data
+
+**Enterprise Knowledge Graphs:**
+- **Facebook, LinkedIn, Microsoft, Amazon, Uber, eBay:** All use knowledge graphs
+- **Netflix:** Unified Data Architecture with ontology-driven modeling
+- **Airbnb:** Knowledge graph for search and recommendations
+
+**Specialized Domains:**
+- **Library Science:** LCSH (Library of Congress Subject Headings) in SKOS
+- **Agriculture:** AGROVOC (FAO agricultural vocabulary) in SKOS
+- **European Union:** EuroVoc multilingual thesaurus in SKOS
+- **Healthcare/Biomedicine:** OWL ontologies with Protégé
+
+### HOW do you design ontologies for extensibility and performance?
+
+**Answer:**
+
+**Extensibility Patterns:**
+1. **Modular Ontology Modeling:** One module per key concept, reusable patterns
+2. **Ontology Design Patterns:** Reuse by extension and composition
+3. **Loose Coupling:** Modules depend on interfaces, not implementations
+4. **Versioning:** OWL ontology versioning with owl:versionInfo
+5. **Open World Assumption:** Design for unknown future extensions
+
+**Performance Strategies:**
+1. **Choose Appropriate Expressiveness:** Use simplest standard that meets requirements
+2. **Hybrid Storage:** Property graph for queries, RDF for validation
+3. **Lazy Reasoning:** Compute inferences only when needed
+4. **Materialization:** Precompute common inferences
+5. **Profiling:** Use OWL DL (decidable) over OWL Full when possible
+
+**Tools and Best Practices:**
+- **W3C OEP Task Force:** 4+ documented patterns
+- **MODL Library:** Curated ontology design pattern collection
+- **Protégé:** Visual ontology editor with reasoning validation
+- **CoModIDE:** Protégé plugin for pattern-based modeling
+
+---
+
+## Appendix: Glossary
+
+| Term | Definition |
+|------|------------|
+| **RDF** | Resource Description Framework - W3C standard for graph data |
+| **RDF-S** | RDF Schema - Basic vocabulary for RDF schemas |
+| **SKOS** | Simple Knowledge Organization System - W3C standard for taxonomies |
+| **OWL** | Web Ontology Language - W3C standard for formal ontologies |
+| **OWL DL** | OWL Description Logic - Decidable subset of OWL |
+| **OWL Full** | Full expressiveness OWL, undecidable |
+| **SPARQL** | SPARQL Protocol and RDF Query Language - Query language for RDF |
+| **Schema.org** | Vocabulary for structured data on the web |
+| **Triple** | RDF statement: subject-predicate-object |
+| **Ontology** | Formal specification of concepts and relationships |
+| **Taxonomy** | Hierarchical classification of concepts |
+| **Thesaurus** | Controlled vocabulary with synonyms and relationships |
+| **Reasoning** | Automatic inference of new knowledge from existing data |
+| **Decidability** | Property that a computation will finish in finite time |
+| **ODP** | Ontology Design Pattern - Reusable modeling solution |
+| **SHACL** | Shapes Constraint Language - RDF data validation |
+| **Reification** | Representing statements as resources (RDF) |
+| **RDF*** | RDF-star - Extension supporting edge properties natively |
+| **kglab** | Python library for knowledge graph abstraction |
+| **Protégé** | Open-source ontology editor from Stanford |
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-08*
+*Author: Claude (ps-researcher agent v2.0.0)*
+*Research Framework: 5W1H*
+*Quality Status: DECISION-GRADE*
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial research document: OWL, SKOS, RDF-S, Schema.org comparison with L0/L1/L2 structure |

--- a/docs/archive/projects-archive/research/work-031-e-003-semantic-technologies.md
+++ b/docs/archive/projects-archive/research/work-031-e-003-semantic-technologies.md
@@ -1,0 +1,1434 @@
+# Semantic Presentation Technologies Research
+
+> **Research Date:** 2026-01-08
+> **Status:** DECISION-GRADE
+> **PS ID:** work-031
+> **Entry ID:** e-003
+> **Purpose:** Research technologies for semantic presentation and knowledge graph tooling
+> **Extends:** `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md`
+
+---
+
+## L0: Executive Summary (Plain Language)
+
+This research extends the existing graph data model analysis by surveying the ecosystem of tools and technologies for building, storing, querying, and visualizing knowledge graphs and semantic data.
+
+### Key Findings
+
+1. **Triple Stores**: Oxigraph emerges as the best embedded option for Jerry (pure Rust, Python bindings, zero Java dependencies), while Apache Jena/Fuseki leads for server-based deployments.
+
+2. **Graph Databases**: Neo4j dominates for property graphs, but Amazon Neptune offers best cloud-native TinkerPop/Gremlin support. ArangoDB provides unique multi-model flexibility.
+
+3. **Python Libraries**: kglab provides an abstraction layer across paradigms, owlready2 excels at OWL ontology work, and pyoxigraph delivers embedded RDF storage.
+
+4. **Visualization**: Gephi for desktop analysis, Cytoscape.js for web interactivity, NetworkX for Python integration.
+
+5. **Embedded vs Server**: Embedded databases (Oxigraph, SQLite) align with Jerry's zero-dependency philosophy; server-based solutions (Jena Fuseki, Neo4j) offer better scalability but require infrastructure.
+
+### Strategic Recommendation for Jerry
+
+**Phase 1 (Current)**: Continue with property graph abstraction layer + file-based JSON storage
+**Phase 2**: Add pyoxigraph as embedded RDF triple store adapter
+**Phase 3**: Expose SPARQL endpoint via Python (SPARQLWrapper + Flask)
+**Phase 4**: Visualization via NetworkX + Cytoscape.js for web presentation
+
+---
+
+## L1: Technical Details
+
+### 1. Triple Stores (RDF Storage)
+
+Triple stores persist RDF data (subject-predicate-object triples) and provide SPARQL query capabilities.
+
+#### 1.1 Apache Jena / Fuseki
+
+**What**: Java-based semantic web framework with TDB2 native triple store and Fuseki SPARQL server
+**Who Maintains**: Apache Software Foundation
+**Why Use**: Industry standard, mature, handles millions of triples efficiently
+**When**: Server-based deployments requiring SPARQL endpoints
+**Where**: Powers DBpedia and many enterprise knowledge graphs
+**How (Python)**: HTTP/SPARQL via SPARQLWrapper, no direct API
+
+**Key Features**:
+- TDB2: High-performance native triple store supporting full Jena APIs
+- Fuseki: REST-style SPARQL endpoint over HTTP
+- Parallel loading: Import millions of triples in minutes using tdb2_tdbloader
+- OWL/RDFS reasoning support
+- Named graph support (dataset-level organization)
+
+**Performance**: Can combine Fuseki's persistent TDB2 stores with parallel loading to handle millions of triples with named graphs in minutes.
+
+**Python Integration**:
+```python
+from SPARQLWrapper import SPARQLWrapper, JSON
+sparql = SPARQLWrapper("http://localhost:3030/dataset/sparql")
+sparql.setQuery("SELECT * WHERE { ?s ?p ?o } LIMIT 10")
+sparql.setReturnFormat(JSON)
+results = sparql.queryAndConvert()
+```
+
+**Citations**: [Apache Jena](https://jena.apache.org/), [Accelerated Parallel RDF Loading](https://medium.com/@deepakpatwal/accelerated-parallel-rdf-loading-import-millions-of-triples-from-multiple-datasets-using-the-c49a3a6eba37)
+
+---
+
+#### 1.2 Virtuoso Universal Server
+
+**What**: Multi-model relational database with linked data component (RDF + SQL)
+**Who Maintains**: OpenLink Software (commercial + open-source editions)
+**Why Use**: Extremely fast query performance (3x faster than competitors for deep queries)
+**When**: Large-scale deployments (DBpedia uses Virtuoso 7)
+**Where**: DBpedia, life sciences knowledge graphs
+**How (Python)**: HTTP SPARQL endpoints via SPARQLWrapper
+
+**Key Features**:
+- Hybrid architecture: RDF layer over relational database
+- 95% better query response than Sesame/Blazegraph for most queries
+- Deep query performance: 128ms vs Blazegraph's 3+ seconds
+- Commercial version offers high availability clustering
+- Supports both SPARQL and SQL queries
+
+**Performance**: Virtuoso and AnzoGraph are significantly faster (almost 3 times faster than Stardog) than other triplestores across diverse queries.
+
+**Tradeoffs**:
+- **Pro**: Exceptional performance, proven at scale (DBpedia)
+- **Con**: Confusing admin interface, C code compilation issues reported, not always returning correct triples in some edge cases
+- **Con**: Stricter requirements for geographical data than Blazegraph
+
+**Citations**: [Comparing Linked Data Triplestores](https://medium.com/wallscope/comparing-linked-data-triplestores-ebfac8c3ad4f), [Wikimedia Virtuoso Evaluation](https://phabricator.wikimedia.org/T206561)
+
+---
+
+#### 1.3 Blazegraph
+
+**What**: Pure Java high-performance triple store (now part of Amazon Neptune)
+**Who Maintains**: Originally Systap LLC, now Amazon (used in Neptune backend)
+**Why Use**: Powers Wikidata Query Service, strong SPARQL 1.1 support
+**When**: Java-based environments, Wikidata-style use cases
+**Where**: Wikidata Query Service
+**How (Python)**: HTTP SPARQL endpoints via SPARQLWrapper
+
+**Key Features**:
+- Syntax highlighting in query editor
+- Server-side pagination
+- Query performance logging
+- Fast RDF/XML loading (2x faster than average)
+- Pure Java (easy deployment via JAR)
+
+**Performance**:
+- **Strengths**: Fast loading, good for shallow queries
+- **Weaknesses**: Trails behind on deep queries (3+ seconds vs Virtuoso's 128ms)
+
+**Tradeoffs**:
+- **Pro**: Pure Java, easy to configure, battle-tested (Wikidata)
+- **Con**: Slower on deep graph traversals, development slowed after Amazon acquisition
+
+**Citations**: [Comparing Triple Stores](https://utecht.github.io/rdf/triple%20stores/comparing-triplestores/), [Blazegraph vs Virtuoso](https://db-engines.com/en/system/Blazegraph%3BVirtuoso)
+
+---
+
+#### 1.4 Oxigraph ⭐ (Jerry Recommended for Embedded Use)
+
+**What**: Pure Rust SPARQL graph database with Python bindings (pyoxigraph)
+**Who Maintains**: Tpt (Oxigraph GitHub organization)
+**Why Use**: Modern, fast, embeddable, zero Java dependencies, active development
+**When**: Embedded use cases, Python-first applications
+**Where**: NaasAI platform, research projects
+**How (Python)**: Native Python API via pyoxigraph
+
+**Key Features**:
+- **Embedded storage**: In-memory or RocksDB-backed disk storage
+- **SPARQL 1.1 support**: Full query, update, federation
+- **RDF 1.2 / SPARQL 1.2**: W3C working draft support (enabled by default in Python)
+- **RDF* support**: Triple terms for meta-properties
+- **Multiple serialization formats**: Turtle, TriG, N-Triples, N-Quads, RDF/XML, JSON-LD 1.0
+- **PyO3-based Python bindings**: Native performance, no JVM
+- **rdflib integration**: oxrdflib provides drop-in replacement for rdflib stores
+
+**Architecture**:
+- RocksDB backend with 11 key-value tables
+- 1 table (id2str) for string IDs
+- 9 tables for different quad orders (SPO, POS, OSP, etc.)
+- 1 table for named graph registry
+
+**Python Integration**:
+```python
+from pyoxigraph import Store
+
+# In-memory store
+store = Store()
+
+# Disk-based store
+store = Store(path="/path/to/data")
+
+# Load triples
+store.load("data.ttl", format="ttl")
+
+# SPARQL query
+results = store.query("SELECT * WHERE { ?s ?p ?o } LIMIT 10")
+for result in results:
+    print(result)
+```
+
+**Integration with rdflib**:
+```python
+from rdflib import Graph
+g = Graph(store="Oxigraph")  # Drop-in replacement
+g.parse("data.ttl")
+results = g.query("SELECT * WHERE { ?s ?p ?o }")
+```
+
+**Recent Updates (2025)**:
+- RDF 1.2 and SPARQL 1.2 support
+- Custom aggregate functions in Rust and Python API
+- oxrdflib updated November 2025 with RocksDB-based storage
+
+**Jerry Alignment**:
+- ✅ **Zero Java dependency**: Pure Rust + Python
+- ✅ **Embeddable**: No separate server process required
+- ✅ **Pre-installed potential**: Could be added to Jerry's stdlib-only core if distribution allows
+- ✅ **Modern standards**: RDF 1.2, SPARQL 1.2, RDF*
+- ✅ **Active development**: Regular updates in 2025
+
+**Citations**: [Oxigraph GitHub](https://github.com/oxigraph/oxigraph), [pyoxigraph PyPI](https://pypi.org/project/pyoxigraph/), [pyoxigraph Documentation](https://pyoxigraph.readthedocs.io/), [oxrdflib GitHub](https://github.com/oxigraph/oxrdflib)
+
+---
+
+### 2. Graph Databases (Property Graphs)
+
+Property graph databases store vertices (nodes) and edges (relationships) with properties, optimized for traversal queries.
+
+#### 2.1 Neo4j
+
+**What**: Native graph database with Cypher query language
+**Who Maintains**: Neo4j, Inc. (commercial + community editions)
+**Why Use**: Market leader, mature ecosystem, advanced graph algorithms
+**When**: Complex relationship queries, fraud detection, recommendation engines
+**Where**: NASA, Walmart, eBay, Airbnb
+**How (Python)**: Official neo4j-driver Python library
+
+**Key Features**:
+- **Cypher query language**: Declarative, SQL-like syntax for graph patterns
+- **Native graph storage**: Index-free adjacency for fast traversals
+- **ACID transactions**: Full transaction support
+- **Graph algorithms library**: PageRank, community detection, pathfinding
+- **Visualization browser**: Built-in graph exploration UI
+- **Multi-deployment**: Self-hosted, cloud (Aura), embedded
+
+**Query Example (Cypher)**:
+```cypher
+MATCH (task:Task)-[:CONTAINS]->(subtask:Subtask)
+WHERE task.status = 'IN_PROGRESS'
+RETURN task.title, count(subtask) AS subtask_count
+```
+
+**Python Integration**:
+```python
+from neo4j import GraphDatabase
+
+driver = GraphDatabase.driver("bolt://localhost:7687", auth=("neo4j", "password"))
+with driver.session() as session:
+    result = session.run("MATCH (n:Task) RETURN n.title LIMIT 10")
+    for record in result:
+        print(record["n.title"])
+```
+
+**Performance**: TigerGraph edges out Neo4j in deep-link traversal benchmarks, but Neo4j performs strongly with Fabric sharding enabled.
+
+**Tradeoffs**:
+- **Pro**: Most mature, best developer experience, strong visualization, flexible deployment
+- **Con**: Enterprise Edition licensing costs, Cypher not standardized (vs Gremlin)
+- **Con**: Not natively TinkerPop-compatible (separate plugin required)
+
+**Citations**: [Neo4j vs Amazon Neptune](https://www.analyticsvidhya.com/blog/2024/08/neo4j-vs-amazon-neptune/), [Best Graph Databases 2025](https://www.getgalaxy.io/learn/data-tools/best-graph-databases-2025)
+
+---
+
+#### 2.2 Amazon Neptune
+
+**What**: Fully managed cloud graph database supporting Gremlin (TinkerPop) and SPARQL
+**Who Maintains**: Amazon Web Services
+**Why Use**: Cloud-native, dual-model (property graph + RDF), serverless scaling
+**When**: AWS-integrated applications, need for both Gremlin and SPARQL
+**Where**: AWS cloud deployments
+**How (Python)**: gremlinpython or SPARQLWrapper over HTTP
+
+**Key Features**:
+- **Dual model**: Property graph (Gremlin) AND RDF (SPARQL) in same database
+- **Compute-storage separation**: Storage auto-scales to 128 TiB, compute scales independently
+- **Serverless v2**: Auto-provisions compute based on workload
+- **15 read replicas**: Low-latency horizontal scaling
+- **TinkerPop 3.x compatible**: Portable to other Gremlin databases
+- **openCypher support**: Compatible with Neo4j workloads via Bolt/HTTPS
+
+**Consistency Model**:
+- Immediate consistency on writer instance
+- Eventual consistency on read replicas
+
+**Tradeoffs**:
+- **Pro**: Fully managed, dual query language support, cloud-native scalability
+- **Con**: AWS lock-in, no built-in visualization (requires SageMaker/Jupyter), costs tied to instance hours
+- **Con**: Eventual consistency on replicas (not fully ACID across cluster)
+
+**Jerry Alignment**:
+- ✅ **TinkerPop compatibility**: Aligns with Jerry's Gremlin-ready design
+- ❌ **Cloud dependency**: Violates Jerry's zero-dependency core principle
+- 🟡 **Future migration target**: Good Phase 3 option if cloud deployment needed
+
+**Citations**: [Amazon Neptune vs Neo4j](https://stackshare.io/stackups/amazon-neptune-vs-neo4j), [Neptune vs Neo4j Comparison](https://www.brilworks.com/blog/neptune-vs-neo4j/)
+
+---
+
+#### 2.3 JanusGraph
+
+**What**: Open-source distributed graph database with pluggable storage backends
+**Who Maintains**: Linux Foundation (JanusGraph community)
+**Why Use**: Flexibility, horizontal scale via Cassandra/HBase/Bigtable
+**When**: Need for massive scale, existing Cassandra/HBase infrastructure
+**Where**: Organizations with big data infrastructure (Cassandra, Spark)
+**How (Python)**: gremlinpython (TinkerPop Gremlin over websocket)
+
+**Key Features**:
+- **Pluggable backends**: Cassandra, ScyllaDB, HBase, Google Bigtable
+- **Gremlin native**: Full Apache TinkerPop 3.x support
+- **Infinite horizontal scale**: Runs atop distributed storage systems
+- **Advanced indexing**: Elasticsearch, Solr, Lucene integration
+- **Open-source**: Apache 2.0 license, no vendor lock-in
+
+**Architecture**:
+- JanusGraph is a layer over proven stores (not a standalone database)
+- Brings Gremlin query capabilities to existing distributed systems
+- Separates graph logic from storage persistence
+
+**Tradeoffs**:
+- **Pro**: True horizontal scaling, open-source, backend flexibility
+- **Con**: Complexity of multi-component setup (JanusGraph + Cassandra + Elasticsearch)
+- **Con**: Consistency model depends on backend (Cassandra = eventual consistency)
+- **Con**: No built-in visualization tools
+
+**Use Case Fit**: Ideal for organizations already using Cassandra/HBase who want graph capabilities without adopting a new storage engine.
+
+**Citations**: [Amazon Neptune vs JanusGraph vs Neo4j](https://db-engines.com/en/system/Amazon+Neptune%3BJanusGraph%3BNeo4j), [Top JanusGraph Alternatives](https://www.puppygraph.com/blog/janusgraph-alternatives)
+
+---
+
+#### 2.4 ArangoDB
+
+**What**: Multi-model database (document, graph, key-value) with AQL query language
+**Who Maintains**: ArangoDB GmbH (commercial + open-source)
+**Why Use**: Flexibility to mix data models, GraphQL/REST API support
+**When**: Applications with diverse data types, microservices architectures
+**Where**: Startups, front-end teams using GraphQL
+**How (Python)**: python-arango official driver
+
+**Key Features**:
+- **Multi-model**: Document, graph, and key-value in one database
+- **AQL (ArangoDB Query Language)**: Supports joins, graph traversals, full-text search
+- **Foxx microservices**: Build data-centric microservices in the database
+- **Full ACID transactions**: Data integrity across models
+- **Cluster support**: Horizontal scaling
+- **Native JSON**: Document model uses JSON natively
+
+**Python Integration**:
+```python
+from arango import ArangoClient
+
+client = ArangoClient(hosts='http://localhost:8529')
+db = client.db('_system', username='root', password='password')
+
+# Document operations
+collection = db.collection('tasks')
+collection.insert({'title': 'Task 1', 'status': 'pending'})
+
+# Graph traversal (AQL)
+cursor = db.aql.execute("""
+    FOR v, e, p IN 1..3 OUTBOUND 'tasks/123' CONTAINS
+    RETURN v
+""")
+```
+
+**Tradeoffs**:
+- **Pro**: Multi-model flexibility, good for startups with evolving schemas
+- **Con**: Smaller community vs Neo4j, steeper learning curve for AQL
+- **Con**: Documentation gaps for advanced features
+- **Con**: AQL is not a standard (vendor-specific)
+
+**Jerry Alignment**:
+- 🟡 **Multi-model**: Interesting but may add complexity
+- ❌ **Non-standard query language**: AQL vs standard Gremlin/SPARQL/Cypher
+- 🟡 **Consideration for Phase 3**: If document + graph co-location needed
+
+**Citations**: [ArangoDB GitHub](https://github.com/arangodb/arangodb), [First Steps with ArangoDB and Python](https://cylab.be/blog/299/first-steps-with-a-graph-database-using-python-and-arangodb), [Best Graph Databases 2025](https://www.puppygraph.com/blog/best-graph-databases)
+
+---
+
+### 3. Python Libraries for Knowledge Graphs
+
+#### 3.1 kglab (Knowledge Graph Abstraction Layer) ⭐
+
+**What**: Unified Python API for knowledge graphs across RDF, NetworkX, and Pandas
+**Who Maintains**: DerwenAI (Paco Nathan)
+**Why Use**: Abstraction across paradigms, integrates semantic web + graph analytics
+**When**: Need to support both RDF and property graph workflows
+**How**: Wraps RDFLib, NetworkX, SHACL, SPARQL in unified interface
+
+**Key Features**:
+- **RDF serialization**: Turtle, RDF/XML, JSON-LD, N-Triples
+- **SPARQL execution**: Query local stores or remote endpoints
+- **SHACL validation**: Schema validation for RDF graphs
+- **NetworkX integration**: Graph algorithms (centrality, clustering, pathfinding)
+- **Pandas export**: Convert graph data to DataFrames for analysis
+- **Visualization**: Integration with PyVis, Matplotlib
+
+**Python Example**:
+```python
+import kglab
+
+# Create knowledge graph
+kg = kglab.KnowledgeGraph()
+kg.load_rdf("data.ttl")
+
+# SPARQL query
+sparql = """
+SELECT ?s ?p ?o
+WHERE { ?s ?p ?o }
+LIMIT 10
+"""
+results = kg.query(sparql)
+
+# Export to NetworkX
+nx_graph = kg.build_nx_graph()
+
+# Export to Pandas
+df = kg.query_as_df(sparql)
+```
+
+**Jerry Alignment**:
+- ✅ **Abstraction layer**: Aligns with Jerry's "Model Once, Represent Everywhere" pattern (Netflix UDA)
+- ✅ **MIT license**: Open-source, compatible with Jerry
+- 🟡 **Dependency tradeoff**: Adds RDFLib, NetworkX as transitive dependencies
+- ✅ **Phase 2 candidate**: Could serve as abstraction over pyoxigraph + NetworkX
+
+**Citations**: [kglab GitHub](https://github.com/DerwenAI/kglab)
+
+---
+
+#### 3.2 RDFLib
+
+**What**: Pure Python library for RDF parsing, querying, and serialization
+**Who Maintains**: RDFLib team (community-driven)
+**Why Use**: Standard Python RDF library, no external dependencies
+**When**: Working with RDF/Turtle/JSON-LD files, local SPARQL queries
+**How**: Native Python API
+
+**Key Features**:
+- **Format support**: Turtle, N-Triples, N-Quads, RDF/XML, JSON-LD, TriG
+- **SPARQL 1.1**: Query and update support
+- **Triple stores**: In-memory, SQLite, BerkeleyDB backends
+- **Namespace management**: Built-in namespace registry
+- **Pure Python**: No C extensions required (though plugins can add performance)
+
+**Python Example**:
+```python
+from rdflib import Graph, Namespace, URIRef, Literal
+
+# Create graph
+g = Graph()
+g.parse("data.ttl", format="turtle")
+
+# Add triples
+JER = Namespace("https://jerry.dev/jer/work-tracker/")
+g.add((JER['task-001'], JER['title'], Literal("Implement feature")))
+
+# SPARQL query
+results = g.query("""
+    SELECT ?task ?title
+    WHERE { ?task jer:title ?title }
+""")
+
+# Serialize
+print(g.serialize(format="json-ld"))
+```
+
+**Tradeoffs**:
+- **Pro**: Pure Python, extensive format support, SPARQL support
+- **Con**: Performance slower than native stores (Oxigraph, Virtuoso)
+- **Con**: SPARQL endpoint requires additional setup (Flask + custom code)
+
+**Jerry Alignment**:
+- ✅ **Pure Python**: No compilation required
+- ✅ **Standard library**: De facto Python RDF standard
+- 🟡 **Performance**: Adequate for small-to-medium graphs, may need Oxigraph for large datasets
+
+**Citations**: [RDFLib Documentation](https://rdflib.dev/sparqlwrapper/), [Semantic Web standards and Python](https://www.lassila.org/publications/2025/lassila-omg-challenge-2025.pdf)
+
+---
+
+#### 3.3 owlready2
+
+**What**: Python library for ontology-oriented programming with OWL/RDF support
+**Who Maintains**: Jean-Baptiste Lamy (Les Fleurs du Normal)
+**Why Use**: Load and manipulate OWL ontologies, reasoning via HermiT/Pellet
+**When**: Working with OWL ontologies, medical terminologies (UMLS), reasoning-heavy tasks
+**How**: Native Python API with optional Java reasoners
+
+**Key Features**:
+- **OWL 2.0 support**: Full ontology manipulation in Python
+- **Reasoning**: HermiT and Pellet reasoners (included, requires Java)
+- **Quadstore**: Optimized RDF/OWL storage backend
+- **ORM capabilities**: Use as object-relational mapper for graph data
+- **Medical domain**: Integrated PyMedTermino2 for UMLS
+- **RDFLib integration**: Can import/export to RDFLib graphs
+
+**Python Example**:
+```python
+from owlready2 import *
+
+# Load ontology
+onto = get_ontology("http://example.org/work-tracker.owl").load()
+
+# Define classes
+class Task(Thing):
+    namespace = onto
+
+class hasStatus(Task >> str):
+    pass
+
+# Create instances
+task1 = Task("task-001")
+task1.hasStatus = "pending"
+
+# Reasoning
+sync_reasoner_pellet(infer_property_values=True)
+
+# Save
+onto.save(file="work-tracker-inferred.owl")
+```
+
+**Performance**: Benchmarked to beat Neo4j, MongoDB, SQLObject, and SQLAlchemy as an ORM.
+
+**Tradeoffs**:
+- **Pro**: Best Python OWL library, built-in reasoning, fast quadstore
+- **Con**: Reasoners require Java (HermiT, Pellet)
+- **Con**: No native SPARQL support (requires RDFLib bridge)
+- **Con**: LGPL v3 license (copyleft)
+
+**Jerry Alignment**:
+- 🟡 **Java dependency for reasoning**: Conflicts with zero-dependency goal
+- ✅ **OWL ontology**: Useful if Jerry adopts formal ontology (Phase 3)
+- ❌ **LGPL license**: May require careful integration to avoid copyleft issues
+
+**Citations**: [owlready2 PyPI](https://pypi.org/project/owlready2/), [owlready2 Documentation](https://www.lesfleursdunormal.fr/static/informatique/owlready/index_en.html)
+
+---
+
+#### 3.4 PyKEEN (Python Knowledge Embeddings)
+
+**What**: Library for training and evaluating knowledge graph embedding models
+**Who Maintains**: PyKEEN team (academic/research-driven)
+**Why Use**: Machine learning on knowledge graphs, link prediction, entity alignment
+**When**: Research, recommendation systems, graph completion tasks
+**How**: PyTorch-based embedding model training
+
+**Key Features**:
+- **Embedding models**: TransE, DistMult, ComplEx, RotatE, ConvE, and 30+ others
+- **Evaluation**: Ranking metrics (MRR, Hits@K)
+- **Hyperparameter optimization**: Integration with Optuna
+- **Training pipelines**: End-to-end workflows for KG embeddings
+- **Interoperability**: Works with PyG (PyTorch Geometric)
+
+**Use Case Example**:
+- **Link prediction**: Given (Task, DEPENDS_ON, ?) predict missing dependencies
+- **Entity alignment**: Match entities across different knowledge graphs
+- **Recommendation**: Recommend related tasks based on graph structure
+
+**Jerry Alignment**:
+- 🟡 **ML/AI future use**: Not immediate need, but could enhance recommendations
+- ❌ **PyTorch dependency**: Large dependency footprint
+- 🟡 **Phase 4+**: Consider for intelligent task suggestions
+
+**Citations**: [semantic-python-overview](https://github.com/pysemtec/semantic-python-overview)
+
+---
+
+#### 3.5 pyoxigraph (Covered in Section 1.4)
+
+See Triple Stores > Oxigraph for full details.
+
+---
+
+### 4. Visualization Tools
+
+#### 4.1 Gephi (Desktop Application)
+
+**What**: "Photoshop of graph visualization" - desktop app for network analysis
+**Who Maintains**: Gephi Consortium (open-source)
+**Why Use**: Advanced graph analytics, publication-quality visualizations
+**When**: Exploratory data analysis, research, generating static diagrams
+**Where**: 10,000+ peer-reviewed publications, academic research
+
+**Key Features**:
+- **Real-time manipulation**: Filter, cluster, layout in real-time
+- **Algorithms**: Modularity detection, PageRank, betweenness centrality
+- **Layouts**: Force-directed (ForceAtlas2), hierarchical, circular
+- **Export**: PNG, SVG, PDF
+- **Gephi Lite**: Web-based version (2025)
+
+**Python Integration**: Export NetworkX graphs to Gephi format (GEXF)
+```python
+import networkx as nx
+G = nx.DiGraph()
+G.add_edge("Task-001", "Subtask-001")
+nx.write_gexf(G, "graph.gexf")
+# Open graph.gexf in Gephi
+```
+
+**Tradeoffs**:
+- **Pro**: Powerful desktop tool, excellent for analysis
+- **Con**: Desktop application (not embeddable), no web interactivity
+- **Con**: Requires manual export/import workflow from Python
+
+**Jerry Alignment**:
+- 🟡 **Desktop tool**: Useful for development/debugging, not production
+- 🟡 **Workflow**: Export Jerry graph to GEXF for visualization
+
+**Citations**: [Gephi](https://gephi.org/), [Graph Visualization Tools Comparison](https://memgraph.com/blog/you-want-a-fast-easy-to-use-and-popular-graph-visualization-tool)
+
+---
+
+#### 4.2 Graphviz (DOT Language)
+
+**What**: Text-based graph description language with automatic layout
+**Who Maintains**: AT&T Research, open-source community
+**Why Use**: Simple syntax, reliable layouts, static diagram generation
+**When**: Documentation, architecture diagrams, simple visualizations
+**Where**: Ubiquitous in software engineering (UML, dependency graphs)
+
+**Key Features**:
+- **DOT language**: Plain text graph specification
+- **Layout engines**: dot (hierarchical), neato (spring), fdp (force), circo (circular)
+- **Output formats**: PNG, SVG, PDF, PostScript
+- **Python binding**: graphviz package
+
+**Python Example**:
+```python
+from graphviz import Digraph
+
+dot = Digraph(comment='Jerry Work Tracker')
+dot.node('PLAN-001', 'Plan: Q1 Goals')
+dot.node('PHASE-001', 'Phase 1: Setup')
+dot.edge('PLAN-001', 'PHASE-001', label='CONTAINS')
+
+dot.render('work-tracker.gv', format='svg', view=True)
+```
+
+**Tradeoffs**:
+- **Pro**: Simple, reliable, great for static diagrams
+- **Con**: No interactivity, limited styling vs modern libraries
+- **Con**: DOT syntax learning curve for complex graphs
+
+**Jerry Alignment**:
+- ✅ **Documentation**: Good for generating docs/diagrams/ visualizations
+- 🟡 **Static output**: Not suitable for interactive web presentations
+- ✅ **Lightweight**: Minimal dependencies
+
+**Citations**: [Graphviz](https://graphviz.org/), [External Resources](https://graphviz.org/resources/)
+
+---
+
+#### 4.3 Cytoscape / Cytoscape.js ⭐
+
+**What**: Open-source network visualization platform (desktop + JavaScript library)
+**Who Maintains**: Cytoscape Consortium (desktop), Max Franz (Cytoscape.js)
+**Why Use**: Interactive web visualizations, bioinformatics standard
+**When**: Web applications, scientific visualization, interactive exploration
+**Where**: Biology, social networks, knowledge graphs
+
+**Key Features (Cytoscape.js)**:
+- **JavaScript library**: Embeddable in web applications
+- **Flexible layouts**: Force-directed, hierarchical, circular, grid, custom
+- **Event handling**: Click, hover, drag interactions
+- **Styling**: CSS-like syntax for node/edge appearance
+- **Extensions**: Plugins for additional layouts and features
+- **Framework agnostic**: Works with React, Vue, vanilla JS
+
+**Python Integration (Dash Cytoscape)**:
+```python
+import dash
+import dash_cytoscape as cyto
+
+app = dash.Dash(__name__)
+
+elements = [
+    {'data': {'id': 'task-001', 'label': 'Implement feature'}},
+    {'data': {'id': 'subtask-001', 'label': 'Write tests'}},
+    {'data': {'source': 'task-001', 'target': 'subtask-001'}}
+]
+
+app.layout = cyto.Cytoscape(
+    id='cytoscape',
+    elements=elements,
+    layout={'name': 'breadthfirst'},
+    style={'width': '100%', 'height': '600px'}
+)
+```
+
+**Tradeoffs**:
+- **Pro**: Rich interactivity, web-native, extensive customization
+- **Con**: Requires JavaScript for web deployment
+- **Con**: Performance limits around 100k nodes (use Cosmos for larger)
+
+**Jerry Alignment**:
+- ✅ **Web presentation**: Ideal for Jerry web UI (Phase 3)
+- ✅ **Dash integration**: Python backend → Cytoscape.js frontend
+- ✅ **Interactive exploration**: Users can navigate knowledge graph visually
+
+**Citations**: [Cytoscape](https://cytoscape.org/), [Dash Cytoscape](https://github.com/pysemtec/semantic-python-overview), [Top 7 Graph Visualization Tools](https://www.marktechpost.com/2024/11/16/top-7-graph-database-visualization-tools/)
+
+---
+
+#### 4.4 NetworkX (Python Graph Algorithms)
+
+**What**: Pure Python library for graph creation, manipulation, and analysis
+**Who Maintains**: NetworkX Developers (BSD license)
+**Why Use**: Standard Python graph library, extensive algorithm collection
+**When**: Graph algorithms, analysis, integration with Python data science stack
+**Where**: Academia, data science, network analysis
+
+**Key Features**:
+- **Graph types**: Directed, undirected, multigraph, weighted
+- **Algorithms**: Shortest path, centrality, community detection, flow
+- **I/O**: GEXF, GraphML, JSON, Pickle, Pajek
+- **Visualization**: Integration with Matplotlib, PyVis
+- **Pure Python**: No compilation required
+
+**Python Example**:
+```python
+import networkx as nx
+import matplotlib.pyplot as plt
+
+# Build graph
+G = nx.DiGraph()
+G.add_edge("PLAN-001", "PHASE-001", relationship="CONTAINS")
+G.add_edge("PHASE-001", "TASK-001", relationship="CONTAINS")
+
+# Algorithms
+shortest_path = nx.shortest_path(G, "PLAN-001", "TASK-001")
+centrality = nx.betweenness_centrality(G)
+
+# Visualize
+nx.draw(G, with_labels=True)
+plt.show()
+```
+
+**Integration with Jerry**:
+- **Convert Jerry graph to NetworkX**: Export vertices/edges to nx.DiGraph
+- **Run algorithms**: Centrality (identify critical tasks), path analysis
+- **Export to visualization**: GEXF for Gephi, JSON for Cytoscape.js
+
+**Jerry Alignment**:
+- ✅ **Pure Python**: No external dependencies
+- ✅ **Algorithm library**: Useful for progress calculation, dependency analysis
+- ✅ **Integration**: Works with Matplotlib, kglab, Gephi
+
+**Citations**: [Graph Visualization Tools](https://memgraph.com/blog/you-want-a-fast-easy-to-use-and-popular-graph-visualization-tool)
+
+---
+
+### 5. Query Engines and Endpoints
+
+#### 5.1 SPARQL Endpoints (SPARQLWrapper)
+
+**What**: Python wrapper for remote SPARQL query execution
+**Who Maintains**: RDFLib team
+**Why Use**: Query remote knowledge graphs (DBpedia, Wikidata, custom endpoints)
+**When**: Federated queries, accessing public knowledge graphs
+**How**: HTTP client wrapper around SPARQL Protocol
+
+**Key Features**:
+- **Return formats**: JSON, XML, Turtle, CSV, TSV, JSON-LD
+- **Authentication**: HTTP Basic/Digest
+- **Update support**: SPARQL UPDATE queries (INSERT, DELETE)
+- **Pandas integration**: sparql-dataframe for DataFrame conversion
+
+**Python Example**:
+```python
+from SPARQLWrapper import SPARQLWrapper, JSON
+
+# Query DBpedia
+sparql = SPARQLWrapper("http://dbpedia.org/sparql")
+sparql.setReturnFormat(JSON)
+sparql.setQuery("""
+    SELECT ?label
+    WHERE { <http://dbpedia.org/resource/Python_(programming_language)>
+            rdfs:label ?label }
+    FILTER (lang(?label) = 'en')
+""")
+
+results = sparql.queryAndConvert()
+for result in results["results"]["bindings"]:
+    print(result["label"]["value"])
+```
+
+**Setting Up Local SPARQL Endpoint (Flask)**:
+```python
+from flask import Flask, request
+from rdflib import Graph
+
+app = Flask(__name__)
+g = Graph()
+g.parse("data.ttl")
+
+@app.route('/sparql', methods=['GET', 'POST'])
+def sparql_endpoint():
+    query = request.args.get('query') or request.form.get('query')
+    results = g.query(query)
+    return results.serialize(format='json')
+
+app.run(port=3030)
+```
+
+**Jerry Alignment**:
+- ✅ **Phase 3**: Expose Jerry knowledge graph as SPARQL endpoint
+- ✅ **Federated queries**: Link Jerry data to external KGs (DBpedia, Wikidata)
+- 🟡 **Requires Flask**: Adds web framework dependency
+
+**Citations**: [SPARQLWrapper Documentation](https://sparqlwrapper.readthedocs.io/), [SPARQLWrapper GitHub](https://github.com/RDFLib/sparqlwrapper)
+
+---
+
+#### 5.2 Gremlin Servers (TinkerPop)
+
+**What**: Graph traversal execution engine for Apache TinkerPop
+**Who Maintains**: Apache TinkerPop project
+**Why Use**: Remote execution of Gremlin queries, multi-language support
+**When**: Distributed graph traversals, JVM-based graph databases
+**Where**: JanusGraph, Amazon Neptune, Azure Cosmos DB
+
+**Key Features**:
+- **WebSocket/HTTP protocols**: Remote query execution
+- **gremlinpython**: Python driver for Gremlin Server
+- **GraphSON serialization**: JSON-based result format
+- **Multi-language support**: Python, JavaScript, Java, .NET, Go
+
+**Python Example (gremlinpython)**:
+```python
+from gremlin_python.driver import client, serializer
+
+# Connect to Gremlin Server
+gremlin_client = client.Client(
+    'ws://localhost:8182/gremlin',
+    'g',
+    message_serializer=serializer.GraphSONSerializersV3d0()
+)
+
+# Execute traversal
+results = gremlin_client.submit(
+    "g.V().has('Task', 'id', 'TASK-001').out('CONTAINS').values('title')"
+).all().result()
+
+for result in results:
+    print(result)
+```
+
+**GraphSON Formats** (covered in Section 6):
+- **GraphSON 1.0**: Basic JSON serialization
+- **GraphSON 2.0**: Type-aware with @typeId/@value
+- **GraphSON 3.0**: Explicit Map/List/Set support (default)
+- **GraphSON 4.0**: TinkerPop 4.0 format
+
+**Jerry Alignment**:
+- 🟡 **Phase 3+**: If migrating to JanusGraph or Neptune
+- ❌ **Requires server**: Adds infrastructure complexity
+- 🟡 **TinkerPop compatibility**: Good if targeting Gremlin ecosystem
+
+**Citations**: [TinkerPop](https://tinkerpop.apache.org/), [IO Reference](https://tinkerpop.apache.org/docs/3.4.1/dev/io/)
+
+---
+
+### 6. Serialization Formats
+
+#### 6.1 GraphSON (TinkerPop)
+
+**What**: JSON-based serialization format for property graphs
+**Who Maintains**: Apache TinkerPop
+**Why Use**: Portable property graph exchange, Gremlin Server communication
+**When**: Exporting to TinkerPop-compatible systems (Neptune, JanusGraph)
+
+**Format Evolution**:
+
+**GraphSON 1.0** (TinkerPop 3.0.0):
+- Basic JSON with optional type embedding
+- `@class` field for Java type information
+- Lossy without type embedding (float → double)
+
+**GraphSON 2.0** (TinkerPop 3.2.2):
+- `@typeId` and `@value` structure
+- Namespace:typename format (e.g., "g:Int64")
+- Less Jackson-dependent, more language-agnostic
+
+**GraphSON 3.0** (TinkerPop 3.3.0, default):
+- Explicit Map, List, Set types
+- Null, Timestamp, UUID support
+- Improved Gremlin collection semantics
+
+**GraphSON 4.0** (TinkerPop 4.0.0):
+- MIME type: `application/vnd.gremlin-v4.0+json`
+- Latest standard for TinkerPop 4.x
+
+**Example (GraphSON 3.0)**:
+```json
+{
+  "@type": "g:Vertex",
+  "@value": {
+    "id": {"@type": "g:UUID", "@value": "TASK-001"},
+    "label": "Task",
+    "properties": {
+      "title": [{"@type": "g:VertexProperty", "@value": {
+        "id": {"@type": "g:UUID", "@value": "prop-001"},
+        "value": "Implement feature",
+        "label": "title"
+      }}]
+    }
+  }
+}
+```
+
+**Tradeoffs**:
+- **Pro**: Standard format for TinkerPop ecosystem
+- **Con**: Verbose compared to RDF Turtle
+- **Con**: Not human-friendly for hand editing
+
+**Jerry Alignment**:
+- ✅ **Phase 3**: If targeting Neptune/JanusGraph
+- 🟡 **Export format**: Good for graph database migration
+- ❌ **Primary storage**: Too verbose for Jerry's file-based storage
+
+**Citations**: [GraphSON Reader/Writer](https://github.com/tinkerpop/blueprints/wiki/GraphSON-Reader-and-Writer-Library), [Oracle GraphSON Format](https://docs.oracle.com/en/database/oracle/property-graph/21.1/spgdg/graphson-data-format.html), [TinkerPop IO Reference](https://tinkerpop.apache.org/docs/3.4.1/dev/io/)
+
+---
+
+#### 6.2 RDF Serializations (Turtle, JSON-LD, etc.)
+
+**What**: Standard formats for RDF triple/quad serialization
+**Who Maintains**: W3C
+**Why Use**: Interoperability with semantic web tools, human-readable (Turtle)
+**When**: Working with RDF data, publishing linked data
+
+**Format Comparison**:
+
+| Format | Readability | Compactness | Use Case |
+|--------|-------------|-------------|----------|
+| **Turtle** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | Human editing, documentation |
+| **N-Triples** | ⭐⭐⭐ | ⭐⭐⭐ | Machine processing, streaming |
+| **RDF/XML** | ⭐⭐ | ⭐⭐ | Legacy systems, XML pipelines |
+| **JSON-LD** | ⭐⭐⭐⭐ | ⭐⭐⭐ | Web APIs, JavaScript integration |
+| **TriG** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | Named graphs (quads), datasets |
+
+**Turtle Example**:
+```turtle
+@prefix jer: <https://jerry.dev/jer/work-tracker/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+jer:task-001 a jer:Task ;
+    jer:title "Implement feature" ;
+    jer:status "pending" ;
+    jer:contains jer:subtask-001 .
+
+jer:subtask-001 a jer:Subtask ;
+    jer:title "Write tests" .
+```
+
+**JSON-LD Example**:
+```json
+{
+  "@context": {
+    "jer": "https://jerry.dev/jer/work-tracker/",
+    "title": "jer:title",
+    "status": "jer:status"
+  },
+  "@id": "jer:task-001",
+  "@type": "jer:Task",
+  "title": "Implement feature",
+  "status": "pending"
+}
+```
+
+**Jerry Alignment**:
+- ✅ **Turtle**: Excellent for human-readable storage (Phase 2)
+- ✅ **JSON-LD**: Good for web APIs (Phase 3)
+- 🟡 **TriG**: Useful if Jerry adopts named graphs
+
+**Citations**: [RDFLib](https://rdflib.dev/sparqlwrapper/)
+
+---
+
+### 7. Embedded vs Server-Based Tradeoffs
+
+| Criterion | Embedded (Oxigraph, SQLite) | Server-Based (Jena, Neo4j, Neptune) |
+|-----------|----------------------------|-------------------------------------|
+| **Deployment** | Single-process, no setup | Requires server infrastructure |
+| **Latency** | Minimal (direct API) | Network overhead (REST/WebSocket) |
+| **Scalability** | Limited to single machine | Horizontal scaling, clustering |
+| **Consistency** | ACID (single-writer) | Configurable (ACID or eventual) |
+| **Dependencies** | Embeddable library only | Server process + client driver |
+| **Use Cases** | Desktop apps, embedded systems, small-to-medium graphs | Web services, multi-user, trillion-scale graphs |
+| **Jerry Alignment** | ✅ Phase 1-2 (zero-dependency) | 🟡 Phase 3+ (cloud deployment) |
+
+**Key Insights**:
+
+1. **Embedded for Jerry Core**: Oxigraph (embedded) aligns with Jerry's zero-dependency philosophy and supports Phase 1-2 development without infrastructure.
+
+2. **Server for Scale**: If Jerry needs to support multi-user environments or trillion-scale graphs, server-based solutions (Fuseki, Neptune) become necessary.
+
+3. **Hybrid Strategy**: Start embedded (pyoxigraph), expose SPARQL endpoint (Flask), migrate to Fuseki if scale demands.
+
+4. **Performance vs Simplicity**:
+   - Embedded: Lower latency (direct API), simpler deployment
+   - Server: Better for distributed workloads, but adds complexity
+
+**Citations**: [Property Graph vs RDF Triple Store](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144578), [Graph Database vs Triple Store](https://community.openlinksw.com/t/what-are-the-differences-between-a-graph-database-and-a-triple-store/88)
+
+---
+
+## L2: Strategic Implications for Jerry Framework
+
+### 1. Recommended Technology Stack
+
+#### Phase 1: Foundation (Current)
+- **Data Model**: Property graph abstractions (Vertex, Edge, VertexProperty)
+- **Storage**: File-based JSON (existing TOON format)
+- **Query**: Repository pattern with Python traversal
+- **Visualization**: NetworkX + Matplotlib (development only)
+
+**Status**: ✅ Complete (per GRAPH_DATA_MODEL_ANALYSIS.md)
+
+---
+
+#### Phase 2: Semantic Layer (Recommended Next)
+- **Triple Store**: pyoxigraph (embedded RDF storage)
+- **Abstraction**: kglab (unified API across RDF + NetworkX)
+- **Serialization**: Turtle (human-readable), JSON-LD (web-ready)
+- **Query**: SPARQL via pyoxigraph + RDFLib
+- **Visualization**: Export to Gephi (GEXF) for analysis
+
+**Why**:
+- **Zero Java**: pyoxigraph is Rust-based, no JVM dependency
+- **Embeddable**: No server infrastructure required
+- **Standards-aligned**: RDF 1.2, SPARQL 1.2, RDF* (meta-properties)
+- **Performance**: RocksDB backend for disk-based storage
+
+**Migration Path**:
+```python
+# Jerry domain model → RDF (via adapter)
+from pyoxigraph import Store
+from jerry.domain.entities import Task
+
+store = Store("jerry-data.db")
+
+# Convert Task to RDF triples
+task = Task.load("TASK-001")
+store.add((
+    URIRef("jer:task-001"),
+    URIRef("jer:title"),
+    Literal(task.title)
+))
+
+# SPARQL query
+results = store.query("""
+    SELECT ?task ?title
+    WHERE { ?task jer:title ?title }
+""")
+```
+
+---
+
+#### Phase 3: Web Presentation
+- **SPARQL Endpoint**: Flask + pyoxigraph (expose HTTP API)
+- **Visualization**: Cytoscape.js (interactive web graphs)
+- **API**: REST API serving GraphSON or JSON-LD
+- **Optional**: Gremlin compatibility layer (if targeting Neptune migration)
+
+**Why**:
+- **Web-native**: Flask is lightweight, Python-standard
+- **Interactive**: Cytoscape.js provides rich user exploration
+- **Federated queries**: Link Jerry data to DBpedia, Wikidata via SPARQL
+
+**Architecture**:
+```
+┌─────────────────────────────────────────────┐
+│          Web UI (Cytoscape.js)              │
+│  - Interactive graph visualization          │
+│  - Node/edge filtering, layout              │
+└────────────────┬────────────────────────────┘
+                 │ HTTP/JSON-LD
+┌────────────────▼────────────────────────────┐
+│          Flask REST API                      │
+│  - /sparql (SPARQL endpoint)                │
+│  - /graph (GraphSON export)                 │
+│  - /rdf (Turtle/JSON-LD export)             │
+└────────────────┬────────────────────────────┘
+                 │ Python API
+┌────────────────▼────────────────────────────┐
+│       pyoxigraph (Embedded Store)           │
+│  - RDF triples persistence                  │
+│  - SPARQL query execution                   │
+└────────────────┬────────────────────────────┘
+                 │ Adapter
+┌────────────────▼────────────────────────────┐
+│      Jerry Domain Model (Vertices/Edges)    │
+│  - Property graph abstractions              │
+│  - DDD aggregates, event sourcing           │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+#### Phase 4: Scale (Optional)
+- **Cloud Migration**: Amazon Neptune (if AWS-hosted) or self-hosted Jena Fuseki
+- **Graph DB**: Neo4j (if Cypher preferred) or JanusGraph (if Cassandra available)
+- **Visualization**: Gephi, Cosmos (for 100k+ nodes)
+
+**Decision Criteria**:
+- **Stay embedded** if: Single-user, desktop application, < 10M triples
+- **Migrate to server** if: Multi-user, cloud deployment, > 10M triples, need clustering
+
+---
+
+### 2. Alignment with Jerry Principles
+
+#### Hexagonal Architecture
+- **Domain Layer**: Vertex/Edge primitives (no external dependencies) ✅
+- **Ports**: IGraphRepository, IRDFStore (abstract interfaces) ✅
+- **Adapters**:
+  - File adapter (JSON/TOON) ✅
+  - pyoxigraph adapter (RDF) ⭐ Recommended
+  - Fuseki adapter (future, if needed)
+
+#### Zero-Dependency Core
+- **Domain**: Pure Python, stdlib only ✅
+- **Infrastructure**: pyoxigraph (Rust + Python bindings, pre-compiled wheels)
+  - **Tradeoff**: Not stdlib, but pre-installed wheels ≈ zero setup
+  - **Alternative**: RDFLib (pure Python, but slower)
+
+#### CQRS Pattern
+- **Commands**: Write triples to pyoxigraph (persist domain events)
+- **Queries**: SPARQL SELECT for read models
+- **Event Sourcing**: CloudEvents as RDF triples (EMITTED edges)
+
+---
+
+### 3. Tradeoff Analysis: Embedded RDF vs Server-Based
+
+| Aspect | Embedded (pyoxigraph + RDFLib) | Server (Jena Fuseki, Neo4j) |
+|--------|-------------------------------|------------------------------|
+| **Setup** | `pip install pyoxigraph` | Docker/systemd service, config |
+| **Performance** | Fast for < 10M triples | Optimized for billions of triples |
+| **SPARQL** | Local execution | HTTP endpoint (federated queries) |
+| **Dependencies** | Python package only | Server process + monitoring |
+| **Scalability** | Single machine | Distributed, clustered |
+| **Jerry Fit** | ✅ Phase 1-3 | 🟡 Phase 4+ (if cloud) |
+
+**Recommendation**: Start with pyoxigraph (embedded) for Phase 2, defer server-based decision until user demand validates need for scale.
+
+---
+
+### 4. Netflix UDA Pattern Application
+
+From GRAPH_DATA_MODEL_ANALYSIS.md Section 11 (DISC-064):
+
+> "Model Once, Represent Everywhere" - Single domain model → multiple projections (GraphQL, Avro, SQL, RDF)
+
+**Jerry Implementation**:
+1. **Canonical Model**: Domain entities (Task, Phase, Plan) as Vertex/Edge
+2. **Representations**:
+   - JSON/TOON (file storage)
+   - RDF Turtle (semantic web export)
+   - JSON-LD (web API)
+   - GraphSON (TinkerPop export)
+   - Cytoscape.js JSON (visualization)
+
+**Adapter Pattern**:
+```python
+# src/infrastructure/persistence/rdf_adapter.py
+
+from pyoxigraph import Store, NamedNode, Literal
+from jerry.domain.entities import Task
+
+class RDFAdapter:
+    def __init__(self, store: Store):
+        self.store = store
+
+    def save_task(self, task: Task):
+        """Convert Task domain entity to RDF triples."""
+        task_uri = NamedNode(f"jer:task:{task.id.value}")
+
+        self.store.add((
+            task_uri,
+            NamedNode("rdf:type"),
+            NamedNode("jer:Task")
+        ))
+
+        self.store.add((
+            task_uri,
+            NamedNode("jer:title"),
+            Literal(task.title)
+        ))
+
+        self.store.add((
+            task_uri,
+            NamedNode("jer:status"),
+            Literal(task.status.value)
+        ))
+
+    def load_task(self, task_id: str) -> Task:
+        """Query RDF store and reconstruct Task domain entity."""
+        results = self.store.query(f"""
+            SELECT ?title ?status
+            WHERE {{
+                jer:task:{task_id} jer:title ?title ;
+                                   jer:status ?status .
+            }}
+        """)
+        # Reconstruct Task from SPARQL results
+        return Task(id=task_id, title=..., status=...)
+```
+
+---
+
+### 5. Semantic Web Alignment (RDF/OWL)
+
+From GRAPH_DATA_MODEL_ANALYSIS.md Section 11 (AN.Q.2):
+
+| Property Graph | RDF/OWL | Jerry Strategy |
+|----------------|---------|----------------|
+| Edge properties | Requires RDF* or reification | Use RDF* (pyoxigraph supports it) |
+| Schema | Implicit | Define OWL ontology (Phase 3) |
+| URIs | Jerry URI scheme (SPEC-001) | Already RDF-compatible ✅ |
+| Inference | None | Layer on via owlready2 (Phase 4) |
+
+**Example RDF* for Edge Properties**:
+```turtle
+# Standard RDF (no edge properties)
+jer:task-001 jer:contains jer:subtask-001 .
+
+# RDF* (edge with properties)
+<<jer:task-001 jer:contains jer:subtask-001>> jer:sequence 1 .
+```
+
+pyoxigraph supports RDF*, so Jerry can model edge properties without reification complexity.
+
+---
+
+### 6. Key Discoveries Informing Jerry Design
+
+| Discovery | Source | Jerry Application |
+|-----------|--------|-------------------|
+| **Oxigraph as embedded RDF store** | pyoxigraph 2025 | Use for Phase 2 semantic layer |
+| **kglab abstraction layer** | DerwenAI | Bridge RDF + NetworkX + Pandas |
+| **RDF* for edge properties** | W3C, pyoxigraph | Model CONTAINS(sequence=1) without reification |
+| **Gephi for exploration** | 10k+ citations | Export to GEXF for graph analysis |
+| **Cytoscape.js for web** | Dash Cytoscape | Interactive web presentation (Phase 3) |
+| **SPARQLWrapper for endpoints** | RDFLib team | Expose Jerry as SPARQL service |
+| **Netflix UDA pattern** | GRAPH_DATA_MODEL_ANALYSIS | Validates "Model Once, Represent Everywhere" |
+
+---
+
+### 7. Recommended Roadmap
+
+**Q1 2026 (Phase 2 Foundation)**:
+1. Install pyoxigraph (`pip install pyoxigraph`)
+2. Create RDFAdapter in `src/infrastructure/persistence/rdf_adapter.py`
+3. Define Jerry ontology in Turtle (`docs/ontology/jerry-work-tracker.ttl`)
+4. Implement domain entity → RDF triple conversion
+5. Test SPARQL queries against embedded store
+
+**Q2 2026 (Phase 2 Completion)**:
+1. Integrate kglab for abstraction layer
+2. Add NetworkX export for graph algorithms
+3. Export to Gephi (GEXF) for visualization testing
+4. Document RDF export format in `docs/specifications/`
+
+**Q3 2026 (Phase 3 Web)**:
+1. Create Flask SPARQL endpoint (`/sparql`)
+2. Add JSON-LD API (`/rdf`, `/graph`)
+3. Build Cytoscape.js web UI prototype
+4. Test federated queries to DBpedia
+
+**Q4 2026 (Phase 3 Refinement)**:
+1. Performance testing (how many triples before slow?)
+2. Decide: Stay embedded or migrate to Fuseki?
+3. If scale needed, evaluate Neptune (cloud) vs Fuseki (self-hosted)
+4. Production deployment of web UI
+
+---
+
+## Tool Comparison Matrix
+
+### Triple Stores
+
+| Tool | License | Python Support | Embedding | SPARQL | RDF* | Performance | Jerry Fit |
+|------|---------|----------------|-----------|--------|------|-------------|-----------|
+| **Oxigraph** | MIT/Apache-2.0 | ✅ pyoxigraph | ✅ Native | ✅ 1.2 | ✅ | Fast (RocksDB) | ⭐⭐⭐⭐⭐ |
+| **RDFLib** | BSD-3 | ✅ Native | ✅ Native | ✅ 1.1 | ❌ | Slower | ⭐⭐⭐⭐ |
+| **Jena/Fuseki** | Apache-2.0 | 🟡 HTTP/SPARQL | ❌ Server | ✅ 1.1 | 🟡 | Very Fast | ⭐⭐⭐ |
+| **Virtuoso** | GPL/Commercial | 🟡 HTTP/SPARQL | ❌ Server | ✅ 1.1 | ❌ | Fastest | ⭐⭐ |
+| **Blazegraph** | GPL v2 | 🟡 HTTP/SPARQL | 🟡 Java JAR | ✅ 1.1 | ❌ | Fast | ⭐⭐ |
+
+**Legend**: ✅ Full support | 🟡 Partial/workaround | ❌ Not supported
+
+---
+
+### Graph Databases (Property Graphs)
+
+| Tool | License | Python Support | Embedding | Query Language | ACID | Cloud | Jerry Fit |
+|------|---------|----------------|-----------|----------------|------|-------|-----------|
+| **Neo4j** | GPL/Commercial | ✅ neo4j-driver | 🟡 Java JAR | Cypher | ✅ | Aura | ⭐⭐⭐ |
+| **Neptune** | Proprietary | ✅ gremlinpython | ❌ AWS only | Gremlin/SPARQL | 🟡 Eventual | ✅ | ⭐⭐ |
+| **JanusGraph** | Apache-2.0 | ✅ gremlinpython | ❌ Server | Gremlin | 🟡 Backend | 🟡 | ⭐⭐ |
+| **ArangoDB** | Apache-2.0 | ✅ python-arango | 🟡 Single mode | AQL | ✅ | 🟡 | ⭐⭐ |
+
+---
+
+### Python Libraries
+
+| Library | Purpose | License | Dependencies | Jerry Phase |
+|---------|---------|---------|--------------|-------------|
+| **pyoxigraph** | Embedded RDF store | MIT/Apache-2.0 | Rust (pre-compiled) | ⭐ Phase 2 |
+| **RDFLib** | RDF parsing/querying | BSD-3 | Pure Python | ⭐ Phase 2 |
+| **kglab** | KG abstraction layer | MIT | RDFLib, NetworkX | ⭐ Phase 2 |
+| **owlready2** | OWL ontology work | LGPL v3 | Java (reasoning) | 🟡 Phase 3+ |
+| **SPARQLWrapper** | SPARQL endpoints | W3C | Pure Python | ⭐ Phase 3 |
+| **NetworkX** | Graph algorithms | BSD-3 | Pure Python | ⭐ Phase 1-3 |
+| **PyKEEN** | KG embeddings | MIT | PyTorch | 🟡 Phase 4+ |
+
+---
+
+### Visualization Tools
+
+| Tool | Type | Python API | Web Interactive | Best For | Jerry Phase |
+|------|------|------------|-----------------|----------|-------------|
+| **Gephi** | Desktop | Export only (GEXF) | ❌ | Analysis, publication | 🟡 Dev only |
+| **Graphviz** | CLI/Library | ✅ graphviz | ❌ | Static diagrams, docs | ⭐ Phase 1-3 |
+| **Cytoscape.js** | JavaScript | ✅ Dash Cytoscape | ✅ | Web applications | ⭐ Phase 3 |
+| **NetworkX** | Python | ✅ Native | 🟡 Matplotlib | Python integration | ⭐ Phase 1-2 |
+| **PyVis** | Python | ✅ Native | ✅ | Quick web graphs | 🟡 Prototyping |
+
+---
+
+## Sources
+
+### Triple Stores
+- [Apache Jena](https://jena.apache.org/)
+- [Accelerated Parallel RDF Loading with Jena](https://medium.com/@deepakpatwal/accelerated-parallel-rdf-loading-import-millions-of-triples-from-multiple-datasets-using-the-c49a3a6eba37)
+- [Comparing Linked Data Triplestores](https://medium.com/wallscope/comparing-linked-data-triplestores-ebfac8c3ad4f)
+- [Wikimedia Virtuoso Evaluation](https://phabricator.wikimedia.org/T206561)
+- [Blazegraph vs Virtuoso Comparison](https://db-engines.com/en/system/Blazegraph%3BVirtuoso)
+- [Oxigraph GitHub](https://github.com/oxigraph/oxigraph)
+- [pyoxigraph PyPI](https://pypi.org/project/pyoxigraph/)
+- [pyoxigraph Documentation](https://pyoxigraph.readthedocs.io/)
+- [oxrdflib GitHub](https://github.com/oxigraph/oxrdflib)
+
+### Graph Databases
+- [Neo4j vs Amazon Neptune](https://www.analyticsvidhya.com/blog/2024/08/neo4j-vs-amazon-neptune/)
+- [Best Graph Databases 2025](https://www.getgalaxy.io/learn/data-tools/best-graph-databases-2025)
+- [Amazon Neptune vs JanusGraph vs Neo4j](https://db-engines.com/en/system/Amazon+Neptune%3BJanusGraph%3BNeo4j)
+- [Neptune vs Neo4j Comparison](https://www.brilworks.com/blog/neptune-vs-neo4j/)
+- [Top JanusGraph Alternatives](https://www.puppygraph.com/blog/janusgraph-alternatives)
+- [ArangoDB GitHub](https://github.com/arangodb/arangodb)
+- [First Steps with ArangoDB and Python](https://cylab.be/blog/299/first-steps-with-a-graph-database-using-python-and-arangodb)
+
+### Python Libraries
+- [kglab GitHub](https://github.com/DerwenAI/kglab)
+- [RDFLib Documentation](https://rdflib.dev/sparqlwrapper/)
+- [owlready2 PyPI](https://pypi.org/project/owlready2/)
+- [owlready2 Documentation](https://www.lesfleursdunormal.fr/static/informatique/owlready/index_en.html)
+- [Semantic Python Overview](https://github.com/pysemtec/semantic-python-overview)
+- [Semantic Web Standards and Python](https://www.lassila.org/publications/2025/lassila-omg-challenge-2025.pdf)
+
+### Visualization
+- [Gephi](https://gephi.org/)
+- [Graph Visualization Tools Comparison](https://memgraph.com/blog/you-want-a-fast-easy-to-use-and-popular-graph-visualization-tool)
+- [Graphviz](https://graphviz.org/)
+- [Cytoscape](https://cytoscape.org/)
+- [Top 7 Graph Visualization Tools](https://www.marktechpost.com/2024/11/16/top-7-graph-database-visualization-tools/)
+
+### Query Engines & Serialization
+- [SPARQLWrapper Documentation](https://sparqlwrapper.readthedocs.io/)
+- [SPARQLWrapper GitHub](https://github.com/RDFLib/sparqlwrapper)
+- [TinkerPop](https://tinkerpop.apache.org/)
+- [GraphSON Reader/Writer](https://github.com/tinkerpop/blueprints/wiki/GraphSON-Reader-and-Writer-Library)
+- [Oracle GraphSON Format](https://docs.oracle.com/en/database/oracle/property-graph/21.1/spgdg/graphson-data-format.html)
+- [TinkerPop IO Reference](https://tinkerpop.apache.org/docs/3.4.1/dev/io/)
+
+### General
+- [Property Graph vs RDF Triple Store](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144578)
+- [Graph Database vs Triple Store](https://community.openlinksw.com/t/what-are-the-differences-between-a-graph-database-and-a-triple-store/88)
+- [Knowledge Graph Ecosystem Survey](https://www.kyvosinsights.com/blog/survey-of-the-knowledge-graph-ecosystem/)
+- [Semantic Web and AI](https://www.dataversity.net/articles/semantic-web-and-ai-empowering-knowledge-graphs-for-smarter-applications/)
+
+---
+
+## 5W1H Framework Summary
+
+### What
+Technologies surveyed: 4 triple stores (Oxigraph ⭐, Jena, Virtuoso, Blazegraph), 4 graph databases (Neo4j, Neptune, JanusGraph, ArangoDB), 7 Python libraries, 5 visualization tools, 2 query engine types, multiple serialization formats.
+
+### Why
+To enable Jerry to:
+1. Store knowledge graphs efficiently (embedded or server-based)
+2. Query semantic data (SPARQL, Gremlin)
+3. Visualize relationships interactively (web + desktop)
+4. Export to standard formats (RDF, GraphSON)
+5. Integrate with semantic web (RDF/OWL alignment)
+
+### Who
+- **Maintainers**: Open-source communities (Apache, W3C), commercial vendors (Neo4j, AWS), research groups
+- **Jerry Users**: Future use cases include agents querying knowledge graph, web UI exploration, federated queries to external KGs
+
+### When
+- **Phase 1** (Complete): Property graph abstractions, file storage
+- **Phase 2** (Recommended): Embedded RDF (pyoxigraph), SPARQL queries
+- **Phase 3** (Web): SPARQL endpoint, Cytoscape.js visualization
+- **Phase 4** (Scale): Server-based migration if needed (Fuseki, Neptune)
+
+### Where
+- **Embedded**: pyoxigraph (in-process, RocksDB files)
+- **Server**: Jena Fuseki (self-hosted), Neptune (AWS cloud)
+- **Visualization**: Gephi (desktop), Cytoscape.js (web browser)
+
+### How
+1. **Install**: `pip install pyoxigraph rdflib kglab`
+2. **Adapt**: Create RDFAdapter to convert Jerry entities → RDF triples
+3. **Query**: Use SPARQL for semantic queries
+4. **Visualize**: Export to GEXF (Gephi) or Cytoscape.js JSON
+5. **Expose**: Flask endpoint for SPARQL HTTP API
+
+---
+
+## Validation Checklist
+
+| Category | Status |
+|----------|--------|
+| **5W1H Coverage** | ✅ All questions addressed |
+| **L0/L1/L2 Levels** | ✅ Complete |
+| **Tool Comparison Matrix** | ✅ 4 matrices provided |
+| **Citations with URLs** | ✅ 30+ sources cited |
+| **Jerry-Specific Recommendations** | ✅ Phase 1-4 roadmap |
+| **Extends Existing Research** | ✅ References GRAPH_DATA_MODEL_ANALYSIS.md |
+| **P-001 (Truth & Accuracy)** | ✅ All claims cited |
+| **P-002 (File Persistence)** | ✅ Document persisted at docs/research/ |
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-08*
+*Author: Claude (ps-researcher v2.0.0)*
+*Extends: docs/research/GRAPH_DATA_MODEL_ANALYSIS.md*
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial research document covering triple stores, graph databases, Python libraries, visualization tools, query engines, serialization formats, and embedded vs server-based tradeoffs |

--- a/docs/archive/projects-archive/research/work-031-e-004-semantic-data.md
+++ b/docs/archive/projects-archive/research/work-031-e-004-semantic-data.md
@@ -1,0 +1,1353 @@
+# Enabling Semantics in Data: JSON-LD, Linked Data, and Semantic Annotations
+
+> **Research Date:** 2026-01-08
+> **PS ID:** work-031
+> **Entry ID:** e-004
+> **Status:** DECISION-GRADE
+> **Purpose:** Research semantic data techniques for Jerry framework integration
+> **Extends:** `GRAPH_DATA_MODEL_ANALYSIS.md` (Jerry URI scheme, CloudEvents)
+
+---
+
+## L0: Executive Summary (Plain Language Findings)
+
+This research investigates how to add **semantic meaning** to data so that machines can understand relationships, context, and intent—not just syntax. Think of it as the difference between a computer reading "2026-01-08" as a string versus understanding it as a date that comes after January 7th and before January 9th.
+
+### What We Found
+
+**JSON-LD (JSON for Linking Data)** is the clear winner for adding semantics to JSON data:
+- **70% of websites** with structured data now use JSON-LD (2024 data)
+- **W3C standard** with active community support
+- **Works with existing JSON** by adding a `@context` section
+- **Schema.org integration** provides 800+ ready-to-use vocabulary terms
+- **Google recommends it** for SEO and knowledge graph integration
+
+### Key Recommendations for Jerry
+
+1. **Adopt JSON-LD** as the semantic layer for Jerry entities (Task, Phase, Plan)
+2. **Reuse Jerry URI scheme** (SPEC-001) which is already RDF-compatible
+3. **Extend CloudEvents** with JSON-LD contexts for semantic event streams
+4. **Reference Schema.org** where possible, create Jerry-specific terms for domain concepts
+5. **Enable content negotiation** so Jerry URIs can return JSON-LD or plain JSON
+
+### Tim Berners-Lee's 5-Star Linked Data Model
+
+Jerry's current state and target:
+
+| Stars | Level | Jerry Status |
+|-------|-------|--------------|
+| ★ | Open license data on web | ✅ **CURRENT** (MIT license, file-based) |
+| ★★ | Structured data | ✅ **CURRENT** (JSON, YAML) |
+| ★★★ | Non-proprietary format | ✅ **CURRENT** (JSON, not Excel) |
+| ★★★★ | URIs to denote things | ✅ **CURRENT** (Jerry URI scheme SPEC-001) |
+| ★★★★★ | Link data to other data | 🎯 **TARGET** (JSON-LD integration) |
+
+---
+
+## L1: Technical Details (JSON-LD Patterns & Examples)
+
+### 1. JSON-LD Core Concepts
+
+#### 1.1 The `@context` - Vocabulary Mapping
+
+The `@context` establishes a mapping from short keys to full URIs:
+
+```json
+{
+  "@context": {
+    "name": "http://schema.org/name",
+    "homepage": {
+      "@id": "http://schema.org/url",
+      "@type": "@id"
+    },
+    "created": {
+      "@id": "http://purl.org/dc/terms/created",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    }
+  },
+  "name": "Manu Sporny",
+  "homepage": "https://manu.sporny.org/",
+  "created": "2026-01-08T10:30:00Z"
+}
+```
+
+**W3C Best Practice:** Cache remote contexts with HTTP cache-control headers to avoid processing delays.
+
+#### 1.2 The `@type` - Entity Classification
+
+The `@type` keyword specifies what kind of thing the JSON object represents:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Ada Lovelace",
+  "jobTitle": "Mathematician"
+}
+```
+
+**Multiple types are supported:**
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": ["Person", "Author"],
+  "name": "Isaac Asimov"
+}
+```
+
+#### 1.3 The `@id` - Unique Identifiers (URIs)
+
+The `@id` keyword assigns a globally unique identifier to an entity:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://jerry.dev/org/acme",
+  "name": "Acme Corporation"
+}
+```
+
+**Jerry Integration:**
+
+```json
+{
+  "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+  "@type": "Task",
+  "@id": "jer:jer:work-tracker:task:TASK-042+abc123",
+  "title": "Implement JSON-LD support",
+  "status": "IN_PROGRESS"
+}
+```
+
+### 2. JSON-LD Patterns for Jerry Entities
+
+#### 2.1 Task Entity with JSON-LD
+
+```json
+{
+  "@context": {
+    "@vocab": "https://jerry.dev/vocab/",
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "task": "https://jerry.dev/vocab/Task",
+    "title": "schema:name",
+    "description": "schema:description",
+    "status": {
+      "@id": "https://jerry.dev/vocab/status",
+      "@type": "@vocab"
+    },
+    "created": {
+      "@id": "schema:dateCreated",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "schema:dateModified",
+      "@type": "xsd:dateTime"
+    },
+    "belongsToPhase": {
+      "@id": "https://jerry.dev/vocab/belongsToPhase",
+      "@type": "@id"
+    },
+    "subtasks": {
+      "@id": "https://jerry.dev/vocab/subtasks",
+      "@container": "@list"
+    }
+  },
+  "@id": "jer:jer:work-tracker:task:TASK-042+abc123",
+  "@type": "task",
+  "title": "Implement JSON-LD support",
+  "description": "Add semantic annotations to Jerry entities",
+  "status": "IN_PROGRESS",
+  "created": "2026-01-08T10:00:00Z",
+  "modified": "2026-01-08T14:30:00Z",
+  "belongsToPhase": "jer:jer:work-tracker:phase:PHASE-003+def456",
+  "subtasks": [
+    {
+      "@type": "Subtask",
+      "title": "Research JSON-LD patterns",
+      "checked": true
+    },
+    {
+      "@type": "Subtask",
+      "title": "Create Jerry context file",
+      "checked": false
+    }
+  ]
+}
+```
+
+#### 2.2 CloudEvents with JSON-LD Semantics
+
+**Standard CloudEvents (current):**
+
+```json
+{
+  "specversion": "1.0",
+  "type": "jer:jer:work-tracker:facts/TaskCompleted",
+  "source": "jer:jer:work-tracker:task:TASK-042",
+  "id": "EVT-a1b2c3d4",
+  "time": "2026-01-08T15:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "task_id": "TASK-042",
+    "completed_by": "claude"
+  }
+}
+```
+
+**CloudEvents with JSON-LD (enhanced):**
+
+```json
+{
+  "@context": [
+    "https://cloudevents.io/context.jsonld",
+    "https://jerry.dev/contexts/worktracker.jsonld"
+  ],
+  "@type": "CloudEvent",
+  "specversion": "1.0",
+  "type": {
+    "@id": "jer:jer:work-tracker:facts/TaskCompleted",
+    "@type": "EventType"
+  },
+  "source": {
+    "@id": "jer:jer:work-tracker:task:TASK-042",
+    "@type": "Task"
+  },
+  "id": "EVT-a1b2c3d4",
+  "time": {
+    "@value": "2026-01-08T15:00:00Z",
+    "@type": "xsd:dateTime"
+  },
+  "datacontenttype": "application/ld+json",
+  "data": {
+    "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+    "@type": "TaskCompletedEvent",
+    "task": {
+      "@id": "jer:jer:work-tracker:task:TASK-042"
+    },
+    "completedBy": {
+      "@id": "jer:jer:work-tracker:actor:claude",
+      "@type": "Actor"
+    }
+  }
+}
+```
+
+**Key Enhancement:** The `data` field now contains semantically rich linked data with explicit types and relationships.
+
+#### 2.3 Phase Aggregate with Contained Tasks
+
+```json
+{
+  "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+  "@id": "jer:jer:work-tracker:phase:PHASE-003+def456",
+  "@type": "Phase",
+  "displayNumber": 1,
+  "title": "Research & Design",
+  "status": "IN_PROGRESS",
+  "targetDate": "2026-02-01",
+  "contains": [
+    {
+      "@id": "jer:jer:work-tracker:task:TASK-042+abc123",
+      "@type": "Task"
+    },
+    {
+      "@id": "jer:jer:work-tracker:task:TASK-043+xyz789",
+      "@type": "Task"
+    }
+  ]
+}
+```
+
+### 3. Schema.org Vocabulary Integration
+
+#### 3.1 Mapping Jerry Concepts to Schema.org
+
+| Jerry Concept | Schema.org Type | Rationale |
+|---------------|-----------------|-----------|
+| **Task** | `schema:Action` or custom | Action represents something to be done |
+| **Phase** | `schema:Project` | Project is a collection of tasks |
+| **Plan** | `schema:PlanAction` | High-level plan encompassing phases |
+| **Actor (Human)** | `schema:Person` | Direct mapping |
+| **Actor (Claude)** | `schema:SoftwareApplication` | AI agent as software |
+| **Evidence** | `schema:CreativeWork` | Documents, artifacts |
+| **Event** | `schema:Event` | Domain events |
+
+#### 3.2 Example: Task as Schema.org Action
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Action",
+  "@id": "jer:jer:work-tracker:task:TASK-042",
+  "name": "Implement JSON-LD support",
+  "description": "Add semantic annotations to Jerry entities",
+  "actionStatus": "ActiveActionStatus",
+  "startTime": "2026-01-08T10:00:00Z",
+  "agent": {
+    "@type": "SoftwareApplication",
+    "@id": "jer:jer:work-tracker:actor:claude",
+    "name": "Claude",
+    "applicationCategory": "AI Assistant"
+  },
+  "object": {
+    "@type": "SoftwareSourceCode",
+    "name": "Jerry Framework"
+  }
+}
+```
+
+### 4. Content Negotiation for Jerry URIs
+
+**Concept:** A single Jerry URI can return different representations based on the HTTP `Accept` header.
+
+#### 4.1 Request/Response Examples
+
+**Request JSON:**
+```http
+GET /jer/work-tracker/task/TASK-042 HTTP/1.1
+Host: jerry.dev
+Accept: application/json
+```
+
+**Response:**
+```json
+{
+  "id": "TASK-042",
+  "title": "Implement JSON-LD support",
+  "status": "IN_PROGRESS"
+}
+```
+
+**Request JSON-LD:**
+```http
+GET /jer/work-tracker/task/TASK-042 HTTP/1.1
+Host: jerry.dev
+Accept: application/ld+json
+```
+
+**Response:**
+```json
+{
+  "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+  "@id": "jer:jer:work-tracker:task:TASK-042+abc123",
+  "@type": "Task",
+  "title": "Implement JSON-LD support",
+  "status": "IN_PROGRESS",
+  "created": "2026-01-08T10:00:00Z"
+}
+```
+
+**Request HTML (human-readable):**
+```http
+GET /jer/work-tracker/task/TASK-042 HTTP/1.1
+Host: jerry.dev
+Accept: text/html
+```
+
+**Response:**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Task TASK-042 - Jerry Framework</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+    "@id": "jer:jer:work-tracker:task:TASK-042",
+    "@type": "Task",
+    "title": "Implement JSON-LD support"
+  }
+  </script>
+</head>
+<body>
+  <h1>Implement JSON-LD support</h1>
+  <dl>
+    <dt>Status:</dt><dd>IN_PROGRESS</dd>
+    <dt>Created:</dt><dd>2026-01-08 10:00:00 UTC</dd>
+  </dl>
+</body>
+</html>
+```
+
+### 5. RDFa and Microdata (Alternative Approaches)
+
+#### 5.1 Adoption Trends (2024)
+
+| Format | Adoption | Use Case | Jerry Applicability |
+|--------|----------|----------|---------------------|
+| **JSON-LD** | 70% | APIs, data files, SEO | ⭐⭐⭐⭐⭐ **PRIMARY** |
+| **Microdata** | 46% | HTML annotations | ⭐⭐⭐ Optional for web UI |
+| **RDFa** | 3% | Complex semantic HTML | ⭐ Low priority |
+| **Microformats** | 23% | Simple HTML (hCard) | ⭐ Legacy support |
+
+**Source:** Web Data Commons 2024 dataset (1.3 billion HTML pages analyzed)
+
+#### 5.2 JSON-LD vs RDFa Example
+
+**JSON-LD (recommended for Jerry):**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Ada Lovelace",
+  "jobTitle": "Mathematician"
+}
+```
+
+**RDFa (HTML embedding):**
+```html
+<div vocab="https://schema.org/" typeof="Person">
+  <span property="name">Ada Lovelace</span>
+  <span property="jobTitle">Mathematician</span>
+</div>
+```
+
+**Verdict:** JSON-LD wins for Jerry because:
+- ✅ Separates data from presentation
+- ✅ Works with file-based storage (no HTML required)
+- ✅ API-friendly
+- ✅ Easier maintenance
+
+### 6. Linked Data Principles (Berners-Lee 2006)
+
+#### 6.1 Four Principles
+
+1. **Use URIs to name things**
+   - Jerry: ✅ SPEC-001 Jerry URI scheme (`jer:jer:work-tracker:task:TASK-042`)
+
+2. **Use HTTP URIs for dereferencing**
+   - Jerry: 🎯 **Future** - Convert `jer:` to `https://jerry.dev/` via resolver
+
+3. **Provide useful information via RDF/SPARQL**
+   - Jerry: 🎯 **This research** - JSON-LD provides RDF serialization
+
+4. **Link to other things via their URIs**
+   - Jerry: 🎯 **Target** - Cross-reference Schema.org, external ontologies
+
+#### 6.2 5-Star Deployment Scheme
+
+| Level | Requirement | Jerry Example |
+|-------|-------------|---------------|
+| ★ | Open data on web under open license | MIT license, file-based storage |
+| ★★ | Structured data | JSON/YAML files |
+| ★★★ | Non-proprietary format | JSON (not Excel) |
+| ★★★★ | Use URIs to denote things | Jerry URI scheme |
+| ★★★★★ | Link your data to other data | **JSON-LD with Schema.org** 🎯 |
+
+**Jerry's Path to 5 Stars:**
+
+```json
+{
+  "@context": [
+    "https://schema.org",
+    "https://jerry.dev/contexts/worktracker.jsonld"
+  ],
+  "@id": "jer:jer:work-tracker:task:TASK-042",
+  "@type": ["Action", "Task"],
+  "name": "Implement JSON-LD support",
+  "partOf": {
+    "@id": "jer:jer:work-tracker:phase:PHASE-003",
+    "@type": "Project"
+  },
+  "agent": {
+    "@id": "https://www.anthropic.com/claude",
+    "@type": "SoftwareApplication",
+    "name": "Claude"
+  },
+  "instrument": {
+    "@id": "https://python.org/",
+    "@type": "ProgrammingLanguage",
+    "name": "Python"
+  }
+}
+```
+
+**Note:** This links to external entities (Anthropic, Python.org) achieving ★★★★★.
+
+### 7. When to Embed vs Reference External Ontologies
+
+#### 7.1 Decision Matrix
+
+| Scenario | Strategy | Example |
+|----------|----------|---------|
+| **Common concepts** (people, dates, organizations) | 🔗 **Reference** Schema.org, Dublin Core | `"name": "schema:name"` |
+| **Domain-specific** (Jerry's Task, Phase, Plan) | 🏠 **Create** Jerry vocabulary | `"status": "jerry:TaskStatus"` |
+| **Well-established standards** (CloudEvents, PROV-O) | 🔗 **Reference** W3C specs | `"@type": "prov:Activity"` |
+| **Experimental concepts** | 🏠 **Embed** temporarily, formalize later | Custom JSON-LD inline |
+
+#### 7.2 Jerry Vocabulary Design
+
+**Jerry Context File** (`https://jerry.dev/contexts/worktracker.jsonld`):
+
+```json
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://jerry.dev/vocab/",
+
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "ce": "https://cloudevents.io/vocab/",
+
+    "Task": {
+      "@id": "jerry:Task",
+      "@type": "@id"
+    },
+    "Phase": {
+      "@id": "jerry:Phase",
+      "@type": "@id"
+    },
+    "Plan": {
+      "@id": "jerry:Plan",
+      "@type": "@id"
+    },
+    "Subtask": {
+      "@id": "jerry:Subtask",
+      "@type": "@id"
+    },
+
+    "title": "schema:name",
+    "description": "schema:description",
+    "created": {
+      "@id": "schema:dateCreated",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "schema:dateModified",
+      "@type": "xsd:dateTime"
+    },
+
+    "status": {
+      "@id": "jerry:status",
+      "@type": "@vocab"
+    },
+    "displayNumber": {
+      "@id": "jerry:displayNumber",
+      "@type": "xsd:integer"
+    },
+    "verification": "jerry:verification",
+    "blockingReason": "jerry:blockingReason",
+
+    "belongsToPhase": {
+      "@id": "jerry:belongsToPhase",
+      "@type": "@id"
+    },
+    "belongsToPlan": {
+      "@id": "jerry:belongsToPlan",
+      "@type": "@id"
+    },
+    "contains": {
+      "@id": "jerry:contains",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "dependsOn": {
+      "@id": "jerry:dependsOn",
+      "@type": "@id",
+      "@container": "@set"
+    },
+
+    "Actor": "prov:Agent",
+    "performedBy": {
+      "@id": "prov:wasAssociatedWith",
+      "@type": "@id"
+    },
+    "emittedEvent": {
+      "@id": "prov:generated",
+      "@type": "@id"
+    }
+  }
+}
+```
+
+**Rationale:**
+- ✅ Reuses `schema:name`, `schema:description` (common concepts)
+- ✅ Reuses `prov:Agent`, `prov:wasAssociatedWith` (provenance)
+- ✅ Defines `jerry:status`, `jerry:displayNumber` (domain-specific)
+- ✅ Maps Jerry edges (`belongsToPhase`, `contains`) to custom vocabulary
+
+### 8. Linked Data Success Stories at Scale
+
+#### 8.1 DBpedia Knowledge Graph
+
+**Scale:** 3.4 million concepts, 1 billion triples
+**Technology:** RDF, SPARQL, Linked Data
+**Use Case:** Extract structured data from Wikipedia
+**Impact:** 600,000+ file downloads/year, backbone of Linked Open Data cloud
+
+**Relevance to Jerry:** Demonstrates that file-based RDF can scale to billions of triples. Jerry could adopt similar architecture for work tracker knowledge graph.
+
+#### 8.2 Wikidata
+
+**Scale:** Collaborative linked dataset, Wikimedia Foundation
+**Technology:** RDF, SPARQL, content negotiation
+**Use Case:** Central structured data repository for Wikipedia projects
+**Impact:** Foundation for archival linked data, GLAM sector initiatives
+
+**Relevance to Jerry:** Shows how URIs with content negotiation enable both human and machine access to the same data.
+
+#### 8.3 Schema.org Deployment
+
+**Scale:** 45+ million websites, 450+ billion Schema.org objects (2024)
+**Technology:** JSON-LD, Microdata, RDFa
+**Use Case:** SEO, knowledge graphs, search engine optimization
+**Impact:** 51.25% of web pages now have structured data (up from 5.7% in 2010)
+
+**Relevance to Jerry:** Validates JSON-LD as the dominant semantic data format. Jerry should align with this ecosystem.
+
+#### 8.4 Netflix Knowledge Graph (2025)
+
+**Architecture:** "Conceptual RDF, Flexible Physical"
+**Pattern:** "Model Once, Represent Everywhere"
+**Technology:** RDF ontology → GraphQL, Avro, SQL projections
+**Impact:** Unified data architecture across Netflix domains
+
+**Relevance to Jerry:** Aligns with `GRAPH_DATA_MODEL_ANALYSIS.md` (DISC-064). Jerry can adopt same pattern: EntityBase → JSON, JSON-LD, Graph, RDF.
+
+### 9. AsyncAPI + CloudEvents + JSON-LD Integration
+
+#### 9.1 Current State
+
+**AsyncAPI** focuses on the application and channels; **CloudEvents** focuses on the message format. They are complementary, not competitive.
+
+**Current Challenge:** Limited guidance on adding semantic annotations to event-driven APIs.
+
+#### 9.2 Proposed Pattern for Jerry
+
+**AsyncAPI Definition** (semantic enhancement):
+
+```yaml
+asyncapi: 3.0.0
+info:
+  title: Jerry Work Tracker Event API
+  version: 1.0.0
+
+channels:
+  task.events:
+    messages:
+      taskCompleted:
+        contentType: application/cloudevents+json; charset=utf-8; profile=ld
+        payload:
+          $ref: '#/components/schemas/TaskCompletedEvent'
+
+components:
+  schemas:
+    TaskCompletedEvent:
+      type: object
+      properties:
+        "@context":
+          type: array
+          items:
+            type: string
+          example:
+            - "https://cloudevents.io/context.jsonld"
+            - "https://jerry.dev/contexts/worktracker.jsonld"
+        "@type":
+          type: string
+          example: "CloudEvent"
+        specversion:
+          type: string
+          example: "1.0"
+        type:
+          type: object
+          properties:
+            "@id":
+              type: string
+              example: "jer:jer:work-tracker:facts/TaskCompleted"
+        data:
+          $ref: '#/components/schemas/TaskCompletedData'
+
+    TaskCompletedData:
+      type: object
+      properties:
+        "@context":
+          type: string
+          example: "https://jerry.dev/contexts/worktracker.jsonld"
+        "@type":
+          type: string
+          example: "TaskCompletedEvent"
+        task:
+          type: object
+          properties:
+            "@id":
+              type: string
+              example: "jer:jer:work-tracker:task:TASK-042"
+```
+
+**Benefits:**
+- ✅ AsyncAPI describes the message structure
+- ✅ CloudEvents provides event envelope
+- ✅ JSON-LD adds semantic richness to event data
+- ✅ Maintains backward compatibility (optional `@context`)
+
+---
+
+## L2: Strategic Implications (For Jerry Framework)
+
+### 1. Integration Roadmap
+
+#### Phase 1: Foundation (Q1 2026)
+- ✅ Jerry URI scheme already RDF-compatible (SPEC-001)
+- 🎯 Create Jerry JSON-LD context at `https://jerry.dev/contexts/worktracker.jsonld`
+- 🎯 Add optional `@context`, `@type`, `@id` to entity serialization
+- 🎯 Maintain backward compatibility (plain JSON still works)
+
+#### Phase 2: Semantic Events (Q2 2026)
+- 🎯 Extend CloudEvents with JSON-LD contexts
+- 🎯 Enable RDF export from event streams
+- 🎯 Add SPARQL query capability (via RDFLib)
+
+#### Phase 3: Linked Data (Q3 2026)
+- 🎯 Implement content negotiation (Accept: application/ld+json)
+- 🎯 URI dereferencing via HTTP server
+- 🎯 Link Jerry entities to Schema.org, external ontologies
+- 🎯 Achieve 5-star Linked Open Data status
+
+#### Phase 4: Knowledge Graph (Q4 2026)
+- 🎯 RDF triple store integration (kglab, RDFLib)
+- 🎯 SHACL validation for data quality
+- 🎯 OWL ontology formalization
+- 🎯 Inference and reasoning capabilities
+
+### 2. Architectural Decisions
+
+#### AD-001: JSON-LD as Optional Extension Layer
+
+**Decision:** Add JSON-LD support as an **optional extension** to existing JSON serialization, not a replacement.
+
+**Rationale:**
+- ✅ Maintains backward compatibility
+- ✅ Low barrier to adoption (gradual enhancement)
+- ✅ Follows "Jerry is JSON-LD-ready, not JSON-LD-required" principle
+
+**Implementation:**
+```python
+# src/domain/serialization/json_ld.py
+
+from typing import Dict, Any, Optional
+from ..entities.task import Task
+
+class JsonLdSerializer:
+    def __init__(self, context_url: str = "https://jerry.dev/contexts/worktracker.jsonld"):
+        self.context_url = context_url
+
+    def serialize(self, entity: Task, include_context: bool = True) -> Dict[str, Any]:
+        """Serialize entity to JSON-LD format."""
+        base_json = entity.to_dict()  # Existing JSON serialization
+
+        if not include_context:
+            return base_json
+
+        json_ld = {
+            "@context": self.context_url,
+            "@id": entity.uri.to_string(),  # Jerry URI
+            "@type": self._get_type(entity),
+            **base_json
+        }
+
+        return json_ld
+
+    def _get_type(self, entity) -> str:
+        return entity.__class__.__name__  # "Task", "Phase", "Plan"
+```
+
+#### AD-002: Reuse Schema.org Where Possible
+
+**Decision:** Map Jerry entities to Schema.org types where semantically appropriate, extend with Jerry-specific vocabulary only when necessary.
+
+**Mapping:**
+- `Task` → `schema:Action` (base) + `jerry:Task` (extension)
+- `Phase` → `schema:Project`
+- `Plan` → `schema:PlanAction`
+- `Actor` → `schema:Person` or `schema:SoftwareApplication`
+- `Evidence` → `schema:CreativeWork`
+
+**Benefits:**
+- ✅ Interoperability with existing tools (Google Knowledge Graph, etc.)
+- ✅ Reduced vocabulary maintenance burden
+- ✅ Leverages 800+ Schema.org terms
+
+#### AD-003: CloudEvents as Semantic Event Stream
+
+**Decision:** Extend CloudEvents `data` field with JSON-LD contexts for semantic event sourcing.
+
+**Rationale:**
+- ✅ CloudEvents provides standardized envelope (specversion, type, source)
+- ✅ JSON-LD in `data` field adds semantic richness
+- ✅ Enables RDF export of entire event history
+- ✅ Supports temporal queries (SPARQL with time filters)
+
+**Example Event Reconstruction:**
+
+```sparql
+# SPARQL query to reconstruct task state from events
+
+PREFIX jerry: <https://jerry.dev/vocab/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT ?event ?time ?eventType ?data
+WHERE {
+  ?task a jerry:Task ;
+        jerry:id "TASK-042" ;
+        prov:generated ?event .
+
+  ?event a <https://cloudevents.io/vocab/CloudEvent> ;
+         <https://cloudevents.io/vocab/time> ?time ;
+         <https://cloudevents.io/vocab/type> ?eventType ;
+         <https://cloudevents.io/vocab/data> ?data .
+}
+ORDER BY ?time
+```
+
+#### AD-004: Content Negotiation for Jerry URIs
+
+**Decision:** Implement HTTP-based content negotiation so Jerry URIs return different formats based on `Accept` header.
+
+**Supported Formats:**
+| Accept Header | Response | Use Case |
+|--------------|----------|----------|
+| `application/json` | Plain JSON | APIs, tools |
+| `application/ld+json` | JSON-LD | Semantic web |
+| `text/turtle` | RDF Turtle | Triple stores |
+| `text/html` | HTML + embedded JSON-LD | Human browsing |
+| `application/rdf+xml` | RDF/XML | Legacy systems |
+
+**Implementation Sketch:**
+
+```python
+# src/interface/http/uri_resolver.py
+
+from flask import Flask, request, jsonify
+from ..serialization.json_ld import JsonLdSerializer
+from ..serialization.turtle import TurtleSerializer
+
+app = Flask(__name__)
+
+@app.route('/jer/work-tracker/task/<task_id>')
+def resolve_task_uri(task_id: str):
+    task = repository.find_by_id(task_id)
+
+    accept = request.headers.get('Accept', 'application/json')
+
+    if 'application/ld+json' in accept:
+        serializer = JsonLdSerializer()
+        return jsonify(serializer.serialize(task)), 200, {'Content-Type': 'application/ld+json'}
+
+    elif 'text/turtle' in accept:
+        serializer = TurtleSerializer()
+        return serializer.serialize(task), 200, {'Content-Type': 'text/turtle'}
+
+    elif 'text/html' in accept:
+        return render_template('task.html', task=task), 200
+
+    else:
+        return jsonify(task.to_dict()), 200
+```
+
+### 3. Knowledge Graph Alignment (Netflix UDA Pattern)
+
+**From `GRAPH_DATA_MODEL_ANALYSIS.md` (DISC-064):**
+
+> Netflix UDA "Model Once, Represent Everywhere" - Single domain model with multiple projections (GraphQL, Avro, SQL, RDF)
+
+**Jerry Adoption:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   JERRY SEMANTIC DATA MODEL                  │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│   ┌──────────────────────────────────────────────┐          │
+│   │        DOMAIN MODEL (EntityBase)             │          │
+│   │  - Task, Phase, Plan (Aggregate Roots)       │          │
+│   │  - Jerry URI scheme (SPEC-001)               │          │
+│   │  - CloudEvents (event sourcing)              │          │
+│   └──────────────┬───────────────────────────────┘          │
+│                  │                                           │
+│                  │ Serialization Adapters                    │
+│                  │                                           │
+│   ┌──────────────┼───────────────────────────────┐          │
+│   │              │                               │          │
+│   ▼              ▼                               ▼          │
+│ JSON          JSON-LD                         RDF Turtle    │
+│ (current)     (semantic)                      (triple store)│
+│   │              │                               │          │
+│   │              │                               │          │
+│   ▼              ▼                               ▼          │
+│ Files         HTTP API                       SPARQL Endpoint│
+│ (storage)     (content negotiation)          (queries)      │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key Insight:** Jerry's existing `EntityBase` and repository pattern already support this. Adding JSON-LD is just another serialization adapter.
+
+### 4. Data Quality & Validation (SHACL)
+
+**Challenge:** As Jerry knowledge graph grows, how do we ensure data quality?
+
+**Solution:** SHACL (Shapes Constraint Language) for RDF validation.
+
+**Example SHACL Shape for Task:**
+
+```turtle
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix jerry: <https://jerry.dev/vocab/> .
+@prefix schema: <https://schema.org/> .
+
+jerry:TaskShape
+  a sh:NodeShape ;
+  sh:targetClass jerry:Task ;
+
+  sh:property [
+    sh:path schema:name ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:string ;
+    sh:minLength 1 ;
+    sh:maxLength 200 ;
+  ] ;
+
+  sh:property [
+    sh:path jerry:status ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:in ( "PENDING" "IN_PROGRESS" "BLOCKED" "COMPLETED" "CANCELLED" ) ;
+  ] ;
+
+  sh:property [
+    sh:path jerry:belongsToPhase ;
+    sh:maxCount 1 ;
+    sh:class jerry:Phase ;
+  ] ;
+
+  sh:property [
+    sh:path schema:dateCreated ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:dateTime ;
+  ] .
+```
+
+**Benefits:**
+- ✅ Machine-readable validation rules
+- ✅ Detects data quality issues early
+- ✅ Documents constraints as code
+- ✅ Integrates with RDF tooling (pySHACL)
+
+**Integration with Jerry:**
+
+```python
+# src/domain/validation/shacl_validator.py
+
+from pyshacl import validate
+from rdflib import Graph
+
+class ShaclValidator:
+    def __init__(self, shapes_file: str):
+        self.shapes = Graph().parse(shapes_file, format="turtle")
+
+    def validate_task(self, task_rdf: str) -> tuple[bool, Graph, str]:
+        """Validate task RDF against SHACL shapes."""
+        data_graph = Graph().parse(data=task_rdf, format="json-ld")
+
+        conforms, results_graph, results_text = validate(
+            data_graph,
+            shacl_graph=self.shapes,
+            inference='rdfs',
+            abort_on_first=False
+        )
+
+        return conforms, results_graph, results_text
+```
+
+### 5. AI & LLM Integration (2025 Trends)
+
+**From Research:** "The growing interplay between semantic technologies and large language models is creating a new layer of enterprise AI, where structured knowledge graphs enhance model accuracy, traceability, and domain adaptation."
+
+**Jerry + LLM Integration Scenarios:**
+
+#### 5.1 LLM-Enhanced Knowledge Graph Construction
+
+**Use Case:** Claude analyzes unstructured task descriptions and infers semantic relationships.
+
+**Example:**
+
+```python
+# LLM extracts entities and relationships from natural language
+
+task_description = """
+Implement JSON-LD support for Jerry entities. This depends on the
+Jerry URI specification (SPEC-001) and should follow W3C best practices.
+Claude will be the primary contributor.
+"""
+
+# LLM output (structured)
+{
+  "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+  "@type": "Task",
+  "title": "Implement JSON-LD support",
+  "dependsOn": [
+    {
+      "@id": "jer:jer:specifications:SPEC-001",
+      "@type": "Specification"
+    }
+  ],
+  "conformsTo": {
+    "@id": "https://www.w3.org/TR/json-ld11/",
+    "@type": "TechnicalSpecification"
+  },
+  "contributor": {
+    "@id": "jer:jer:work-tracker:actor:claude",
+    "@type": "SoftwareApplication"
+  }
+}
+```
+
+#### 5.2 Semantic Query Enhancement
+
+**Use Case:** User asks natural language question, LLM converts to SPARQL, executes against Jerry knowledge graph.
+
+**Example:**
+
+```
+User: "What tasks has Claude completed in the last week?"
+
+LLM → SPARQL:
+PREFIX jerry: <https://jerry.dev/vocab/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?task ?title ?completedTime
+WHERE {
+  ?task a jerry:Task ;
+        jerry:status "COMPLETED" ;
+        schema:name ?title ;
+        prov:wasAssociatedWith ?actor ;
+        schema:dateModified ?completedTime .
+
+  ?actor schema:name "Claude" .
+
+  FILTER (?completedTime >= "2026-01-01T00:00:00Z"^^xsd:dateTime)
+}
+ORDER BY DESC(?completedTime)
+```
+
+#### 5.3 Knowledge Graph Validation via LLM
+
+**Use Case:** LLM reviews Jerry knowledge graph for inconsistencies, suggests fixes.
+
+**Example:**
+
+```
+LLM Analysis:
+"Task TASK-042 has status 'COMPLETED' but no 'dateCompleted' property.
+Recommendation: Add schema:endTime property with completion timestamp."
+
+Suggested Fix (JSON-LD):
+{
+  "@id": "jer:jer:work-tracker:task:TASK-042",
+  "schema:endTime": {
+    "@value": "2026-01-08T15:30:00Z",
+    "@type": "xsd:dateTime"
+  }
+}
+```
+
+### 6. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Complexity Creep** | JSON-LD adds cognitive overhead | Make it optional; provide simple defaults |
+| **Context File Maintenance** | Stale context breaks parsing | Version contexts (v1.0, v1.1); cache with HTTP headers |
+| **Performance Overhead** | JSON-LD processing is slower than plain JSON | Lazy evaluation; cache expanded forms |
+| **Vocabulary Proliferation** | Too many custom Jerry terms | Reuse Schema.org; limit Jerry vocab to essentials |
+| **RDF Tooling Immaturity** | Python RDF tools less mature than JSON tools | Use battle-tested RDFLib; contribute upstream |
+
+### 7. Success Metrics
+
+**How do we know JSON-LD integration is successful?**
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| **Adoption** | 50% of Jerry entities serialized with JSON-LD | Count `@context` in output files |
+| **Interoperability** | Jerry data consumable by 3+ external tools | Test with Google Structured Data Testing Tool, RDF validators |
+| **Query Capability** | 10+ useful SPARQL queries documented | Query library in `docs/knowledge/` |
+| **Performance** | JSON-LD serialization < 2x plain JSON | Benchmark suite |
+| **Data Quality** | SHACL validation passing for 95%+ entities | Automated SHACL tests |
+
+### 8. Related Work & Prior Art
+
+**From `GRAPH_DATA_MODEL_ANALYSIS.md` (Section 11):**
+
+| Library | Purpose | Jerry Applicability |
+|---------|---------|---------------------|
+| **kglab** | Unified KG abstraction (RDF, NetworkX, Pandas) | ⭐⭐⭐⭐⭐ HIGH - Bridges paradigms |
+| **RDFLib** | Pure Python RDF processing | ⭐⭐⭐⭐⭐ HIGH - Semantic Web foundation |
+| **rdf2gremlin** | RDF → TinkerPop transformation | ⭐⭐⭐⭐ HIGH - Bridges RDF to property graph |
+
+**Recommendation:** Use **RDFLib** for JSON-LD processing, **kglab** if Jerry needs to support both RDF and property graph paradigms.
+
+---
+
+## Recommendations for Jerry Framework
+
+### Immediate Actions (Week 1)
+
+1. ✅ **Create Jerry JSON-LD Context**
+   - File: `contexts/worktracker.jsonld`
+   - Host at: `https://jerry.dev/contexts/worktracker.jsonld` (future)
+   - Include mappings to Schema.org, Dublin Core, PROV-O
+
+2. ✅ **Add JSON-LD Serializer**
+   - Module: `src/domain/serialization/json_ld.py`
+   - Make `@context` optional (backward compatibility)
+   - Add `@id`, `@type` to Task/Phase/Plan entities
+
+3. ✅ **Document Pattern**
+   - Create `docs/design/JSON_LD_INTEGRATION.md`
+   - Include examples for each entity type
+   - Reference this research document
+
+### Short-term Actions (Month 1)
+
+4. 🎯 **Extend CloudEvents with JSON-LD**
+   - Add `@context` to CloudEvents `data` field
+   - Create `contexts/cloudevents.jsonld` extension
+
+5. 🎯 **Add RDFLib Dependency**
+   - Update `requirements.txt`: `rdflib>=7.0.0`
+   - Create RDF export utility for knowledge graph
+
+6. 🎯 **Create SHACL Validation Shapes**
+   - File: `schemas/shacl/task-shape.ttl`
+   - Integrate with CI/CD for data quality checks
+
+### Medium-term Actions (Quarter 1)
+
+7. 🎯 **Implement Content Negotiation**
+   - HTTP server for Jerry URI dereferencing
+   - Support: `application/json`, `application/ld+json`, `text/turtle`, `text/html`
+
+8. 🎯 **Create SPARQL Query Library**
+   - `docs/knowledge/sparql-queries.md`
+   - Document common traversals (task dependencies, progress aggregation)
+
+9. 🎯 **Link to External Ontologies**
+   - Map Jerry entities to Schema.org types
+   - Reference W3C PROV-O for provenance
+   - Link to CloudEvents vocabulary
+
+### Long-term Vision (2026)
+
+10. 🎯 **5-Star Linked Open Data**
+    - Publish Jerry knowledge graph as Linked Open Data
+    - Enable external tools to query Jerry data
+    - Contribute Jerry vocabulary to community
+
+11. 🎯 **Knowledge Graph Analytics**
+    - SPARQL endpoint for complex queries
+    - OWL reasoning for inferred relationships
+    - Graph algorithms via NetworkX/kglab
+
+12. 🎯 **LLM + Knowledge Graph Integration**
+    - LLM-enhanced entity extraction from natural language
+    - Semantic query interface (natural language → SPARQL)
+    - Knowledge graph validation via LLM analysis
+
+---
+
+## Sources
+
+| Source | Title | URL |
+|--------|-------|-----|
+| **W3C-001** | JSON-LD Best Practices | https://w3c.github.io/json-ld-bp/ |
+| **W3C-002** | JSON-LD 1.1 Specification | https://www.w3.org/TR/json-ld11/ |
+| **W3C-003** | Content Negotiation by Profile | https://www.w3.org/TR/dx-prof-conneg/ |
+| **W3C-004** | SHACL Shapes Constraint Language | https://www.w3.org/TR/shacl/ |
+| **W3C-005** | RDF 1.1 Primer | https://www.w3.org/TR/rdf11-primer/ |
+| **W3C-006** | SPARQL 1.1 Query Language | https://www.w3.org/TR/sparql11-query/ |
+| **JSONLD-001** | JSON-LD Official Site | https://json-ld.org/ |
+| **JSONLD-002** | JSON-LD Primer | https://json-ld.org/primer/latest/ |
+| **SCHEMA-001** | Schema.org Developers Guide | https://schema.org/docs/developers.html |
+| **SCHEMA-002** | Schema.org JSON-LD Context | https://schema.org/docs/jsonldcontext.json |
+| **BERNERS-LEE-001** | Linked Data Principles (2006) | https://www.w3.org/DesignIssues/LinkedData.html |
+| **5STAR-001** | 5-Star Open Data | https://5stardata.info/en/ |
+| **WDC-001** | Web Data Commons 2024 Corpus | https://webdatacommons.org/structureddata/ |
+| **WDC-002** | RDFa, Microdata, JSON-LD Dataset | https://www.uni-mannheim.de/dws/news/wdc-json-ld-microdata-rdfa-data-corpus-2024-published/ |
+| **DBPEDIA-001** | DBpedia Association | https://www.dbpedia.org/ |
+| **WIKIDATA-001** | Wikidata Linked Open Data Workflow | https://www.wikidata.org/wiki/Wikidata:Linked_open_data_workflow |
+| **ASYNC-001** | AsyncAPI and CloudEvents | https://www.asyncapi.com/blog/asyncapi-cloud-events |
+| **CLOUDEVENTS-001** | CloudEvents Specification | https://cloudevents.io/ |
+| **ONTOTEXT-001** | Five-Star Linked Open Data | https://www.ontotext.com/knowledgehub/fundamentals/five-star-linked-open-data/ |
+| **SEMANTIC-ARTS-001** | Year of the Knowledge Graph (2025) | https://www.semanticarts.com/the-year-of-the-knowledge-graph-2025/ |
+| **MARKETS-001** | Semantic Web Market 2025-2030 | https://www.marketsandmarkets.com/PressReleases/semantic-web.asp |
+| **NETFLIX-001** | Netflix Knowledge Graph | https://netflixtechblog.medium.com/unlocking-entertainment-intelligence-with-knowledge-graph-da4b22090141 |
+| **NETFLIX-002** | Netflix UDA Architecture | https://netflixtechblog.com/uda-unified-data-architecture-6a6aee261d8d |
+| **RDFLIB-001** | RDFLib Python Library | https://github.com/RDFLib/rdflib |
+| **KGLAB-001** | kglab - Graph Data Science | https://github.com/DerwenAI/kglab |
+| **SHACL-PERF-001** | UpSHACL: Targeted Validation | https://link.springer.com/chapter/10.1007/978-3-032-09527-5_7 |
+| **W3C-CNEG-001** | Content Negotiation (2006) | https://www.w3.org/blog/2006/content-negotiation/ |
+| **TPXIMPACT-001** | Linked Data Principles Walkthrough | https://www.tpximpact.com/knowledge-hub/blogs/tech/linked-data-principles |
+
+---
+
+## Appendix A: Jerry JSON-LD Context (Draft)
+
+**File:** `contexts/worktracker.jsonld`
+
+```json
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://jerry.dev/vocab/",
+
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "dc": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "ce": "https://cloudevents.io/vocab/",
+
+    "Task": {
+      "@id": "jerry:Task",
+      "@type": "@id"
+    },
+    "Phase": {
+      "@id": "jerry:Phase",
+      "@type": "@id"
+    },
+    "Plan": {
+      "@id": "jerry:Plan",
+      "@type": "@id"
+    },
+    "Subtask": {
+      "@id": "jerry:Subtask",
+      "@type": "@id"
+    },
+    "Actor": {
+      "@id": "prov:Agent",
+      "@type": "@id"
+    },
+    "Evidence": {
+      "@id": "schema:CreativeWork",
+      "@type": "@id"
+    },
+
+    "title": "schema:name",
+    "description": "schema:description",
+    "created": {
+      "@id": "schema:dateCreated",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "schema:dateModified",
+      "@type": "xsd:dateTime"
+    },
+    "createdBy": {
+      "@id": "prov:wasAttributedTo",
+      "@type": "@id"
+    },
+
+    "status": {
+      "@id": "jerry:status",
+      "@type": "@vocab"
+    },
+    "displayNumber": {
+      "@id": "jerry:displayNumber",
+      "@type": "xsd:integer"
+    },
+    "verification": "jerry:verification",
+    "blockingReason": "jerry:blockingReason",
+    "targetDate": {
+      "@id": "schema:targetDate",
+      "@type": "xsd:date"
+    },
+
+    "belongsToPhase": {
+      "@id": "jerry:belongsToPhase",
+      "@type": "@id"
+    },
+    "belongsToPlan": {
+      "@id": "jerry:belongsToPlan",
+      "@type": "@id"
+    },
+    "contains": {
+      "@id": "schema:hasPart",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "dependsOn": {
+      "@id": "jerry:dependsOn",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "blocks": {
+      "@id": "jerry:blocks",
+      "@type": "@id",
+      "@container": "@set"
+    },
+
+    "checked": {
+      "@id": "jerry:checked",
+      "@type": "xsd:boolean"
+    },
+    "checkedAt": {
+      "@id": "jerry:checkedAt",
+      "@type": "xsd:dateTime"
+    },
+    "checkedBy": {
+      "@id": "jerry:checkedBy",
+      "@type": "@id"
+    },
+
+    "performedBy": {
+      "@id": "prov:wasAssociatedWith",
+      "@type": "@id"
+    },
+    "emittedEvent": {
+      "@id": "prov:generated",
+      "@type": "@id"
+    },
+    "evidencedBy": {
+      "@id": "jerry:evidencedBy",
+      "@type": "@id",
+      "@container": "@set"
+    }
+  }
+}
+```
+
+---
+
+## Appendix B: 5W1H Research Summary
+
+| Question | Answer |
+|----------|--------|
+| **What** techniques enable semantic meaning? | JSON-LD (primary), RDFa, Microdata, RDF/XML. JSON-LD is the clear winner (70% adoption). |
+| **Why** is linked data valuable? | Enables machine understanding, interoperability, knowledge graph construction, and AI/LLM integration. |
+| **Who** are authoritative sources? | Tim Berners-Lee (Linked Data principles), W3C (JSON-LD spec), Manu Sporny (JSON-LD co-creator), Schema.org (vocabulary). |
+| **When** to embed vs reference? | Reference Schema.org/Dublin Core for common concepts; create Jerry vocabulary for domain-specific concepts. |
+| **Where** is it deployed at scale? | DBpedia (1B triples), Wikidata (collaborative LD), Schema.org (45M+ websites), Netflix KG (conceptual RDF). |
+| **How** to add semantics to JSON? | Add `@context` (vocabulary), `@type` (entity class), `@id` (URI identifier). Use Schema.org context or create custom. |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial research document (ps-researcher agent v2.0.0) |
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-08*
+*Author: Claude (ps-researcher agent)*
+*Research Framework: 5W1H*
+*Output Levels: L0 (Executive), L1 (Technical), L2 (Strategic)*
+*Constitution Compliance: P-001 (Truth & Accuracy), P-002 (File Persistence)*

--- a/docs/archive/projects-archive/research/work-031-e-005-llm-grounding.md
+++ b/docs/archive/projects-archive/research/work-031-e-005-llm-grounding.md
@@ -1,0 +1,967 @@
+# LLM Semantic Grounding via Knowledge Graphs and RAG
+
+> **Research Date:** 2026-01-08
+> **PS ID:** work-031
+> **Entry ID:** e-005
+> **Topic:** LLM Semantic Grounding
+> **Status:** DECISION-GRADE
+> **Purpose:** Research RAG patterns, knowledge graph integration, and grounding techniques for Jerry framework
+
+---
+
+## L0: Executive Summary (Plain Language Findings)
+
+### What is LLM Semantic Grounding?
+
+**LLM grounding** is the process of linking a large language model's outputs to trusted, external sources of truth. Instead of relying solely on what the LLM learned during pretraining, grounding allows it to retrieve and use up-to-date, factual, or organization-specific information when generating responses.
+
+When an LLM is grounded, it can handle complex queries with far greater accuracy and nuance. It dramatically reduces AI hallucinations because the model is no longer forced to guess when it lacks knowledge.
+
+### Why This Matters for Jerry
+
+Jerry's core mission is to **solve problems while accruing knowledge, wisdom, and experience**. Without grounding:
+- Claude Code agents would rely only on training data (knowledge cutoff: January 2025)
+- Jerry's accumulated knowledge in `docs/` would be inaccessible during LLM inference
+- Work Tracker state, entity relationships, and historical decisions would be invisible to reasoning
+
+**With grounding**, Jerry becomes a **knowledge-augmented system** where:
+- Claude agents can retrieve from Jerry's knowledge repository
+- Work items, plans, and entities are traversable during inference
+- Decisions are fact-checked against accumulated experience
+- Context rot is minimized through persistent, retrievable state
+
+### Key Findings (2025 Research)
+
+1. **RAG is the foundation**: Retrieval-Augmented Generation (RAG) is the primary technique for grounding LLMs, with 2025 seeing maturity in production systems achieving 300-320% ROI.
+
+2. **GraphRAG outperforms vector-only RAG**: Microsoft Research's GraphRAG uses knowledge graphs to provide substantial improvements in Q&A performance when reasoning about complex information, particularly for multi-hop reasoning.
+
+3. **HybridRAG is the emerging best practice**: Combining vector retrieval (semantic similarity) with knowledge graph traversal (relational reasoning) achieves the best of both worlds - accuracy, explainability, and scalability.
+
+4. **Grounding verification is critical**: New benchmarks like MiniCheck and FACTS Grounding enable automatic fact-checking of LLM outputs against source documents with GPT-4-level accuracy at 400x lower cost.
+
+5. **Production systems show measurable impact**:
+   - FalkorDB: 90% hallucination reduction with sub-50ms latency
+   - LinkedIn: 63% reduction in ticket resolution time (40hrs → 15hrs)
+   - Amazon Finance: 49% → 86% accuracy improvement with RAG
+
+### Recommendations for Jerry
+
+1. **Extend Jerry URI scheme** (SPEC-001) to support RAG retrieval identifiers
+2. **Implement HybridRAG** combining file-based vector search with graph traversal
+3. **Integrate with Claude Code** via extended citations and grounding context
+4. **Add grounding verification** using lightweight fact-checking models
+5. **Persist retrieval context** to enable reproducibility and debugging
+
+---
+
+## L1: Technical Details
+
+### 1. RAG Architectures and Patterns (2025 State-of-the-Art)
+
+#### 1.1 Traditional RAG
+
+**Flow**: Query → Embed → Retrieve → Augment → Generate
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        TRADITIONAL RAG PIPELINE                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   1. USER QUERY                                                          │
+│      "What are the tasks in Phase 2 of WORK-030?"                       │
+│                                                                          │
+│   2. QUERY EMBEDDING                                                     │
+│      Vector: [0.23, -0.45, 0.67, ...]  (768-dim)                        │
+│                                                                          │
+│   3. VECTOR SIMILARITY SEARCH                                            │
+│      Retrieve top-k chunks from knowledge base                           │
+│      ┌──────────────────────────────────────┐                           │
+│      │ Chunk 1: WORK-030 Phase 2 tasks...  │ Score: 0.89               │
+│      │ Chunk 2: Phase 2 completion criteria│ Score: 0.82               │
+│      │ Chunk 3: Dependencies for Phase 2   │ Score: 0.78               │
+│      └──────────────────────────────────────┘                           │
+│                                                                          │
+│   4. CONTEXT AUGMENTATION                                                │
+│      System: "Answer using only the following context:"                 │
+│      Context: [Chunk 1] + [Chunk 2] + [Chunk 3]                         │
+│      User: "What are the tasks in Phase 2 of WORK-030?"                 │
+│                                                                          │
+│   5. LLM GENERATION                                                      │
+│      Claude/GPT generates response grounded in retrieved context         │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Strengths**: Simple, fast, works well for semantic similarity
+**Weaknesses**: No relational reasoning, fixed chunk size, context window limits
+
+**Sources**:
+- [Prompt Engineering Guide: RAG](https://www.promptingguide.ai/research/rag)
+- [EdenAI: 2025 Guide to RAG](https://www.edenai.co/post/the-2025-guide-to-retrieval-augmented-generation-rag)
+
+#### 1.2 Self-RAG (Self-Reflective RAG)
+
+**Innovation**: Model decides when to retrieve and self-critiques outputs.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           SELF-RAG ARCHITECTURE                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   Query → [RETRIEVE?] → Yes/No decision                                 │
+│              │                                                           │
+│              ├─ No  → Generate directly                                 │
+│              │                                                           │
+│              └─ Yes → Retrieve → [RELEVANT?] → Filter irrelevant        │
+│                                      │                                   │
+│                                      └─ Generate → [SUPPORTED?]         │
+│                                                        │                 │
+│                                                        └─ [USEFUL?]     │
+│                                                              │           │
+│                                                              └─ Output   │
+│                                                                          │
+│   Reflection Tokens:                                                     │
+│   - [Retrieve]: Should I retrieve external knowledge?                   │
+│   - [Relevant]: Is retrieved passage relevant to query?                 │
+│   - [Supported]: Is my answer supported by the evidence?                │
+│   - [Useful]: Is my answer useful to the user?                          │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key Benefit**: Reduces unnecessary retrievals and hallucinations through self-critique.
+
+**Source**: [Medium: 2025 RAG Retrieval Methods](https://medium.com/@mehulpratapsingh/2025s-ultimate-guide-to-rag-retrieval-how-to-pick-the-right-method-and-why-your-ai-s-success-2cedcda99f8a)
+
+#### 1.3 Long RAG
+
+**Innovation**: Processes longer retrieval units (sections/documents) instead of small chunks.
+
+**Traditional RAG**: 300-500 token chunks → loses context
+**Long RAG**: Full sections (4K+ tokens) → preserves context
+
+**Trade-offs**:
+- ✅ Better context preservation, fewer retrieval calls
+- ❌ Larger context windows required, higher token costs
+
+**Source**: [EdenAI: Long RAG](https://www.edenai.co/post/the-2025-guide-to-retrieval-augmented-generation-rag)
+
+#### 1.4 GraphRAG (Microsoft Research)
+
+**Innovation**: Uses knowledge graphs to enable multi-hop reasoning.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     GRAPHRAG ARCHITECTURE (MICROSOFT)                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   INDEXING PHASE (Offline)                                               │
+│   ┌──────────────────────────────────────────────────────────┐          │
+│   │ 1. Input Corpus → Slice into TextUnits                   │          │
+│   │ 2. LLM extracts:                                          │          │
+│   │    - Entities (Task, Phase, Plan, Actor)                 │          │
+│   │    - Relationships (CONTAINS, DEPENDS_ON, EMITTED)       │          │
+│   │    - Key Claims (facts, decisions, requirements)         │          │
+│   │ 3. Build Knowledge Graph                                 │          │
+│   │ 4. Leiden Clustering (hierarchical communities)          │          │
+│   │ 5. Generate Community Summaries (bottom-up)              │          │
+│   └──────────────────────────────────────────────────────────┘          │
+│                                                                          │
+│   QUERY PHASE (Runtime)                                                  │
+│   ┌──────────────────────────────────────────────────────────┐          │
+│   │ Query → Global/Local Retriever                           │          │
+│   │   │                                                       │          │
+│   │   ├─ GLOBAL: Use community summaries for holistic view   │          │
+│   │   │                                                       │          │
+│   │   └─ LOCAL: Traverse graph from entity nodes             │          │
+│   │        Example: TASK-042 --BELONGS_TO--> Phase 2         │          │
+│   │                 Phase 2 --CONTAINS--> [Task list]        │          │
+│   │                                                           │          │
+│   │ Retrieved context → LLM → Grounded response              │          │
+│   └──────────────────────────────────────────────────────────┘          │
+│                                                                          │
+│   KEY INNOVATION: Multi-hop graph traversal provides relational context │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Performance**: Substantial improvements over vector-only RAG for complex reasoning tasks.
+
+**Sources**:
+- [Microsoft Research: GraphRAG](https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/)
+- [Microsoft GraphRAG Docs](https://microsoft.github.io/graphrag/)
+- [FalkorDB: Knowledge Graphs for LLMs](https://www.falkordb.com/blog/glossary/knowledge-graph-llms-graphrag/)
+
+#### 1.5 HybridRAG (Vector + Graph)
+
+**Innovation**: Combines vector retrieval (semantic similarity) with graph traversal (relational reasoning).
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        HYBRIDRAG ARCHITECTURE                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   User Query: "What tasks block TASK-042?"                              │
+│        │                                                                 │
+│        ├────────────────┬────────────────┐                              │
+│        │                │                │                              │
+│        ▼                ▼                ▼                              │
+│   ┌─────────┐    ┌──────────┐    ┌──────────────┐                      │
+│   │ VECTOR  │    │  GRAPH   │    │   HYBRID     │                      │
+│   │  RAG    │    │   RAG    │    │  RETRIEVAL   │                      │
+│   └─────────┘    └──────────┘    └──────────────┘                      │
+│        │                │                │                              │
+│        │                │                │                              │
+│   1. Embed query   2. Parse entities  3. Parallel                       │
+│      ↓                  ↓                execution                      │
+│   Vector search    Graph traversal                                      │
+│      ↓                  ↓                                                │
+│   Top-k chunks     Related nodes                                        │
+│      │                  │                                                │
+│      └────────┬─────────┘                                               │
+│               │                                                          │
+│               ▼                                                          │
+│        ┌────────────┐                                                    │
+│        │  CONTEXT   │                                                    │
+│        │   MERGER   │                                                    │
+│        └────────────┘                                                    │
+│               │                                                          │
+│               ├─ VectorRAG: Semantic chunks (broad coverage)            │
+│               ├─ GraphRAG: Relationship paths (structured reasoning)    │
+│               └─ Combined: Deduplicated, ranked context                 │
+│               │                                                          │
+│               ▼                                                          │
+│         LLM Generation                                                   │
+│               │                                                          │
+│               ▼                                                          │
+│         Grounded Response with Citations                                │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Integration Patterns**:
+
+1. **Graph-First Enhancement**: Traverse graph to find entities → enhance vector search
+2. **Parallel Retrieval**: Both retrievers run simultaneously → merge results
+3. **Dynamic Routing**: Query classifier decides which retriever to use
+4. **Unified Embedding**: Graph structure enriches text embeddings
+
+**Performance**: HybridRAG achieves balanced performance combining VectorRAG's broad coverage with GraphRAG's relational precision.
+
+**Sources**:
+- [ArXiv: HybridRAG Paper](https://arxiv.org/abs/2408.04948)
+- [Memgraph: Why HybridRAG](https://memgraph.com/blog/why-hybridrag)
+- [RAG About It: Complete Enterprise Guide](https://ragaboutit.com/how-to-build-hybrid-rag-systems-with-vector-and-knowledge-graph-integration-the-complete-enterprise-guide/)
+
+---
+
+### 2. Knowledge Graph Integration with LLMs
+
+#### 2.1 Neo4j LLM Knowledge Graph Builder (2025)
+
+**Key Features** (Released January 2025):
+- Community summaries for hierarchical graph understanding
+- Local and global retrievers for different query types
+- Custom prompt instructions for domain-specific extraction
+- 4th most popular source of interaction on AuraDB Free
+
+**Workflow**:
+```
+Documents → LLM Extraction → Entities + Relationships → Neo4j Graph → RAG Retrieval
+```
+
+**Source**: [Neo4j: LLM Knowledge Graph Builder](https://neo4j.com/blog/developer/llm-knowledge-graph-builder-release/)
+
+#### 2.2 Knowledge Graph Construction from Unstructured Text
+
+**LLM-Powered Extraction**: LLMs already understand language structure, entity types, and common relationships from training. You don't need specialized models—teach the LLM your schema and let it extract accordingly.
+
+**Best Practices**:
+1. Define clear ontology/schema
+2. Provide few-shot examples in prompts
+3. Use structured output (JSON, GraphQL)
+4. Validate extractions against schema
+
+**Source**: [Medium: Production-Ready Graph Systems](https://medium.com/@claudiubranzan/from-llms-to-knowledge-graphs-building-production-ready-graph-systems-in-2025-2b4aff1ec99a)
+
+#### 2.3 Jerry Graph Model Integration
+
+Jerry's existing graph data model (see `GRAPH_DATA_MODEL_ANALYSIS.md`) provides the foundation for RAG integration:
+
+| Jerry Component | RAG Role | Integration Point |
+|-----------------|----------|-------------------|
+| **Property Graph (TinkerPop)** | Knowledge storage | Gremlin traversal for retrieval |
+| **Jerry URI Scheme (SPEC-001)** | Unique identifiers | Citation linking |
+| **Vertex Labels** (Task, Phase, Plan) | Entity types | Schema for extraction |
+| **Edge Labels** (CONTAINS, DEPENDS_ON) | Relationships | Multi-hop reasoning |
+| **CloudEvents vertices** | Event history | Temporal grounding |
+
+**Extension Required**: Add `embedding` property to vertices for vector similarity search.
+
+```python
+# Proposed: Hybrid Graph+Vector Vertex
+@dataclass
+class HybridVertex(Vertex):
+    """
+    Vertex with both property graph and vector retrieval support.
+    """
+    embedding: Optional[List[float]] = None  # 768-dim vector (e.g., text-embedding-3-small)
+    embedding_model: str = "text-embedding-3-small"
+    last_embedded_at: datetime = None
+
+    def compute_embedding(self, text: str, model: EmbeddingModel) -> None:
+        """Compute and store embedding for vector retrieval."""
+        self.embedding = model.embed(text)
+        self.embedding_model = model.name
+        self.last_embedded_at = datetime.utcnow()
+```
+
+---
+
+### 3. Grounding Verification and Fact-Checking
+
+#### 3.1 MiniCheck (2024)
+
+**Purpose**: Efficient fact-checking of LLM outputs against grounding documents.
+
+**Innovation**: Small models (770M parameters) achieve GPT-4-level accuracy at 400x lower cost using synthetic training data.
+
+**Workflow**:
+```
+LLM Output + Grounding Document → MiniCheck-FT5 → Supported/Not Supported
+```
+
+**Benchmark**: LLM-AggreFact (unified fact-checking benchmark)
+
+**Source**: [ArXiv: MiniCheck](https://arxiv.org/abs/2404.10774)
+
+#### 3.2 FACTS Grounding Benchmark (Google DeepMind, 2025)
+
+**Purpose**: Evaluate LLM ability to generate factually accurate AND sufficiently detailed responses.
+
+**Evaluation Metrics**:
+1. **Factual Accuracy**: Response grounded in provided context
+2. **Completeness**: Response addresses all aspects of query
+3. **Attribution**: Citations to source material
+
+**Judges**: Gemini 1.5 Pro, GPT-4o, Claude 3.5 Sonnet (mitigate judge bias)
+
+**Context Size**: Up to 32K tokens from finance, legal, medical domains
+
+**Source**: [Google DeepMind: FACTS Grounding](https://deepmind.google/blog/facts-grounding-a-new-benchmark-for-evaluating-the-factuality-of-large-language-models/)
+
+#### 3.3 Anthropic Claude Grounding Techniques
+
+**Constitutional AI**: Claude trained with principles from UN Universal Declaration of Human Rights to promote truthfulness.
+
+**Quote-First Strategy**: For long documents (>20K tokens), Claude extracts word-for-word quotes before performing tasks, grounding responses in actual text.
+
+**Web Search Tool** (Claude 3.5+, 3.7, 4.0):
+- Real-time web search during inference
+- Automatic citation of sources
+- Reduces reliance on training data
+
+**Hallucination Rate**: Internal testing shows Claude 3.5 outperforms humans on structured factual quizzes, though Claude Opus 4 showed ~10% hallucination rate vs. <5% for Sonnet 3.7.
+
+**Sources**:
+- [Anthropic: System Card Claude Opus 4](https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf)
+- [Claude Docs: Reduce Hallucinations](https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)
+
+#### 3.4 OpenAI GPT Grounding Techniques
+
+**RAG in GPTs**: Automatic retrieval from uploaded files when knowledge retrieval is enabled. Query → vector search → semantic chunks → augmented prompt.
+
+**Best Practices** (OpenAI 2025):
+1. **Chunking**: 300-500 token chunks
+2. **Hybrid Search**: BM25 (keyword) + vector (semantic)
+3. **Explicit Instructions**: "Answer only from context; say 'I don't know' if not found"
+4. **Reranking**: Adjust similarity thresholds and top-k selection
+
+**Sources**:
+- [OpenAI Help: RAG for GPTs](https://help.openai.com/en/articles/8868588-retrieval-augmented-generation-rag-and-semantic-search-for-gpts)
+- [Medium: ChatGPT RAG Guide 2025](https://medium.com/@illyism/chatgpt-rag-guide-2025-build-reliable-ai-with-retrieval-0f881a4714af)
+
+---
+
+### 4. Integration Patterns for Jerry + Claude Code
+
+#### 4.1 Jerry RAG Architecture (Proposed)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    JERRY HYBRIDRAG ARCHITECTURE                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│   ┌──────────────────────────────────────────────────────────────┐      │
+│   │                    KNOWLEDGE SOURCES                          │      │
+│   ├──────────────────────────────────────────────────────────────┤      │
+│   │                                                               │      │
+│   │  docs/                    skills/                src/         │      │
+│   │  ├─ research/             ├─ SKILL.md            ├─ domain/  │      │
+│   │  ├─ experience/           └─ PLAYBOOK.md         └─ events/  │      │
+│   │  ├─ wisdom/                                                  │      │
+│   │  └─ plans/                Work Tracker State                 │      │
+│   │                           ├─ Plans (JSON/TOON)               │      │
+│   │                           ├─ Phases                          │      │
+│   │                           └─ Tasks                           │      │
+│   └──────────────────────────────────────────────────────────────┘      │
+│                               │                                          │
+│                               ▼                                          │
+│   ┌──────────────────────────────────────────────────────────────┐      │
+│   │                  DUAL RETRIEVAL LAYER                         │      │
+│   ├──────────────────────────────────────────────────────────────┤      │
+│   │                                                               │      │
+│   │  ┌─────────────────────┐       ┌──────────────────────┐     │      │
+│   │  │  VECTOR RETRIEVAL   │       │  GRAPH TRAVERSAL     │     │      │
+│   │  ├─────────────────────┤       ├──────────────────────┤     │      │
+│   │  │ • Markdown files    │       │ • Work Tracker graph │     │      │
+│   │  │ • Code docstrings   │       │ • Entity vertices    │     │      │
+│   │  │ • Research docs     │       │ • Relationship edges │     │      │
+│   │  │ • Experience logs   │       │ • CloudEvents chain  │     │      │
+│   │  │                     │       │                      │     │      │
+│   │  │ Tech: ChromaDB,     │       │ Tech: Gremlin,       │     │      │
+│   │  │ Qdrant, or in-mem   │       │ file-based graph     │     │      │
+│   │  └─────────────────────┘       └──────────────────────┘     │      │
+│   │              │                             │                 │      │
+│   │              └──────────┬──────────────────┘                 │      │
+│   │                         │                                    │      │
+│   │                         ▼                                    │      │
+│   │              ┌──────────────────────┐                        │      │
+│   │              │  CONTEXT MERGER      │                        │      │
+│   │              │  • Deduplicate       │                        │      │
+│   │              │  • Rank by relevance │                        │      │
+│   │              │  • Add Jerry URIs    │                        │      │
+│   │              └──────────────────────┘                        │      │
+│   └──────────────────────────────────────────────────────────────┘      │
+│                               │                                          │
+│                               ▼                                          │
+│   ┌──────────────────────────────────────────────────────────────┐      │
+│   │                   CLAUDE CODE AGENT                           │      │
+│   ├──────────────────────────────────────────────────────────────┤      │
+│   │                                                               │      │
+│   │  System Prompt + Retrieved Context + User Query              │      │
+│   │                                                               │      │
+│   │  Context Example:                                             │      │
+│   │  ---                                                          │      │
+│   │  [JERRY CONTEXT]                                              │      │
+│   │  Source: jer:jer:work-tracker:plan:PLAN-001#phase-2          │      │
+│   │  Content: Phase 2 includes tasks TASK-007, TASK-008...       │      │
+│   │                                                               │      │
+│   │  Source: docs/research/GRAPH_DATA_MODEL_ANALYSIS.md          │      │
+│   │  Content: Property graph model with Vertex/Edge...           │      │
+│   │  ---                                                          │      │
+│   │                                                               │      │
+│   │  Claude generates response with citations                    │      │
+│   └──────────────────────────────────────────────────────────────┘      │
+│                               │                                          │
+│                               ▼                                          │
+│   ┌──────────────────────────────────────────────────────────────┐      │
+│   │                  GROUNDING VERIFICATION                       │      │
+│   ├──────────────────────────────────────────────────────────────┤      │
+│   │                                                               │      │
+│   │  MiniCheck-FT5 (optional):                                    │      │
+│   │  Response + Retrieved Context → Verify factual support       │      │
+│   │                                                               │      │
+│   │  Output: Grounded response with Jerry URI citations          │      │
+│   └──────────────────────────────────────────────────────────────┘      │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 4.2 Implementation Strategy
+
+**Phase 1: File-Based Vector RAG** (Immediate)
+- Index `docs/` using lightweight embedding model (e.g., `text-embedding-3-small`)
+- Store embeddings in JSON/TOON alongside documents
+- Implement simple cosine similarity search
+- Inject top-k results into Claude Code system prompt
+
+**Phase 2: Graph Traversal RAG** (Short-term)
+- Extend Work Tracker graph to support Gremlin queries
+- Add graph traversal retrieval for entity relationships
+- Combine vector + graph results (HybridRAG)
+
+**Phase 3: Unified Retrieval API** (Medium-term)
+- Abstract retrieval behind domain port (`IKnowledgeRetriever`)
+- Support multiple adapters (file, vector DB, graph DB)
+- Enable query routing based on query type
+
+**Phase 4: Grounding Verification** (Long-term)
+- Integrate MiniCheck or similar fact-checking model
+- Log verification results for audit trail
+- Emit CloudEvents for grounding failures
+
+#### 4.3 Jerry URI as Citation Standard
+
+Jerry's URI scheme (SPEC-001) is ideal for RAG citations:
+
+```
+# Citation format in Claude Code responses
+Source: jer:jer:work-tracker:task:TASK-042+a3f8b2
+Retrieved: 2026-01-08T14:32:15Z
+Confidence: 0.89
+
+Content: "TASK-042 is blocked pending completion of TASK-039..."
+```
+
+**Benefits**:
+- Unique, dereferenceable identifiers
+- Content-addressable hashes for version tracking
+- Compatible with RDF/Semantic Web standards
+
+---
+
+### 5. Production Case Studies (2025)
+
+#### 5.1 FalkorDB GraphRAG
+
+**Results**:
+- 90% hallucination reduction vs. traditional RAG
+- Sub-50ms query latency
+- Structured reasoning via knowledge graph
+
+**Source**: [Medium: Production-Ready Graph Systems](https://medium.com/@claudiubranzan/from-llms-to-knowledge-graphs-building-production-ready-graph-systems-in-2025-2b4aff1ec99a)
+
+#### 5.2 LinkedIn GraphRAG
+
+**Results**:
+- 63% reduction in ticket resolution time (40hrs → 15hrs)
+- Multi-hop reasoning for complex support queries
+
+**Source**: [ZenML: LLMOps Case Studies](https://www.zenml.io/blog/llmops-in-production-457-case-studies-of-what-actually-works)
+
+#### 5.3 Amazon Finance RAG
+
+**Results**:
+- 49% → 86% accuracy improvement
+- Iterative optimization of chunking, prompts, embeddings
+
+**Source**: [ZenML: LLMOps Case Studies](https://www.zenml.io/blog/llmops-in-production-457-case-studies-of-what-actually-works)
+
+#### 5.4 Accenture Knowledge Assist
+
+**Architecture**: Multi-model GenAI (Claude-2, Amazon Titan, Pinecone, Kendra)
+
+**Results**:
+- 50% reduction in new hire training time
+- 40% drop in query escalations
+
+**Source**: [ZenML: LLMOps Case Studies](https://www.zenml.io/blog/llmops-in-production-457-case-studies-of-what-actually-works)
+
+#### 5.5 Cedars-Sinai AlzKB (Alzheimer's Knowledge Base)
+
+**Architecture**: HybridRAG with Memgraph (graph) + vector database
+
+**Use Case**: Biomedical entity reasoning with multi-hop queries
+
+**Tools**: KRAGEN, ESCARGOT for compound queries
+
+**Source**: [Memgraph: Why HybridRAG](https://memgraph.com/blog/why-hybridrag)
+
+---
+
+## L2: Strategic Implications for Jerry Framework
+
+### 1. Jerry's Knowledge Persistence Strategy
+
+Jerry's existing architecture is **already well-positioned** for RAG integration:
+
+| Jerry Component | RAG Alignment | Strategic Benefit |
+|-----------------|---------------|-------------------|
+| **Filesystem as infinite memory** | Knowledge base for retrieval | No external DB dependency |
+| **Work Tracker graph model** | GraphRAG foundation | Multi-hop reasoning ready |
+| **Jerry URI scheme** | Citation standard | Dereferenceable sources |
+| **CloudEvents** | Temporal grounding | Event history retrieval |
+| **docs/ hierarchy** | Structured knowledge | Domain-specific RAG |
+
+**Recommendation**: Implement **HybridRAG** using Jerry's existing property graph as the graph retrieval layer and add lightweight vector indexing for `docs/`.
+
+### 2. Integration with Claude Code Agents
+
+**Current State**: Claude Code agents operate with:
+- Training data (cutoff: January 2025)
+- Conversation context window
+- File reads during session
+
+**Enhanced with RAG**:
+- Jerry knowledge base accessible during inference
+- Work Tracker state traversable for decision-making
+- Historical decisions retrievable from `docs/experience/`
+- Skill orchestration grounded in past executions
+
+**Implementation Path**:
+
+```python
+# Proposed: RAG-Enhanced Agent Tool
+class JerryKnowledgeRetriever:
+    """
+    Tool for Claude Code agents to retrieve Jerry knowledge.
+    """
+
+    def search_knowledge(
+        self,
+        query: str,
+        domains: List[str] = ["all"],
+        max_results: int = 5,
+        include_graph: bool = True
+    ) -> List[RetrievalResult]:
+        """
+        Retrieve knowledge from Jerry's hybrid RAG system.
+
+        Args:
+            query: Natural language query
+            domains: Filter by domain (work-tracker, research, experience, etc.)
+            max_results: Top-k results to return
+            include_graph: Enable graph traversal (GraphRAG)
+
+        Returns:
+            List of retrieval results with Jerry URI citations
+        """
+        pass
+```
+
+**Usage in Agent Prompts**:
+
+```markdown
+You are the ps-researcher agent. You have access to Jerry's knowledge base via RAG.
+
+Before answering, use the JerryKnowledgeRetriever tool to search for:
+- Prior research on this topic (domain: research)
+- Related work items (domain: work-tracker)
+- Past experiences and lessons (domain: experience)
+
+Always cite sources using Jerry URIs.
+```
+
+### 3. Mitigating Context Rot
+
+**Context Rot Problem**: LLM performance degrades as context window fills, even within technical limits.
+
+**Jerry's RAG Solution**:
+
+1. **Offload to Retrieval**: Instead of keeping all knowledge in context, retrieve on-demand
+2. **Persistent State**: Work Tracker state persisted in graph, not held in memory
+3. **Selective Injection**: Only inject relevant context based on query
+4. **Citation Trails**: Jerry URIs enable following citation chains without context bloat
+
+**Example**:
+
+```
+Without RAG (context bloat):
+- System prompt: 2K tokens
+- Work Tracker state: 10K tokens
+- Research docs: 15K tokens
+- Conversation: 5K tokens
+Total: 32K tokens → Context rot risk
+
+With RAG (selective retrieval):
+- System prompt: 2K tokens
+- Retrieved context (top-5): 3K tokens
+- Conversation: 5K tokens
+Total: 10K tokens → Fresh context
+```
+
+### 4. Enabling Semantic Search Across Jerry Artifacts
+
+**Current**: File navigation by path, Glob patterns, Grep search
+**Enhanced**: Semantic search across all Jerry artifacts
+
+**Use Cases**:
+
+| Query | Traditional Approach | RAG Approach |
+|-------|---------------------|--------------|
+| "Find research on graph databases" | Grep for "graph database" in docs/ | Semantic search retrieves all related docs |
+| "What tasks are blocked?" | Parse Work Tracker JSON manually | Graph traversal: `DEPENDS_ON` edges |
+| "Show me similar past decisions" | Manual file browsing | Vector similarity on `docs/experience/` |
+| "What did we learn about RAG?" | Grep for "RAG" | Retrieve experience + research + code |
+
+### 5. Recommendations for Jerry Development
+
+#### Immediate (Phase 1)
+
+1. **Add `embedding` field to EntityBase**:
+   ```python
+   @dataclass
+   class EntityBase:
+       embedding: Optional[List[float]] = None
+       embedding_model: str = "text-embedding-3-small"
+   ```
+
+2. **Create vector index for `docs/`**:
+   - Use lightweight solution (ChromaDB, Qdrant, or in-memory)
+   - Index all markdown files on write
+   - Store embeddings alongside documents (TOON format)
+
+3. **Extend Claude Code agent prompts**:
+   - Add "search Jerry knowledge base" instruction
+   - Provide citation format using Jerry URIs
+
+#### Short-term (Phase 2)
+
+4. **Implement HybridRAG retrieval**:
+   - Vector retrieval for semantic search
+   - Graph traversal for relational queries
+   - Context merger combining both
+
+5. **Add grounding verification**:
+   - Integrate MiniCheck or lightweight fact-checker
+   - Log verification results as CloudEvents
+   - Emit warnings on unsupported claims
+
+6. **Create RAG skill**:
+   - `skills/rag/SKILL.md` for knowledge retrieval orchestration
+   - Playbook for when to use vector vs. graph retrieval
+
+#### Long-term (Phase 3)
+
+7. **Migrate to production RAG stack**:
+   - Evaluate Weaviate, Qdrant, or Pinecone for vector DB
+   - Consider Neo4j for graph layer if file-based graph insufficient
+   - Benchmark retrieval latency and accuracy
+
+8. **Enable real-time grounding**:
+   - Integrate web search tool (like Claude 3.5+)
+   - Combine Jerry knowledge + web search for comprehensive grounding
+
+9. **Build RAG analytics**:
+   - Track retrieval quality metrics
+   - Analyze hallucination rates
+   - Measure grounding verification accuracy
+
+### 6. Alignment with Netflix UDA Pattern
+
+Jerry's **"EntityBase → Multiple Representations"** pattern aligns with Netflix's **"Model Once, Represent Everywhere"** (see `GRAPH_DATA_MODEL_ANALYSIS.md`, DISC-064).
+
+**Extension for RAG**:
+
+```
+EntityBase (Domain Model)
+    ├─ JSON (Persistence)
+    ├─ TOON (Human-readable)
+    ├─ GraphSON (Graph export)
+    ├─ RDF (Semantic Web)
+    └─ EMBEDDING (Vector retrieval)  ← NEW
+```
+
+This ensures Jerry entities are **both graph-traversable and vector-searchable**, enabling HybridRAG without dual modeling.
+
+---
+
+## 5W1H Research Framework (Answered)
+
+### 1. WHAT techniques ground LLMs in factual knowledge?
+
+**Answer**:
+- **RAG (Retrieval-Augmented Generation)**: Traditional, Self-RAG, Long RAG
+- **GraphRAG**: Knowledge graph-based retrieval with multi-hop reasoning
+- **HybridRAG**: Vector + Graph combination
+- **Grounding Verification**: MiniCheck, FACTS Grounding benchmark
+- **Constitutional AI**: Principle-based training (Anthropic)
+- **Quote-First Strategy**: Extract quotes before reasoning (Claude)
+
+### 2. WHY is knowledge grounding important for accuracy and reliability?
+
+**Answer**:
+- **Reduces hallucinations**: 90% reduction (FalkorDB case study)
+- **Enables fresh data**: Access to post-training knowledge
+- **Improves accuracy**: 49% → 86% (Amazon Finance)
+- **Provides transparency**: Citations enable verification
+- **Reduces training costs**: Update knowledge without retraining
+- **Domain specialization**: Incorporate proprietary knowledge bases
+
+### 3. WHO are the leading researchers?
+
+**Answer**:
+- **Microsoft Research**: GraphRAG architecture
+- **Google DeepMind**: FACTS Grounding benchmark, Gemini grounding
+- **Anthropic**: Constitutional AI, quote-first strategy, Claude web search
+- **OpenAI**: GPT RAG patterns, retrieval for GPTs
+- **Neo4j**: LLM Knowledge Graph Builder
+- **FalkorDB**: GraphRAG SDK
+- **Academic**: Tang et al. (MiniCheck), Branzan (production systems)
+
+### 4. WHEN should you use retrieval vs embedding vs hybrid approaches?
+
+**Answer**:
+
+| Scenario | Recommended Approach | Rationale |
+|----------|---------------------|-----------|
+| **Simple facts** | Vector RAG | Fast, semantic similarity sufficient |
+| **Multi-hop reasoning** | GraphRAG | Relational traversal required |
+| **Complex enterprise** | HybridRAG | Best of both worlds |
+| **Real-time data** | Web search + RAG | Fresh information needed |
+| **Long documents** | Long RAG | Context preservation |
+| **Self-critique needed** | Self-RAG | Reliability critical |
+| **Healthcare/Legal** | Long RAG + Self-RAG | Accuracy and context critical |
+| **E-commerce** | Hybrid search + API | Real-time inventory + semantic search |
+
+### 5. WHERE has knowledge grounding succeeded in production?
+
+**Answer**:
+- **FalkorDB**: 90% hallucination reduction, <50ms latency
+- **LinkedIn**: 63% faster ticket resolution (40hrs → 15hrs)
+- **Amazon Finance**: 49% → 86% accuracy improvement
+- **Accenture**: 50% reduced training time, 40% fewer escalations
+- **Cedars-Sinai AlzKB**: Biomedical multi-hop reasoning
+- **300-320% ROI** across finance, healthcare, manufacturing (2025 industry data)
+
+### 6. HOW do you integrate knowledge graphs with LLM inference?
+
+**Answer**:
+
+**Indexing Phase** (Offline):
+1. Extract entities/relationships from documents using LLM
+2. Build knowledge graph (Property Graph or RDF)
+3. Apply hierarchical clustering (e.g., Leiden algorithm)
+4. Generate community summaries bottom-up
+
+**Query Phase** (Runtime):
+1. Parse query for entity mentions
+2. Perform graph traversal from entity nodes (local retrieval)
+3. OR use community summaries for holistic view (global retrieval)
+4. Combine graph context with vector retrieval (HybridRAG)
+5. Inject into LLM prompt
+6. Generate response with citations
+7. Optionally verify grounding (MiniCheck/FACTS)
+
+**Technologies**:
+- Graph DB: Neo4j, Amazon Neptune, Memgraph, FalkorDB
+- Vector DB: Pinecone, Weaviate, Qdrant, ChromaDB
+- Graph Query: Gremlin (TinkerPop), Cypher (Neo4j), SPARQL (RDF)
+- Embeddings: OpenAI text-embedding-3, Google text-embedding-gecko
+- Frameworks: LangChain, LlamaIndex, Haystack
+
+---
+
+## Architecture Diagrams
+
+### Diagram 1: RAG Pipeline (Traditional)
+
+See Section L1.1.1 above.
+
+### Diagram 2: GraphRAG Flow
+
+See Section L1.1.4 above.
+
+### Diagram 3: HybridRAG Integration
+
+See Section L1.1.5 above.
+
+### Diagram 4: Jerry + Claude Code Grounding Pattern
+
+See Section L1.4.1 above.
+
+---
+
+## Sources Table
+
+| ID | Source | Type | URL |
+|----|--------|------|-----|
+| S-001 | EdenAI: 2025 Guide to RAG | Industry | https://www.edenai.co/post/the-2025-guide-to-retrieval-augmented-generation-rag |
+| S-002 | Medium: 2025 RAG Retrieval Methods | Industry | https://medium.com/@mehulpratapsingh/2025s-ultimate-guide-to-rag-retrieval-how-to-pick-the-right-method-and-why-your-ai-s-success-2cedcda99f8a |
+| S-003 | ArXiv: Enhancing RAG Best Practices | Academic | https://arxiv.org/abs/2501.07391 |
+| S-004 | Prompt Engineering Guide: RAG | Industry | https://www.promptingguide.ai/research/rag |
+| S-005 | Microsoft Research: GraphRAG | Industry | https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/ |
+| S-006 | Microsoft GraphRAG Docs | Documentation | https://microsoft.github.io/graphrag/ |
+| S-007 | FalkorDB: Knowledge Graphs for LLMs | Industry | https://www.falkordb.com/blog/glossary/knowledge-graph-llms-graphrag/ |
+| S-008 | Medium: Production-Ready Graph Systems | Industry | https://medium.com/@claudiubranzan/from-llms-to-knowledge-graphs-building-production-ready-graph-systems-in-2025-2b4aff1ec99a |
+| S-009 | Neo4j: LLM Knowledge Graph Builder | Industry | https://neo4j.com/blog/developer/llm-knowledge-graph-builder-release/ |
+| S-010 | NVIDIA: LLM-Driven Knowledge Graphs | Industry | https://developer.nvidia.com/blog/insights-techniques-and-evaluation-for-llm-driven-knowledge-graphs/ |
+| S-011 | ArXiv: MiniCheck | Academic | https://arxiv.org/abs/2404.10774 |
+| S-012 | Google DeepMind: FACTS Grounding | Industry | https://deepmind.google/blog/facts-grounding-a-new-benchmark-for-evaluating-the-factuality-of-large-language-models/ |
+| S-013 | Anthropic: Claude Opus 4 System Card | Industry | https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf |
+| S-014 | Claude Docs: Reduce Hallucinations | Documentation | https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations |
+| S-015 | OpenAI Help: RAG for GPTs | Documentation | https://help.openai.com/en/articles/8868588-retrieval-augmented-generation-rag-and-semantic-search-for-gpts |
+| S-016 | Medium: ChatGPT RAG Guide 2025 | Industry | https://medium.com/@illyism/chatgpt-rag-guide-2025-build-reliable-ai-with-retrieval-0f881a4714af |
+| S-017 | ArXiv: HybridRAG Paper | Academic | https://arxiv.org/abs/2408.04948 |
+| S-018 | Memgraph: Why HybridRAG | Industry | https://memgraph.com/blog/why-hybridrag |
+| S-019 | RAG About It: Enterprise Guide | Industry | https://ragaboutit.com/how-to-build-hybrid-rag-systems-with-vector-and-knowledge-graph-integration-the-complete-enterprise-guide/ |
+| S-020 | Neo4j: RAG Tutorial | Tutorial | https://neo4j.com/blog/developer/rag-tutorial/ |
+| S-021 | ZenML: LLMOps Case Studies | Industry | https://www.zenml.io/blog/llmops-in-production-457-case-studies-of-what-actually-works |
+| S-022 | GitHub: GenAI Case Studies | Repository | https://github.com/themanojdesai/genai-llm-ml-case-studies |
+| S-023 | Nexos: What is LLM Grounding | Industry | https://nexos.ai/blog/what-is-llm-grounding/ |
+
+---
+
+## Key Discoveries
+
+| ID | Discovery | Category | Impact |
+|----|-----------|----------|--------|
+| DISC-069 | **HybridRAG outperforms vector-only and graph-only RAG** | Architecture | Jerry should implement hybrid approach |
+| DISC-070 | **MiniCheck achieves GPT-4 accuracy at 400x lower cost** | Tooling | Grounding verification is economically feasible |
+| DISC-071 | **90% hallucination reduction with GraphRAG** (FalkorDB) | Performance | Graph-based retrieval dramatically improves reliability |
+| DISC-072 | **Jerry's property graph model is RAG-ready** | Architecture | Existing graph infrastructure can support GraphRAG |
+| DISC-073 | **Self-RAG reduces unnecessary retrievals** | Architecture | Query-time decision-making improves efficiency |
+| DISC-074 | **Quote-first strategy reduces hallucinations** (Anthropic) | Technique | Applicable to Jerry's long document processing |
+| DISC-075 | **LLM-powered KG construction reached production maturity** (2024-2025) | Industry | Jerry can leverage LLMs for graph construction |
+| DISC-076 | **300-320% ROI for KG-grounded systems** | Business | Strong business case for Jerry RAG investment |
+
+---
+
+## Recommendations for Jerry (Summary)
+
+### Immediate Actions
+
+1. ✅ **Add embedding support to EntityBase** for vector retrieval
+2. ✅ **Index `docs/` with lightweight vector DB** (ChromaDB/in-memory)
+3. ✅ **Extend agent prompts** with Jerry knowledge retrieval instructions
+
+### Short-term Actions
+
+4. ✅ **Implement HybridRAG** combining vector + graph retrieval
+5. ✅ **Integrate MiniCheck** for grounding verification
+6. ✅ **Create RAG skill** (`skills/rag/SKILL.md`)
+
+### Long-term Actions
+
+7. ✅ **Evaluate production RAG stack** (Weaviate, Qdrant, Neo4j)
+8. ✅ **Enable web search integration** (like Claude 3.5+)
+9. ✅ **Build RAG analytics** for retrieval quality monitoring
+
+### Architectural Principles
+
+- **Leverage existing graph model**: Jerry's property graph is GraphRAG-ready
+- **Use Jerry URIs for citations**: Dereferenceable, content-addressable sources
+- **Follow Netflix UDA pattern**: EntityBase → multiple representations including embeddings
+- **Persist retrieval context**: Enable reproducibility and debugging
+- **Verify grounding**: Use lightweight fact-checking to maintain quality
+
+---
+
+## Validation Status
+
+| Category | Status | Score |
+|----------|--------|-------|
+| 5W1H COVERAGE | ✅ COMPLETE | 6/6 |
+| L0/L1/L2 SECTIONS | ✅ COMPLETE | 3/3 |
+| AUTHORITATIVE SOURCES | ✅ COMPLETE | 23 sources |
+| ARCHITECTURE DIAGRAMS | ✅ COMPLETE | 4 diagrams |
+| PRODUCTION CASE STUDIES | ✅ COMPLETE | 5 case studies |
+| JERRY INTEGRATION | ✅ COMPLETE | Specific recommendations |
+
+**Quality Status:** DECISION-GRADE
+
+---
+
+## Related Documents
+
+- `docs/research/GRAPH_DATA_MODEL_ANALYSIS.md` - Jerry's property graph foundation
+- `docs/specifications/JERRY_URI_SPECIFICATION.md` - URI scheme for citations
+- `docs/governance/JERRY_CONSTITUTION.md` - P-001 (Truth and Accuracy), P-002 (File Persistence)
+- `.claude/agents/ps-researcher.md` - Research agent specification
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-08*
+*Author: Claude (ps-researcher agent v2.0.0)*
+*Status: DECISION-GRADE*
+
+---
+
+### Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-08 | Initial research document: RAG patterns, GraphRAG, HybridRAG, grounding verification, Jerry integration strategy |

--- a/docs/archive/projects-archive/research/work-032-e-001-km-fundamentals.md
+++ b/docs/archive/projects-archive/research/work-032-e-001-km-fundamentals.md
@@ -1,0 +1,802 @@
+# Knowledge Management Fundamentals Research
+
+**PS ID:** work-032
+**Entry ID:** e-001
+**Topic:** Knowledge Management Fundamentals
+**Date:** 2026-01-08
+**Researcher:** ps-researcher v2.0.0
+
+---
+
+## L0: Executive Summary (ELI5)
+
+**What is Knowledge Management?**
+
+Imagine your brain stores two types of memories: things you can easily explain (like how to spell your name) and things you "just know" but can't easily describe (like how to ride a bike). Knowledge Management (KM) helps organizations collect, organize, and share both types of knowledge so teams work smarter.
+
+**Why does it matter?**
+
+Companies waste about 20% of their time—one full day per week—just searching for information or asking colleagues for help. Good KM fixes this by making knowledge easy to find and share, which makes teams faster, smarter, and more innovative.
+
+**The Big Idea:**
+
+Knowledge is like a spiral. When people share experiences (tacit knowledge) and write things down (explicit knowledge), and then others read and apply them, new knowledge is created. This cycle keeps repeating, making the whole organization smarter over time.
+
+---
+
+## L1: Technical Details
+
+### 1. WHAT is Knowledge Management?
+
+#### Authoritative Definitions
+
+**Davenport & Prusak (1998):** "Knowledge management is the process of applying a systematic approach to the capture, structure, management, and dissemination of knowledge throughout an organization in order to work faster, reuse best practices, and reduce costly rework from project to project."
+
+**ISO 30401:2018:** Knowledge Management is "a management system that promotes and enables value-creation through knowledge" by establishing, implementing, maintaining, reviewing and improving an effective management system for knowledge management in organizations.
+
+**Gartner:** "A declaration of how the enterprise will use knowledge to compete, and how knowledge management will support the enterprise's business strategies."
+
+#### Core Distinction: Explicit vs. Tacit Knowledge
+
+The foundational concept in KM theory, introduced by **Ikujiro Nonaka and Hirotaka Takeuchi**, distinguishes two fundamental types of knowledge:
+
+**Tacit Knowledge:**
+- Subjective, experience-based knowledge
+- Cannot be easily expressed in words, sentences, numbers, or formulas
+- Context-specific
+- Includes cognitive skills (beliefs, images, intuition, mental models)
+- Includes technical skills (craft, know-how)
+- Example: "Knowing how to ride a bicycle"
+
+**Explicit Knowledge:**
+- Objective, rational knowledge
+- Can be expressed in words, sentences, numbers, or formulas
+- Context-free
+- Can be easily documented and shared
+- Example: "The manual for bicycle assembly"
+
+### 2. WHY is Knowledge Management Important?
+
+#### Business Value & Competitive Advantage
+
+**McKinsey Research (1987-present):**
+- Employees spend an average of **20% of their workweek** searching for internal information or tracking down colleagues
+- For a 1,000-person company with $60K average salary, this represents **$12M annually** spent just searching for information
+- McKinsey first used the term "knowledge management" in its current management context in 1987
+
+**Gartner Impact Metrics:**
+- **10-20% improvement** in customer satisfaction
+- **15-25% increase** in employee productivity
+- **20-30% increase** in revenue
+- KM plays a "foundational role in optimizing service delivery and maximizing the ROI from investments in GenAI"
+
+**Forrester Analysis (Q4 2024):**
+- KM has a "critical function in sustaining competitive advantage and cultivating a culture of ongoing improvement"
+- Strategic KM reduces inefficiencies, accelerates onboarding, and preserves valuable organizational knowledge
+- Nearly **half of employees** lack the ability to search for existing insights (Data Culture & Literacy Survey, 2023)
+
+**Additional Industry Metrics:**
+- Organizations deploying AI-powered KM solutions experience **35% improvement in efficiency**
+- Firms with strong knowledge-sharing cultures achieve **3.9 times the revenue growth** compared to competitors
+- Knowledge Management ROI encompasses financial and non-financial returns through improved efficiency, reduced costs, enhanced innovation, better decision-making, and increased competitive advantage
+
+**Strategic Perspective (Senge, 1990):**
+> "In the long run, the only sustainable competitive advantage is your organization's ability to learn faster than the competition."
+
+### 3. WHO are the Key Thought Leaders?
+
+#### Foundational Theorists
+
+**1. Ikujiro Nonaka & Hirotaka Takeuchi**
+- **Key Work:** *The Knowledge-Creating Company* (1995)
+- **Contribution:** SECI Model of knowledge conversion
+- **Impact:** Established the theoretical landmark for most KM conceptualization
+- **Core Concept:** Knowledge is created through dynamic interaction between tacit and explicit knowledge
+
+**2. Thomas H. Davenport & Laurence Prusak**
+- **Key Work:** *Working Knowledge: How Organizations Manage What They Know* (1998)
+- **Award:** Library Journal's Best Business Book (1997)
+- **Contribution:** Established fundamental principles and enduring vocabulary for the emerging KM field
+- **Context:** Davenport (MIT Sloan) shifted from business process innovation to KM in late 1990s; Prusak (IBM) served as worldwide KM competency leader
+- **Core Insight:** "Knowledge management must move way beyond the implementation of an efficient IT system"—culture, employee behaviors, reward systems, and leadership support are equally critical
+
+**3. Etienne Wenger**
+- **Key Work:** *Situated Learning* (1991, with Jean Lave); *Communities of Practice: Learning, Meaning, and Identity* (1998); *Cultivating Communities of Practice* (2002)
+- **Contribution:** Developed the Communities of Practice (CoP) framework
+- **Impact:** Shifted KM focus from information systems to people and social structures
+- **Core Concept:** "A group of people who share a concern or a passion for something they do and learn how to do it better as they interact regularly"
+
+**4. Peter M. Senge**
+- **Key Work:** *The Fifth Discipline: The Art & Practice of the Learning Organization* (1990)
+- **Impact:** Called "one of the seminal management books of the past seventy-five years" by Harvard Business Review; sold over 1 million copies
+- **Contribution:** Five Disciplines framework (Personal Mastery, Mental Models, Shared Vision, Team Learning, Systems Thinking)
+- **Recognition:** Named one of the 24 people with "the greatest influence on business strategy over the last 100 years" (Journal of Business Strategy)
+- **Core Concept:** Learning organizations are "organizations where people continually expand their capacity to create the results they truly desire"
+
+#### Other Notable Contributors
+- **Michael Polanyi** (1958): First articulated tacit knowledge concept
+- **Karl Wiig** (1993): KM framework based on creation, manifestation, use, and transfer
+- **Michael Zack** (1999): KM cycle model (acquisition, refinement, storage/retrieval, distribution, presentation/use)
+- **Wanda Bukowitz & Ruth Williams**: Process framework for generating, maintaining, and expanding strategic knowledge stock
+- **Maryam Alavi & Dorothy Leidner** (2001): Information systems perspective on KM roles
+
+### 4. WHEN did Knowledge Management Emerge?
+
+#### Historical Evolution
+
+**Pre-1990s: Conceptual Foundations**
+- **1958:** Michael Polanyi introduces tacit knowledge concept
+- **1987:** McKinsey first uses "knowledge management" in current management context
+- **Late 1980s:** Initial focus on information systems and databases (with "disappointing results")
+
+**1990s: Discipline Formalization**
+- **1991:** Lave & Wenger coin "Communities of Practice"
+- **1990:** Peter Senge publishes *The Fifth Discipline*
+- **1993:** Karl Wiig develops early KM framework
+- **1995:** Nonaka & Takeuchi publish *The Knowledge-Creating Company*
+- **1996:** Spender and Grant make major academic contributions
+- **1998:** Davenport & Prusak publish *Working Knowledge*
+- **1998:** Wenger publishes *Communities of Practice: Learning, Meaning, and Identity*
+- **Late 1990s:** Shift from system-focused to people-focused approaches
+
+**2000s: Maturation & Standardization**
+- **2001:** Alavi & Leidner consolidate information systems perspective
+- **2002:** Wenger, McDermott & Snyder publish *Cultivating Communities of Practice*
+- **Mid-2000s:** Recognition of KM as highly multidisciplinary field (organizational science, cognitive science, linguistics, information technologies, library science)
+
+**2010s-Present: Integration & AI Era**
+- **2018:** ISO 30401 Knowledge Management Systems standard published
+- **2022-2024:** ISO 30401 amendments (Amd 1:2022, Amd 2:2024)
+- **2024:** Forrester Wave™: Knowledge Management Solutions (Q4 2024)
+- **2025-2026:** GenAI integration becomes critical; KM recognized as foundational for AI/ML applications
+
+### 5. WHERE is Knowledge Management Applied?
+
+#### Industry-Specific Applications
+
+**Healthcare**
+- **Use Cases:** Clinical protocols, treatment guidelines, case studies, regulatory updates, electronic health records (EHR), clinical decision support systems
+- **Impact:** Improves patient care quality, reduces medical errors, enables evidence-based decision making, produces better patient outcomes
+- **Example:** AI-powered KM analyzes patient records to improve diagnostics
+
+**Finance & Banking**
+- **Use Cases:** Compliance documents, credit policies, audit procedures, financial regulations, risk management
+- **Impact:** Aids employee awareness, supports audits, suggests best approaches to new cases based on past precedents
+- **Example:** Banks use KM systems to track regulatory compliance and precedent-based decision making
+
+**Manufacturing & Engineering**
+- **Use Cases:** Design manuals, maintenance procedures, safety protocols, Standard Operating Procedures (SOPs)
+- **Impact:** Reduces downtime, improves operational efficiency, aids frontline workers and engineers
+- **Example:** Manufacturing firms document SOPs in KM systems for consistent process execution
+
+**Technology & Software**
+- **Use Cases:** Technical documentation, code repositories, API documentation, troubleshooting guides
+- **Impact:** Enables AI/ML applications, provides foundation for intelligent search, auto-tagging, predictive recommendations
+- **Critical Role:** "By organizing and structuring enterprise data, knowledge management provides the foundation for machine learning and AI tools to perform analytics and automate decision-making"
+
+**Professional Services (Consulting, Legal)**
+- **Use Cases:** Project methodologies, client case histories, legal precedents, best practice libraries
+- **Example:** McKinsey, World Bank, Shell, DaimlerChrysler have leveraged CoPs to drive strategy and transfer best practices
+
+#### Cross-Industry Applications
+
+**Compliance & Regulatory Management**
+- Critical in heavily regulated industries (finance, healthcare, government)
+- Centralized tracking of compliance documentation, training records, regulatory updates
+- Ensures employees are informed of relevant regulations
+
+**Innovation & R&D**
+- Captures research findings, experimental results, lessons learned
+- Accelerates innovation cycles through knowledge reuse
+
+**Customer Service & Support**
+- Knowledge bases, FAQ systems, chatbots, self-service portals
+- Gartner: "Interest in modern customer service knowledge management systems continues to grow"
+
+**Talent Development & Onboarding**
+- Accelerates employee onboarding, preserves knowledge from retiring experts
+- Develops professional skills, retains top talent
+
+### 6. HOW is Knowledge Management Implemented?
+
+#### A. The SECI Model (Nonaka & Takeuchi)
+
+The **SECI Model of Knowledge Creation** explains how tacit and explicit knowledge are converted into organizational knowledge through four modes:
+
+**1. Socialization (Tacit → Tacit)**
+- Process of spreading tacit knowledge through shared experience
+- Occurs through spending time together, working in same environment, informal social meetings
+- Example: Apprenticeship, mentoring, job shadowing
+
+**2. Externalization (Tacit → Explicit)**
+- Process of making tacit knowledge explicit
+- Knowledge is crystallized and can be shared by others, becoming basis of new knowledge
+- Example: Writing documentation, creating process guides, storytelling
+
+**3. Combination (Explicit → Explicit)**
+- Process of converting explicit knowledge into more complex and systematic sets
+- Explicit knowledge is collected, combined, edited, or processed to form new knowledge
+- Example: Data analysis, report compilation, database integration
+
+**4. Internalization (Explicit → Tacit)**
+- Process of converting explicit knowledge into tacit knowledge
+- Example: Training programs where employees read about jobs and incorporate ideas through reflection into tacit knowledge base
+
+**The Knowledge Spiral:**
+Knowledge creation is a continual process where the four modes form an evolving spiral. Knowledge is amplified through ontological levels (individual → group → organization), creating dynamic and continuous epistemological and ontological interaction.
+
+**The Concept of "Ba" (Nonaka & Konno):**
+- Japanese concept meaning "place" or shared context
+- Unifies physical space (office), virtual space (email, digital platforms), and mental space (shared ideas)
+- Provides the context where knowledge is shared, created, and utilized
+
+#### B. Knowledge Lifecycle Frameworks
+
+**Unified Framework: K-TSACA Model**
+Analysis of 20 prominent KM lifecycle frameworks identified five core processes:
+1. **Knowledge Transfer**
+2. **Knowledge Storage**
+3. **Knowledge Application**
+4. **Knowledge Creation**
+5. **Knowledge Acquisition**
+
+**Alavi & Leidner Framework (2001) - Information Systems Perspective:**
+Four KM roles for information systems:
+1. **Knowledge Creation** (data warehousing)
+2. **Knowledge Storage & Retrieval** (multimedia databases, query languages)
+3. **Knowledge Transfer** (collaboration platforms like Lotus Notes)
+4. **Knowledge Application** (decision support systems)
+
+**Meyer & Zack Model (1999):**
+- Introduced critical **refinement phase**
+- First to propose critically assessing knowledge before passing to next processing phase
+- Stages: acquisition → refinement → storage/retrieval → distribution → presentation/use
+
+**Common Lifecycle Stages:**
+1. **Knowledge Creation/Acquisition** - Generating new knowledge or obtaining existing knowledge
+2. **Knowledge Capture** - Documenting and recording knowledge
+3. **Knowledge Refinement** - Validating, organizing, and improving knowledge quality
+4. **Knowledge Storage** - Persisting knowledge in repositories, databases, or systems
+5. **Knowledge Distribution/Transfer** - Sharing knowledge across individuals and teams
+6. **Knowledge Presentation** - Formatting knowledge for accessibility and usability
+7. **Knowledge Application** - Using knowledge to solve problems and make decisions
+
+#### C. ISO 30401:2018 Standard
+
+**Purpose:**
+Sets requirements and provides guidelines for establishing, implementing, maintaining, reviewing and improving an effective management system for knowledge management in organizations.
+
+**Scope:**
+- Applicable to any organization, regardless of type, size, products, or services
+- Establishes KM principles and requirements
+- Provides basis for auditing, certifying, evaluating, and recognizing competent organizations
+
+**Key Principles:**
+1. **Value Creation:** Ensuring knowledge contributes to business success
+2. **Leadership and Culture:** Encouraging a culture of knowledge sharing
+3. **Governance and Measurement:** Establishing clear policies and metrics
+4. **Risk and Opportunity Management:** Identifying knowledge risks and opportunities
+
+**Implementation Steps:**
+1. Prepare a knowledge management plan (objectives, actions, resources)
+2. Identify critical knowledge areas and assets
+3. Implement processes to capture explicit and tacit knowledge
+4. Establish mechanisms and platforms for sharing knowledge
+5. Promote collaboration and culture of openness
+6. Measure, review, and improve continuously
+
+**Publication History:**
+- **Edition 1:** November 2018 (20 pages)
+- **Amendment 1:** ISO 30401:2018/Amd1:2022
+- **Amendment 2:** ISO 30401:2018/Amd2:2024
+- **Draft Revision:** Currently under committee review
+- **Technical Committee:** ISO/TC 260
+
+#### D. Communities of Practice (Wenger)
+
+**Definition:** "A group of people who share a concern or a passion for something they do and learn how to do it better as they interact regularly"
+
+**Three Dimensions of Practice (Wenger):**
+1. **Domain:** Creates common ground, inspires participation, guides learning
+2. **Community:** Creates the social fabric for learning, fosters interactions, encourages collaboration
+3. **Practice:** Shared repertoire of resources (tools, stories, ways of addressing problems)
+
+**Four Dualities:**
+1. **Participation-Reification** (particular focus in KM)
+2. **Designed-Emergent**
+3. **Identification-Negotiability**
+4. **Local-Global**
+
+**Key Insight:**
+Traditional KM approaches attempt to capture existing knowledge within formal systems (databases). CoPs address the kind of dynamic "knowing" that makes a difference in practice through participation of people fully engaged in creating, refining, communicating, and using knowledge.
+
+**Organizational Benefits:**
+- Drive strategy
+- Generate new business opportunities
+- Solve problems
+- Transfer best practices
+- Develop professional skills
+- Recruit and retain top talent
+
+**Critical Success Factors:**
+- Management interest and support
+- Appropriate reward systems
+- Supportive work processes
+- Knowledge-sharing culture
+- Enabling company policies
+
+#### E. Learning Organizations (Senge)
+
+**Five Disciplines:**
+
+1. **Personal Mastery:** "A discipline of continually clarifying and deepening our personal vision, of focusing our energies, of developing patience, and of seeing reality objectively"
+
+2. **Mental Models:** "Deeply ingrained assumptions, generalizations, or even pictures of images that influence how we understand the world and how we take action"
+
+3. **Building Shared Vision:** "A practice of unearthing shared pictures of the future that foster genuine commitment and enrollment rather than compliance"
+
+4. **Team Learning:** "Starts with 'dialogue', the capacity of members of a team to suspend assumptions and enter into genuine 'thinking together'"
+
+5. **Systems Thinking (The Fifth Discipline):** Integrates the other four disciplines into a coherent body of theory and practice
+
+**Core Philosophy:**
+- People are active participants in shaping their reality, not helpless reactors
+- Shift from seeing parts to seeing wholes
+- Collective aspiration and continuous learning
+- In knowledge-based economies, organizations with best chance to succeed are those that "generate, communicate, and leverage their intellectual assets"
+
+### 7. Key Concepts Deep Dive
+
+#### A. Organizational Learning Relationship
+
+**Connection to Knowledge Management:**
+Organizational culture is "the most significant factor for effective organizational learning and knowledge sharing, since it determines beliefs, values, attitudes and processes that can facilitate or impede the process of learning" (Oliver & Kandadi, 2006; Gold et al., 2001; Alavi & Leidner, 2001).
+
+**Relationship:**
+- **Organizational Learning** is the process by which organizations acquire, create, and transfer knowledge
+- **Knowledge Management** provides the systems, processes, and infrastructure to enable and scale organizational learning
+- Both are mutually reinforcing: KM enables learning; learning generates knowledge
+
+#### B. Communities of Practice (Expanded)
+
+**Key Publications (Wenger):**
+- *Situated Learning* (1991) - where "community of practice" was coined
+- *Communities of Practice: Learning, Meaning, and Identity* (1998) - Cambridge University Press
+- *Cultivating Communities of Practice: A Guide to Managing Knowledge* (2002, with McDermott & Snyder) - Harvard Business School Press
+
+**Structural Characteristics:**
+- **Domain:** Creates common ground and sense of common identity
+- **Community:** Creates social fabric enabling learning through interaction and relationships
+- **Practice:** Shared repertoire of communal resources
+
+**Organizational Challenges:**
+- CoPs "still do not fit very easily within traditional hierarchical organization"
+- Concepts like self-governance, voluntary participation, personal meaning, identity, boundary crossing, and peer-to-peer connections are "slowly reshaping the discourse on knowledge and learning"
+- Many traditionally hierarchical organizations now show genuine interest in fostering horizontal communities and networks
+
+#### C. Knowledge Assets and Intellectual Capital
+
+**Intellectual Capital Components:**
+In knowledge-based economies (mid-to-late 1990s emergence), intellectual capital includes:
+- Knowledge repositories
+- Relationships and networks
+- Information technologies and infrastructure
+- Communications infrastructure
+- Functional skill sets
+- Process know-how
+- Environmental responsiveness
+- Organizational intelligence
+- External knowledge sources
+
+**Strategic Value:**
+- Organizations with best chance to succeed are those that "generate, communicate, and leverage their intellectual assets"
+- Knowledge is "the only sustainable source of competitive advantage" (Davenport & Prusak)
+- Focus areas include: enhancing brand recognition, developing intellectual capital and knowledge, delivering product innovation
+
+#### D. Barriers to Knowledge Management
+
+**Primary Barriers (Cultural > Technological):**
+
+**1. Knowledge Hoarding**
+- Employees withhold information to maintain control, job security, or competitive advantage
+- Motivations: competition, fear, leverage
+- Often traced to organizational culture that unintentionally encourages such behavior
+
+**2. Organizational Silos**
+- Knowledge restricted within teams rather than across organization
+- Hinders cross-functional learning and innovation
+- Results from culture that doesn't prioritize collaboration or transparency
+
+**3. Lack of Trust**
+- Fear that sharing knowledge reduces individual value
+- Reluctance to share when trust is absent
+- Critical: "A culture of trust is crucial to knowledge sharing"
+
+**4. Technological Barriers**
+- Systems don't integrate or aren't compatible
+- Lack of immediate technical support and maintenance
+- Don't meet employee expectations
+- Users don't know how, when, and why to use each tool
+
+**5. Lack of Incentives**
+- Absence of rewards system beyond compelling goals
+- Lack of clarity on incentives for individuals, teams, or organization
+- Approximately half of nonprofits surveyed experience this problem
+
+**Overcoming Strategies:**
+- Lead by example (senior leaders visibly sharing insights, including failures)
+- Make sharing intrinsic and natural, not forced
+- Celebrate learning from mistakes
+- Embed sharing in organizational values
+- Break down silos
+- Recognize contributors
+- Provide meaningful incentives
+
+**Critical Insight:**
+"Cultural issues, not technology, are usually the primary obstacle to effective knowledge sharing"
+
+### 8. Current Trends & Future Directions
+
+#### AI & GenAI Integration
+- KM is "foundational for optimizing service delivery and maximizing the ROI from investments in GenAI" (Gartner)
+- By organizing and structuring enterprise data, KM provides the foundation for machine learning and AI tools
+- AI-driven capabilities: intelligent search, auto-tagging, predictive recommendations, chatbots
+
+#### Modern Tools & Platforms
+- Shift from traditional databases to modern knowledge management solutions
+- Integration with collaboration platforms, intranets, and workflow tools
+- Emphasis on user experience and accessibility
+
+#### Measurement & Analytics
+- Increased focus on KM metrics and ROI measurement
+- Data-driven approaches to understanding knowledge flows
+- Analytics to identify knowledge gaps and opportunities
+
+---
+
+## L2: Strategic Implications for Jerry
+
+### 1. Direct Alignment with Jerry's Core Mission
+
+**Jerry's Problem Statement:** Context Rot
+**KM's Solution:** Filesystem as infinite memory + structured knowledge architecture
+
+Jerry embodies several KM principles identified in this research:
+
+#### A. Explicit Knowledge Capture (Externalization)
+- **Jerry's Implementation:** `docs/` hierarchy (knowledge, experience, wisdom, design, research)
+- **KM Theory:** Nonaka's SECI Model - Externalization (Tacit → Explicit)
+- **Alignment:** Jerry systematically converts tacit knowledge (agent reasoning, problem-solving insights) into explicit documentation
+
+#### B. Knowledge Lifecycle Management
+- **Jerry's Implementation:** Work Tracker skill for persistent task state
+- **KM Theory:** K-TSACA framework (Transfer, Storage, Application, Creation, Acquisition)
+- **Alignment:** Work Tracker manages knowledge across creation (tasks defined) → storage (filesystem persistence) → application (task execution) → transfer (cross-session continuity)
+
+#### C. Communities of Practice Analog
+- **Jerry's Implementation:** Agent Registry + Skills as compressed interfaces
+- **KM Theory:** Wenger's CoP - Domain (problem-solving), Community (agent collaboration), Practice (shared skills/procedures)
+- **Alignment:** Jerry's agents form a "community" with shared domain (problem-solving), common practices (skills), and collaborative workflows
+
+### 2. Theoretical Validation of Jerry's Design
+
+#### Davenport & Prusak: "KM must move beyond IT systems"
+**Jerry's Response:**
+- ✅ Governance layer (.claude/) provides culture and behavioral norms (Jerry Constitution)
+- ✅ Skills provide "people-centric" natural language interfaces
+- ✅ Work Tracker enforces process discipline (not just technology)
+
+#### Senge: "Sustainable competitive advantage = learning faster"
+**Jerry's Response:**
+- ✅ `docs/experience/` and `docs/wisdom/` create organizational learning repository
+- ✅ Structured feedback loops (PLAN files, post-mortems, ADRs) accelerate learning
+- ✅ Each problem-solving cycle adds to knowledge base
+
+#### ISO 30401: Value Creation through Knowledge
+**Jerry's Response:**
+- ✅ Hexagonal architecture ensures domain knowledge remains pure and accessible
+- ✅ CQRS pattern separates knowledge creation (commands) from knowledge retrieval (queries)
+- ✅ Zero-dependency core ensures knowledge longevity (no external system lock-in)
+
+### 3. Gaps & Opportunities
+
+#### Gap 1: Missing "Ba" (Shared Context)
+**KM Theory:** Nonaka's "Ba" concept - physical, virtual, and mental spaces for knowledge sharing
+**Jerry's Current State:** File-based, lacks real-time collaborative context
+**Opportunity:**
+- Consider session-based "Ba" through enhanced agent collaboration protocols
+- Explore virtual "Ba" via structured agent dialogues or shared working memory
+
+#### Gap 2: Limited Socialization (Tacit → Tacit)
+**KM Theory:** SECI Model - Socialization requires shared experience
+**Jerry's Current State:** Agents don't directly share tacit experiences
+**Opportunity:**
+- Implement "experience transfer" between agents (e.g., ps-researcher findings inform ps-analyst)
+- Create "mentoring" protocols where experienced agents guide newer ones
+
+#### Gap 3: Knowledge Refinement Phase
+**KM Theory:** Meyer & Zack - critically assess knowledge before advancing to next phase
+**Jerry's Current State:** No systematic validation before knowledge enters `docs/`
+**Opportunity:**
+- Add validation step before committing research, experience, or wisdom docs
+- Implement peer review or validation workflow (e.g., QA agent reviews before final commit)
+
+#### Gap 4: Measurement & Metrics
+**KM Theory:** ISO 30401 requires governance and measurement; Gartner emphasizes ROI
+**Jerry's Current State:** No KM performance metrics
+**Opportunity:**
+- Track knowledge reuse (how often docs are referenced)
+- Measure time-to-solution improvements via Work Tracker
+- Calculate "knowledge leverage" (solutions per documentation unit)
+
+#### Gap 5: Knowledge Discovery & Search
+**KM Theory:** Forrester - "nearly half of employees lack the ability to search for existing insights"
+**Jerry's Current State:** File-based grep/glob search, no semantic search
+**Opportunity:**
+- Implement semantic search over `docs/` hierarchy
+- Add knowledge graph or linked concepts for better discovery
+- Create "knowledge navigator" skill for intelligent search
+
+### 4. Recommendations for Jerry Evolution
+
+#### Phase 1: Immediate (Low Effort, High Impact)
+1. **Formalize Knowledge Refinement Process**
+   - Add validation checklist before committing to `docs/knowledge/`
+   - Require citations/sources for research outputs (as demonstrated in this document)
+
+2. **Implement Knowledge Reuse Tracking**
+   - Add metadata to docs indicating: creation date, last accessed, reference count
+   - Track which docs inform which work items
+
+3. **Create Knowledge Transfer Protocol**
+   - Standardize how agents share findings (e.g., ps-researcher → ps-analyst)
+   - Document knowledge flow in PLAN files
+
+#### Phase 2: Medium-Term (Moderate Effort)
+1. **Develop Knowledge Metrics Dashboard**
+   - Track: docs created per sprint, knowledge reuse rate, time-to-solution trends
+   - Visualize knowledge growth and utilization
+
+2. **Enhance Communities of Practice**
+   - Formalize agent "specializations" (domains of practice)
+   - Create shared repertoire of problem-solving patterns
+
+3. **Implement "Ba" Concept**
+   - Session-based working memory for active problem-solving
+   - Shared context files for collaborative agent work
+
+#### Phase 3: Long-Term (High Effort, Transformational)
+1. **Semantic Knowledge Layer**
+   - Build knowledge graph connecting concepts across `docs/`
+   - Enable intelligent traversal and discovery
+
+2. **AI-Powered Knowledge Assistant**
+   - Leverage LLM to answer questions from Jerry's knowledge base
+   - Implement RAG (Retrieval-Augmented Generation) over `docs/`
+
+3. **ISO 30401 Compliance**
+   - Formally align Jerry with ISO 30401 requirements
+   - Position Jerry as reference implementation for AI agent KM systems
+
+### 5. Unique Positioning: KM for AI Agent Systems
+
+**Industry Gap:** Existing KM literature focuses on human organizations; Jerry operates in AI agent context
+
+**Novel Contribution Areas:**
+1. **Agent-to-Agent Knowledge Transfer:** How do autonomous agents share tacit knowledge?
+2. **LLM Context Rot Mitigation:** Filesystem-based KM as solution to context window limitations
+3. **Governance for Agent KM:** Jerry Constitution as KM culture/policy for AI systems
+4. **Skills as Knowledge Interfaces:** Natural language APIs as knowledge access layer
+
+**Research Opportunity:**
+Jerry could pioneer "Knowledge Management for AI Agent Ecosystems" as a new sub-discipline, extending KM theory from human organizations to AI-native systems.
+
+### 6. Behavioral Alignment Validation
+
+Cross-reference with Jerry Constitution principles:
+
+| KM Concept | Jerry Principle | Alignment |
+|------------|-----------------|-----------|
+| Externalization (tacit→explicit) | P-002: File Persistence | ✅ Strong |
+| Knowledge validation | P-001: Truth and Accuracy | ✅ Strong |
+| Organizational learning | P-004: Reasoning Documentation | ✅ Strong |
+| Knowledge governance | P-020: User Authority | ✅ Strong |
+| Transparency in KM | P-022: No Deception | ✅ Strong |
+| Knowledge lifecycle tracking | P-010: Task Tracking Integrity | ✅ Strong |
+
+**Conclusion:** Jerry's constitution principles strongly align with KM best practices, suggesting the framework has solid theoretical grounding.
+
+### 7. Summary of Strategic Insights
+
+1. **Jerry is inherently a KM system** - not just a problem-solving framework, but a knowledge-creating organization
+2. **Theoretical foundation is sound** - aligns with Nonaka, Wenger, Senge, ISO 30401
+3. **Key gaps** are in socialization, measurement, and discovery
+4. **Unique positioning** as KM for AI agents creates research/thought leadership opportunity
+5. **Evolution path** is clear: formalize refinement → add metrics → enhance discovery → achieve ISO compliance
+
+---
+
+## Bibliography
+
+### Academic & Seminal Works
+
+1. **Nonaka, I., & Takeuchi, H.** (1995). *The Knowledge-Creating Company: How Japanese Companies Create the Dynamics of Innovation*. Oxford University Press.
+   - Primary source for SECI model and tacit/explicit knowledge distinction
+
+2. **Davenport, T. H., & Prusak, L.** (1998). *Working Knowledge: How Organizations Manage What They Know*. Harvard Business School Press.
+   - Foundational KM vocabulary and concepts
+   - [Amazon](https://www.amazon.com/Working-Knowledge-Thomas-H-Davenport/dp/1578513014)
+
+3. **Wenger, E.** (1998). *Communities of Practice: Learning, Meaning, and Identity*. Cambridge University Press.
+   - Definitive work on Communities of Practice
+   - [Amazon](https://www.amazon.com/Communities-Practice-Cognitive-Computational-Perspectives/dp/0521663636)
+
+4. **Wenger, E., McDermott, R., & Snyder, W.** (2002). *Cultivating Communities of Practice: A Guide to Managing Knowledge*. Harvard Business School Press.
+   - Practical implementation of CoPs
+   - [Amazon](https://www.amazon.com/Cultivating-Communities-Practice-Etienne-Wenger/dp/1578513308)
+   - [Internet Archive](https://archive.org/details/cultivatingcommu0000weng)
+
+5. **Senge, P. M.** (1990). *The Fifth Discipline: The Art & Practice of the Learning Organization*. Currency Doubleday.
+   - Five disciplines framework; systems thinking
+   - [Amazon](https://www.amazon.com/Fifth-Discipline-Practice-Learning-Organization/dp/0385517254)
+
+6. **Lave, J., & Wenger, E.** (1991). *Situated Learning: Legitimate Peripheral Participation*. Cambridge University Press.
+   - Original coining of "community of practice"
+
+7. **Alavi, M., & Leidner, D. E.** (2001). "Review: Knowledge Management and Knowledge Management Systems: Conceptual Foundations and Research Issues." *MIS Quarterly*, 25(1), 107-136.
+   - Information systems perspective on KM
+
+### Web Resources & Articles
+
+8. **SECI Model - Wikipedia**
+   [https://en.wikipedia.org/wiki/SECI_model_of_knowledge_dimensions](https://en.wikipedia.org/wiki/SECI_model_of_knowledge_dimensions)
+
+9. **Nonaka and Takeuchi - Praxis Framework**
+   [https://www.praxisframework.org/en/library/nonaka-and-takeuchi](https://www.praxisframework.org/en/library/nonaka-and-takeuchi)
+
+10. **SECI Model - ASCN Higher Education**
+    [https://ascnhighered.org/ASCN/change_theories/collection/seci.html](https://ascnhighered.org/ASCN/change_theories/collection/seci.html)
+
+11. **Managing Knowledge in Organizations: A Nonaka's SECI Model Operationalization** (PMC)
+    [https://pmc.ncbi.nlm.nih.gov/articles/PMC6914727/](https://pmc.ncbi.nlm.nih.gov/articles/PMC6914727/)
+
+12. **The Nonaka Takeuchi Knowledge Spiral - Mindtools**
+    [https://www.mindtools.com/aqwn9zx/the-nonaka-takeuchi-knowledge-spiral/](https://www.mindtools.com/aqwn9zx/the-nonaka-takeuchi-knowledge-spiral/)
+
+13. **Thomas Davenport and Larry Prusak: Working Knowledge - Mindtools**
+    [https://www.mindtools.com/aq7u1c3/thomas-davenport-and-larry-prusak-working-knowledge/](https://www.mindtools.com/aq7u1c3/thomas-davenport-and-larry-prusak-working-knowledge/)
+
+14. **Wenger, E.** (2000). "Communities of Practice and Social Learning Systems." *Organization*, 7(2), 225-246.
+    [https://journals.sagepub.com/doi/10.1177/135050840072002](https://journals.sagepub.com/doi/10.1177/135050840072002)
+
+15. **Wenger, E.** "Communities of practice: learning as a social system."
+    [https://www.wenger-trayner.com/wp-content/uploads/2022/06/1998-EWT-Article-for-the-Systems-Thinker.pdf](https://www.wenger-trayner.com/wp-content/uploads/2022/06/1998-EWT-Article-for-the-Systems-Thinker.pdf)
+
+16. **Introduction to communities of practice - Wenger-Trayner**
+    [https://www.wenger-trayner.com/introduction-to-communities-of-practice/](https://www.wenger-trayner.com/introduction-to-communities-of-practice/)
+
+17. **Community of practice - Wikipedia**
+    [https://en.wikipedia.org/wiki/Community_of_practice](https://en.wikipedia.org/wiki/Community_of_practice)
+
+18. **The Fifth Discipline - Wikipedia**
+    [https://en.wikipedia.org/wiki/The_Fifth_Discipline](https://en.wikipedia.org/wiki/The_Fifth_Discipline)
+
+19. **Peter Senge and the learning organization - infed.org**
+    [https://infed.org/mobi/peter-senge-and-the-learning-organization/](https://infed.org/mobi/peter-senge-and-the-learning-organization/)
+
+### Standards & Technical Documentation
+
+20. **ISO 30401:2018** - Knowledge management systems — Requirements
+    [https://www.iso.org/standard/68683.html](https://www.iso.org/standard/68683.html)
+
+21. **The essence of the ISO 30401 knowledge management standard** - RealKM
+    [https://realkm.com/2022/02/02/the-essence-of-the-iso-30401-knowledge-management-standard/](https://realkm.com/2022/02/02/the-essence-of-the-iso-30401-knowledge-management-standard/)
+
+22. **ISO 30401:2018 - Easy Guide To Knowledge Management** - UCS
+    [https://ucsiso.com/iso-30401-knowledge-management-system/](https://ucsiso.com/iso-30401-knowledge-management-system/)
+
+23. **ISO 30401 Knowledge Management Systems - Standards Explained**
+    [https://standardsexplained.com/iso-30401-knowledge-management-systems/](https://standardsexplained.com/iso-30401-knowledge-management-systems/)
+
+### Industry Research & Reports
+
+24. **Enable Effective Digital Support Channels With Knowledge Management** - Gartner
+    [https://www.gartner.com/en/customer-service-support/trends/unlock-knowledge-management-roi](https://www.gartner.com/en/customer-service-support/trends/unlock-knowledge-management-roi)
+
+25. **Definition of KM Strategy** - Gartner Information Technology Glossary
+    [https://www.gartner.com/en/information-technology/glossary/km-strategy](https://www.gartner.com/en/information-technology/glossary/km-strategy)
+
+26. **Market Guide for Customer Service Knowledge Management Systems** - Gartner
+    [https://www.gartner.com/en/documents/5491795](https://www.gartner.com/en/documents/5491795)
+
+27. **The Forrester Wave™: Knowledge Management Solutions, Q4 2024** - Forrester
+    [https://www.forrester.com/blogs/the-forrester-wave-knowledge-management-solutions-q4-2024-insights/](https://www.forrester.com/blogs/the-forrester-wave-knowledge-management-solutions-q4-2024-insights/)
+
+28. **Knowledge management** - Forrester
+    [https://www.forrester.com/blogs/category/knowledge-management/?categoryid=2849204](https://www.forrester.com/blogs/category/knowledge-management/?categoryid=2849204)
+
+29. **The ROI of Smarter Knowledge Management: A Business Leader's Guide** - SearchUnify
+    [https://www.searchunify.com/resource-center/blog/the-roi-of-smarter-knowledge-management-a-business-leaders-guide](https://www.searchunify.com/resource-center/blog/the-roi-of-smarter-knowledge-management-a-business-leaders-guide)
+
+30. **Knowledge Management ROI: Calculating the Value of Knowledge** - ClearPeople
+    [https://www.clearpeople.com/blog/return-on-investment-knowledge-productivity](https://www.clearpeople.com/blog/return-on-investment-knowledge-productivity)
+
+### Knowledge Lifecycle & Frameworks
+
+31. **Mastering the Knowledge Management Cycle: A Complete Guide** - Alltius
+    [https://www.alltius.ai/glossary/knowledge-management-cycle](https://www.alltius.ai/glossary/knowledge-management-cycle)
+
+32. **An Analysis of Knowledge Management Lifecycle Frameworks: Towards a Unified Framework** - Electronic Journal of Knowledge Management
+    [https://academic-publishing.org/index.php/ejkm/article/view/1081](https://academic-publishing.org/index.php/ejkm/article/view/1081)
+
+33. **Models of KM Cycle** - Tutorialspoint
+    [https://www.tutorialspoint.com/knowledge_management/models_of_km_cycle.htm](https://www.tutorialspoint.com/knowledge_management/models_of_km_cycle.htm)
+
+34. **Knowledge Management Cycle** - Bloomfire
+    [https://bloomfire.com/blog/knowledge-management-cycle/](https://bloomfire.com/blog/knowledge-management-cycle/)
+
+### Industry Applications
+
+35. **Knowledge Management Systems: Types, Use Cases, and Cloud-Based Solutions** - Q3 Technologies
+    [https://www.q3tech.com/blogs/ultimate-guide-to-knowledge-management-systems/](https://www.q3tech.com/blogs/ultimate-guide-to-knowledge-management-systems/)
+
+36. **12 Knowledge Management Use Case Examples for Your Organization** - ProcedureFlow
+    [https://blog.procedureflow.com/knowledge-management/knowledge-management-examples](https://blog.procedureflow.com/knowledge-management/knowledge-management-examples)
+
+37. **Knowledge Management Implementation in Healthcare** - PMC
+    [https://pmc.ncbi.nlm.nih.gov/articles/PMC5615016/](https://pmc.ncbi.nlm.nih.gov/articles/PMC5615016/)
+
+38. **Benefits of knowledge management in healthcare** - CKEditor
+    [https://ckeditor.com/blog/benefits-of-knowledge-management-in-healthcare/](https://ckeditor.com/blog/benefits-of-knowledge-management-in-healthcare/)
+
+39. **Knowledge Management in the Healthcare Industry** - Helpjuice
+    [https://helpjuice.com/blog/healthcare-knowledge-management](https://helpjuice.com/blog/healthcare-knowledge-management)
+
+40. **How is knowledge management used in healthcare?** - Document360
+    [https://document360.com/blog/knowledge-management-in-healthcare/](https://document360.com/blog/knowledge-management-in-healthcare/)
+
+### Organizational Culture & Barriers
+
+41. **Overcoming Cultural Barriers to Sharing Knowledge** - ResearchGate
+    [https://www.researchgate.net/publication/235267176_Overcoming_Cultural_Barriers_to_Sharing_Knowledge](https://www.researchgate.net/publication/235267176_Overcoming_Cultural_Barriers_to_Sharing_Knowledge)
+
+42. **The Challenge of Organizational Learning** - Stanford Social Innovation Review
+    [https://ssir.org/articles/entry/the_challenge_of_organizational_learning](https://ssir.org/articles/entry/the_challenge_of_organizational_learning)
+
+43. **Overcoming Knowledge-Sharing Barriers** - PMI
+    [https://www.pmi.org/learning/library/overcoming-knowledge-sharing-barriers-10169](https://www.pmi.org/learning/library/overcoming-knowledge-sharing-barriers-10169)
+
+44. **The Importance of a Knowledge Sharing Culture** - Whatfix
+    [https://whatfix.com/blog/knowledge-sharing-culture/](https://whatfix.com/blog/knowledge-sharing-culture/)
+
+45. **10 Essential Steps to Promote a Knowledge Sharing Culture** - MentorCliq
+    [https://www.mentorcliq.com/blog/knowledge-sharing-culture](https://www.mentorcliq.com/blog/knowledge-sharing-culture)
+
+46. **7 Knowledge Sharing Best Practices** - Starmind
+    [https://www.starmind.ai/blog/ways-to-improve-knowledge-sharing-across-your-organization](https://www.starmind.ai/blog/ways-to-improve-knowledge-sharing-across-your-organization)
+
+47. **How to Encourage Knowledge Sharing in the Workplace** - Helpjuice
+    [https://helpjuice.com/blog/knowledge-sharing](https://helpjuice.com/blog/knowledge-sharing)
+
+48. **Knowledge Sharing & Organizational Learning** - Guru
+    [https://www.getguru.com/reference/knowledge-management-for-knowledge-sharing](https://www.getguru.com/reference/knowledge-management-for-knowledge-sharing)
+
+49. **Empowering teams: Unleashing the power of knowledge sharing** - Stack Overflow
+    [https://stackoverflow.co/internal/resources/empowering-teams-unleashing-the-power-of-knowledge-sharing/](https://stackoverflow.co/internal/resources/empowering-teams-unleashing-the-power-of-knowledge-sharing/)
+
+### Additional References
+
+50. **Knowledge Management in Theory and Practice** - Kimiz Dalkir, Elsevier
+    [PDF Resource](https://dianabarbosa.wordpress.com/wp-content/uploads/2009/03/knowledge-management-kimiz-dalkir.pdf)
+
+51. **Knowledge management: re-thinking information management** - Information Research
+    [https://informationr.net/ir/8-1/paper143.html](https://informationr.net/ir/8-1/paper143.html)
+
+52. **Knowledge Management: Origins, History, and Development** - SpringerLink
+    [https://link.springer.com/chapter/10.1007/978-3-319-09501-1_1](https://link.springer.com/chapter/10.1007/978-3-319-09501-1_1)
+
+---
+
+**End of Research Document**
+
+*This research was conducted using authoritative academic, industry, and standards sources to provide a comprehensive foundation for understanding Knowledge Management fundamentals and their strategic application to the Jerry framework.*

--- a/docs/archive/projects-archive/research/work-032-e-002-km-protocols.md
+++ b/docs/archive/projects-archive/research/work-032-e-002-km-protocols.md
@@ -1,0 +1,1848 @@
+# Knowledge Management Protocols and Standards Research
+
+**PS ID:** work-032
+**Entry ID:** e-002
+**Agent:** ps-researcher v2.0.0
+**Date:** 2026-01-08
+**Topic:** Knowledge Management Protocols, Standards, and Methodologies
+
+---
+
+## L0: Executive Summary
+
+### Key Findings
+
+Knowledge Management (KM) has matured from a vague business concept into a discipline with international standards (ISO 30401:2018), established frameworks (APQC), maturity models (Siemens KMMM, APQC), and proven operational protocols (After Action Reviews, Knowledge Audits). This research synthesizes six standards, six protocols, and strategic decision frameworks to guide KM implementation.
+
+### Critical Insights
+
+1. **Standards Evolution**: ISO 30401:2018 represents the first time ISO recognized knowledge as a formal organizational resource requiring systematic management
+2. **Protocol Selection is Context-Dependent**: No single protocol fits all scenarios; selection depends on knowledge type (tacit vs. explicit), organizational maturity, and strategic goals
+3. **The Codification-Personalization Trade-off**: Organizations must balance document-based knowledge capture (codification) with people-based knowledge sharing (personalization), typically in an 80-20 split aligned with competitive strategy
+4. **Maturity Models Provide Roadmaps**: Multiple maturity models exist (APQC, Siemens KMMM, Infosys) with similar 5-stage progressions from ad-hoc to optimizing
+5. **Metadata Standards Enable Interoperability**: Dublin Core and SKOS provide lightweight, standardized vocabularies for knowledge organization across systems
+
+### Recommended Actions for Jerry Framework
+
+1. **Immediate**: Implement After Action Reviews (AARs) for completed work items to capture lessons learned
+2. **Short-term**: Conduct initial Knowledge Audit to assess current knowledge assets and flows
+3. **Medium-term**: Develop knowledge maps linking documentation to expertise areas
+4. **Long-term**: Pursue ISO 30401:2018 alignment for systematic KM maturity
+
+---
+
+## L1: Standards and Protocols Catalog
+
+### A. International Standards
+
+#### 1. ISO 30401:2018 - Knowledge Management Systems
+
+**Purpose**: Establishes requirements for implementing, maintaining, and improving organizational KM systems
+
+**Scope**: Applicable to any organization regardless of type, size, or industry
+
+**Key Components**:
+- Establishes KM system requirements and guidelines
+- Encourages knowledge management process as foundation for operations
+- Requires consideration of organizational characteristics, environment, and culture
+- Integrates with ISO 27001 (information security), ISO 9001 (quality management)
+
+**When to Use**:
+- Organizations seeking formal KM certification
+- Large enterprises requiring standardized KM across divisions
+- Industries with regulatory compliance needs (healthcare, finance, aerospace)
+- Organizations at "Managed" or "Optimizing" maturity levels
+
+**Trade-offs**:
+- ✅ Provides comprehensive, internationally recognized framework
+- ✅ Facilitates integration with other ISO management systems
+- ❌ Implementation requires significant resources and commitment
+- ❌ May be excessive for small organizations or early-stage startups
+- ❌ Formal certification is optional and can be costly
+
+**Current Status**: Published 2018-10-31; amended 2022 and 2024; new version (ISO/CD 30401) in development
+
+**Citations**:
+- [ISO 30401:2018 Official Standard](https://www.iso.org/standard/68683.html)
+- [The essence of ISO 30401 - RealKM](https://realkm.com/2022/02/02/the-essence-of-the-iso-30401-knowledge-management-standard/)
+
+---
+
+#### 2. ISO 9001:2015 - Quality Management (Organizational Knowledge)
+
+**Purpose**: Clause 7.1.6 addresses organizational knowledge as a quality management resource
+
+**Scope**: Applies to all organizations with ISO 9001:2015 quality management systems
+
+**Key Components**:
+- **Determine**: Identify knowledge needed to operate processes and ensure product/service conformity
+- **Maintain**: Keep knowledge current and available as needed
+- **Consider Changes**: Assess current knowledge when changes occur; acquire new knowledge as needed
+
+**Definition of Organizational Knowledge**: "Knowledge specific to the organization, gained through experience, used and shared to achieve objectives"
+
+**Knowledge Sources**:
+- **Internal**: Intellectual property, lessons learned, improvement results, employee expertise
+- **External**: Conferences, customer knowledge, supplier knowledge, benchmarking
+
+**When to Use**:
+- Organizations already implementing ISO 9001:2015
+- Manufacturing and production environments focused on quality
+- Succession planning and knowledge retention initiatives
+- Preventing knowledge loss from employee turnover
+
+**Trade-offs**:
+- ✅ First ISO standard to recognize knowledge as a resource
+- ✅ Integrates KM into existing quality management processes
+- ✅ No explicit documentation requirement (flexible implementation)
+- ❌ Limited to quality management context (not comprehensive KM)
+- ❌ Emphasis on explicit knowledge; tacit knowledge less addressed
+- ❌ Requires existing ISO 9001 framework
+
+**Practical Implementation**:
+- Create mentoring programs to transfer tacit knowledge
+- Document lessons learned from failures and successes
+- Establish knowledge retention procedures for critical roles
+- Conduct knowledge risk assessments during organizational changes
+
+**Citations**:
+- [Organizational Knowledge in ISO 9001:2015 - Cognidox](https://www.cognidox.com/blog/2015/08/organizational-knowledge-in-iso-90012015)
+- [Knowledge Management and ISO 9001:2015 - RealKM](https://realkm.com/2015/10/14/knowledge-management-and-iso-90012015/)
+
+---
+
+#### 3. APQC Knowledge Management Framework
+
+**Purpose**: Systematic approach to managing knowledge flow through four key areas: strategy, assessment, knowledge flow processes, and enabling factors
+
+**Scope**: Scalable across organizations of all sizes and industries
+
+**Key Components**:
+
+**A. KM Strategic Framework**:
+- Transforms KM from abstract concept to actionable system
+- Breaks down into clear components: strategy, people, processes, technology
+- Provides roadmap for design, implementation, and sustainability
+
+**B. Knowledge Flow Process (7-Step Cycle)**:
+1. Creating knowledge
+2. Identifying knowledge
+3. Collecting knowledge
+4. Reviewing knowledge
+5. Sharing knowledge
+6. Accessing knowledge
+7. Using knowledge
+
+**C. KM Maturity Model (5 Stages)**:
+1. **Initiate**: Initial, inconsistent KM activities
+2. **Develop**: Structured KM approaches emerging
+3. **Standardize**: Consistent KM practices established
+4. **Optimize**: KM aligned to business imperatives
+5. **Innovate**: KM drives innovation and competitive advantage
+
+**D. 150-Item Assessment Tool**:
+- Determines current maturity level
+- Items are actionable conditions (not just descriptive)
+- Provides baseline for strategy development
+
+**When to Use**:
+- Organizations implementing KM programs from scratch
+- Technology companies, consulting firms, research institutions
+- Environments requiring continuous learning and innovation
+- Organizations needing measurable KM outcomes and ROI
+
+**Trade-offs**:
+- ✅ Built on decades of benchmarking and best practices
+- ✅ Detailed, prescriptive guidance with step-by-step processes
+- ✅ Scalable across different organization sizes
+- ✅ Focuses on measurable outcomes
+- ❌ Requires significant initial effort and planning
+- ❌ Needs consistent leadership support
+- ❌ May be too structured for highly agile/adaptive organizations
+
+**Differentiators**:
+- Evidence-based approach from benchmarking top performers
+- Maps KM methods directly to implementation steps
+- Adaptable to digital transformation and remote work scenarios
+
+**Citations**:
+- [APQC's Knowledge Management Framework](https://www.apqc.org/resource-library/resource-listing/apqcs-knowledge-management-framework)
+- [Knowledge Management Strategic Framework - APQC](https://www.apqc.org/expertise/knowledge-management/interactive-km-framework)
+- [APQC's Knowledge Flow Process Framework](https://www.apqc.org/resource-library/resource-listing/apqcs-knowledge-flow-process-framework)
+
+---
+
+#### 4. Knowledge Management Maturity Models
+
+**Purpose**: Provide roadmaps for progressing from immature, ad-hoc KM to mature, strategic approaches
+
+**Common Structure**: Most models follow CMM (Capability Maturity Model) with 5 levels
+
+**Major Models Compared**:
+
+**A. Siemens KMMM (Ehms & Langen, 2002)**
+
+**5 Stages**: Initial → Repeated → Defined → Managed → Optimizing
+
+**8 Key Areas**:
+1. Strategy & knowledge goals
+2. Environment & partnerships
+3. People & competencies
+4. Collaboration & culture
+5. Leadership & support
+6. Knowledge structures & knowledge forms
+7. Technology & infrastructure
+8. Processes, roles & organization
+
+**Best For**: Large enterprises with complex organizational structures
+
+---
+
+**B. APQC Maturity Model (Hubert & Lemons)**
+
+**5 Stages**: Initiate → Develop → Standardize → Optimize → Innovate
+
+**Assessment**: 150-item actionable assessment (conditions that must exist for maturity)
+
+**Best For**: Organizations wanting clear roadmap tied to business results
+
+---
+
+**C. Infosys KMMM (Kochikar, 2000)**
+
+**5 Stages**: Default → Reactive → Aware → Convinced → Sharing
+
+**Key Areas**: People, Process, Technology (PPT framework)
+
+**Best For**: Technology companies and IT service organizations
+
+---
+
+**D. KPQM - Knowledge Process Quality Model (Paulzen et al., 2002)**
+
+**5 Stages**: Initial → Aware → Established → Quantitatively Managed → Optimizing
+
+**Focus**: Quality improvement in knowledge processes
+
+**Best For**: Organizations with strong quality management culture
+
+---
+
+**E. Strategic KMMM (Kruger & Snyman, 2007)**
+
+**6 Phases**:
+1. ICT as enabler of KM
+2. Deciding on KM principles
+3. Formulating organization-wide knowledge policy
+4. Building knowledge strategies
+5. Formulation of KM strategies
+6. Ubiquitous knowledge
+
+**Best For**: Organizations integrating KM with strategic planning
+
+---
+
+**When to Use Maturity Models**:
+- Assessing current KM capabilities and gaps
+- Creating multi-year KM implementation roadmaps
+- Benchmarking against industry standards
+- Securing executive buy-in with clear progression paths
+- Identifying specific improvement priorities
+
+**Trade-offs**:
+- ✅ Provides clear progression path and milestones
+- ✅ Enables benchmarking and assessment
+- ✅ Helps prioritize investments and initiatives
+- ❌ Risk of "checklist mentality" vs. genuine transformation
+- ❌ May not account for organization-specific nuances
+- ❌ Can create pressure to advance prematurely
+
+**Critical Perspective** (Nick Milton):
+Warns that maturity models can be "inappropriate and dangerous" if followed slavishly rather than adapted to organizational context.
+
+**Recommendation**: Use maturity models as sources of ideas and frameworks, not rigid prescriptions. Understand specific organizational challenges first, then map tailored approaches.
+
+**Citations**:
+- [Knowledge Management Maturity Models - Stan Garfield](https://stangarfield.medium.com/knowledge-management-maturity-models-fd094ed49e48)
+- [APQC's Levels of Knowledge Management Maturity](https://www.apqc.org/resource-library/resource-listing/apqcs-levels-knowledge-management-maturity)
+- [Knowledge Management Maturity Models – A Morphological Analysis](https://journals.klalliance.org/index.php/JKMP/article/download/228/222/462)
+
+---
+
+#### 5. Dublin Core Metadata Initiative (DCMI)
+
+**Purpose**: Open-standard metadata vocabularies for resource description and interoperability
+
+**Scope**: Cross-domain metadata standard for describing diverse resources
+
+**Core Element Set**: 15 properties for resource description
+1. Title
+2. Creator
+3. Subject
+4. Description
+5. Publisher
+6. Contributor
+7. Date
+8. Type
+9. Format
+10. Identifier
+11. Source
+12. Language
+13. Relation
+14. Coverage
+15. Rights
+
+**Technical Implementation**:
+- **Data Model**: RDF-based (since 2012)
+- **Syntax**: Syntax-independent, applies to multiple contexts
+- **Interoperability**: Designed for machine and human interpretation
+
+**Formal Standards**:
+- ISO 15836 (International Organization for Standardization)
+- IETF RFC 5013 (Internet Engineering Task Force)
+- ANSI/NISO Z39.85 (U.S. National Information Standards Organization)
+
+**Application Profiles** (Specialized Extensions):
+- DCAT (Data Catalog Vocabulary)
+- AGLS Metadata Profile
+- AGRIS Application Profile
+- ANZLIC Metadata Profile
+- Dryad Metadata Application Profile
+
+**When to Use**:
+- Digital libraries and archives
+- Cross-system knowledge repositories
+- Heterogeneous content management
+- Semantic web and linked data applications
+- Organizations requiring metadata interoperability
+- Publishing and content distribution platforms
+
+**Trade-offs**:
+- ✅ Internationally standardized and widely adopted
+- ✅ Simple, extensible vocabulary (easy to implement)
+- ✅ Syntax-independent (works with XML, RDF, JSON, etc.)
+- ✅ Supports application profiles for domain-specific needs
+- ❌ May be too simple for complex domain-specific metadata
+- ❌ Requires additional ontologies for rich semantics
+- ❌ Limited expressiveness compared to full ontology languages
+
+**Evolution**: Continues to evolve with semantic web technologies; DCMI 2026 conference theme: "Meaning-Driven AI: Using Metadata to Align Systems with Human Values"
+
+**Citations**:
+- [Dublin Core Metadata Initiative - Official Site](https://www.dublincore.org/)
+- [Dublin Core - Wikipedia](https://en.wikipedia.org/wiki/Dublin_Core)
+- [DCMI: Dublin Core Metadata Element Set v1.1](https://www.dublincore.org/specifications/dublin-core/dces/)
+
+---
+
+#### 6. SKOS - Simple Knowledge Organization System
+
+**Purpose**: W3C standard for representing thesauri, taxonomies, classification schemes, and controlled vocabularies as linked data
+
+**Scope**: Part of Semantic Web family (built on RDF and RDFS)
+
+**Standard Status**: W3C Recommendation (18 August 2009)
+
+**Key Features**:
+
+**Concepts** can be:
+- Identified using URIs (web addresses)
+- Labeled with lexical strings in multiple languages
+- Assigned notations (lexical codes)
+- Documented with various note types
+- Linked to other concepts
+- Organized into hierarchies and association networks
+- Aggregated into concept schemes
+- Grouped into labeled/ordered collections
+- Mapped to concepts in other schemes
+
+**Relationship to OWL**:
+- SKOS: Simple language for knowledge organization systems
+- OWL: General framework for formal knowledge representation
+- SKOS is NOT a formal knowledge representation language
+- Can be used alone or combined with OWL
+
+**Use Cases**:
+- Libraries and museums (cataloging)
+- Government portals and enterprises (taxonomies)
+- News organizations (subject classification)
+- Social networks (tagging and categorization)
+- Corporate glossaries and business vocabularies
+- Legacy thesaurus migration to semantic web
+
+**When to Use**:
+- Representing existing controlled vocabularies in RDF
+- Building lightweight taxonomies and classification systems
+- Enabling linked data and semantic interoperability
+- Publishing vocabularies for reuse across systems
+- Situations where OWL's complexity is unnecessary
+
+**Trade-offs**:
+- ✅ Low-cost migration path for existing vocabularies
+- ✅ Lightweight and intuitive compared to full ontologies
+- ✅ W3C standard with broad tool support
+- ✅ Enables semantic web and linked data integration
+- ❌ Not suitable for formal logic and reasoning
+- ❌ Less expressive than full ontology languages
+- ❌ Requires RDF knowledge for implementation
+
+**Data Model**: Centered on concepts with URIs, supporting:
+- Preferred and alternate labels (any language)
+- Hierarchical relationships (broader/narrower)
+- Associative relationships (related concepts)
+- Metadata and documentation notes
+
+**Citations**:
+- [SKOS Simple Knowledge Organization System - W3C](https://www.w3.org/2004/02/skos/)
+- [SKOS Reference - W3C Recommendation](https://www.w3.org/TR/skos-reference/)
+- [Simple Knowledge Organization System - Wikipedia](https://en.wikipedia.org/wiki/Simple_Knowledge_Organization_System)
+
+---
+
+### B. Operational Protocols and Methods
+
+#### 1. Knowledge Audit
+
+**Purpose**: Systematic process to identify organizational knowledge needs, resources, and flows to determine where KM can add value
+
+**Methodology**:
+
+**6-Step Process** (Tiwana):
+1. Define audit goals and scope
+2. Select audit method and tools
+3. Determine ideal state (desired future)
+4. Perform knowledge audit (assess current state)
+5. Document existing knowledge assets
+6. Determine strategic position and gaps
+
+**Core Audit Components**:
+- **Knowledge Environment Audit**: Assess internal/external factors influencing knowledge
+- **Knowledge Property Audit**: Inventory knowledge assets and IP
+- **Knowledge Management Ability Audit**: Evaluate processes and capabilities
+- **Knowledge Management Performance Audit**: Measure KM effectiveness
+
+**Analysis Modules**:
+- Knowledge demand analysis (what knowledge is needed)
+- Knowledge inventory analysis (what knowledge exists)
+- Knowledge maps (where knowledge resides)
+- Knowledge flow analysis (how knowledge moves)
+
+**Knowledge Audit Framework (KAF)**:
+- Process and templates for planning/executing audits
+- Emphasis on knowledge sharing
+- Based on Data Audit Framework (DAF) methodology
+
+**When to Use**:
+- Beginning KM initiatives (baseline assessment)
+- Major organizational changes (mergers, restructuring)
+- Knowledge loss risk (retirements, turnover)
+- Before implementing KM systems (requirements gathering)
+- Periodic KM program health checks
+- Identifying knowledge gaps and redundancies
+
+**Trade-offs**:
+- ✅ Reveals hidden knowledge assets and flows
+- ✅ Identifies critical knowledge gaps and risks
+- ✅ Provides baseline for KM strategy
+- ✅ Uncovers inefficiencies and redundancies
+- ❌ Time and resource intensive
+- ❌ Requires cross-functional participation
+- ❌ May reveal uncomfortable truths about knowledge silos
+- ❌ Results can be overwhelming without clear priorities
+
+**Best Practices**:
+- Secure executive sponsorship before starting
+- Focus on core business processes first
+- Use mixed methods (interviews, surveys, observation)
+- Document findings visually (maps, diagrams)
+- Link findings to business value and risks
+- Develop actionable recommendations, not just reports
+
+**Citations**:
+- [Knowledge Audit Concepts, Processes and Practice - ResearchGate](https://www.researchgate.net/publication/264096059_Knowledge_audit_concepts_processes_and_practice)
+- [Knowledge Management Audit Framework - Emerald Insight](https://www.emerald.com/insight/content/doi/10.1108/17468770911013546/full/html)
+- [How to Conduct a Knowledge Management Assessment in 5 Steps - Shelf](https://shelf.io/blog/knowledge-management-assessement/)
+
+---
+
+#### 2. Knowledge Mapping
+
+**Purpose**: Visualization techniques to represent knowledge location, flows, relationships, and structures within organizations
+
+**Types of Knowledge Maps**:
+
+**A. Conceptual Maps**:
+- Show relationships between ideas, issues, and topics
+- Main idea branches to related concerns
+- Reveal how issues interconnect
+
+**B. Mind Maps**:
+- Organic brainstorming structure
+- Less rigid, more free-form
+- Single concept at center with radiating connections
+- Visual web of associations
+
+**C. Concept Maps** (Novak & Gowin, 1984):
+- Nodes representing concepts
+- Labeled links showing relationships
+- Hierarchical structure with propositions
+- Based on constructivist learning theory
+
+**Tools and Technologies**:
+
+**CmapTools** (IHMC):
+- Construct, navigate, share, and critique knowledge models
+- Collaborative editing with distributed teams
+- Server-based sharing (CmapServers)
+- Link maps to other maps and resources
+- Auto-generate web pages from maps
+- Search web for information relevant to concepts
+- Export formats: images, web pages, outlines, XML, LifeMap
+
+**Other Tools**:
+- **Open Source**: Visual Understanding Environment (VUE), Mind42
+- **Commercial**: Inspiration, SmartIdeas, DEMCO, MACOSOFT
+- **Other Free Tools**: FreeMind, XMind
+
+**Knowledge Visualization Integration**:
+- Combines knowledge visualization with information visualization
+- Concept map-based models organize information repositories
+- Makes knowledge browsable and searchable
+- Supports semantic search algorithms
+
+**Educational Applications** (Gowin's Knowledge Vee):
+- Facilitates metacognitive processes
+- Connects new information to existing knowledge structures
+- Promotes meaningful learning vs. rote memorization
+
+**When to Use**:
+- Onboarding new employees (organizational knowledge landscape)
+- Strategic planning (knowledge dependencies)
+- Research and development (concept relationships)
+- Process documentation (workflow knowledge)
+- Expert location (who knows what)
+- Knowledge retention (capturing retiring employees' knowledge)
+
+**Trade-offs**:
+- ✅ Makes tacit knowledge structures visible
+- ✅ Reveals knowledge gaps and overlaps
+- ✅ Supports collaborative knowledge building
+- ✅ Engaging and intuitive for diverse audiences
+- ❌ Can become overly complex without discipline
+- ❌ Requires maintenance to stay current
+- ❌ Initial creation is time-intensive
+- ❌ Tool selection and training overhead
+
+**Best Practices**:
+- Start simple, expand iteratively
+- Use consistent notation and conventions
+- Focus on business-critical knowledge first
+- Involve domain experts in creation
+- Link maps to actual knowledge resources
+- Review and update regularly
+
+**Citations**:
+- [Concept Maps: Integrating Knowledge and Information Visualization - Springer](https://link.springer.com/chapter/10.1007/11510154_11)
+- [CmapTools - Official Site](https://cmap.ihmc.us/)
+- [Everything You Need to Know about Knowledge Mapping - Tettra](https://tettra.com/article/knowledge-mapping/)
+
+---
+
+#### 3. After Action Review (AAR)
+
+**Purpose**: Structured learning methodology to capture lessons from events, operations, and projects
+
+**Origin**: Developed by U.S. Army in 1970s to address defensive and blame-focused debriefs that hindered learning
+
+**Principles**:
+- Emphasize participation from all involved
+- Encourage open discussion without blame
+- Identify areas for improvement, not individuals
+- Focus on future performance, not punishment
+
+**The Four Core Questions**:
+
+1. **What did we intend to accomplish?** (Strategy/Objectives)
+2. **What did we do?** (Execution/Actions)
+3. **Why did it happen that way?** (Analysis of variance)
+4. **What will we do next time?** (Adaptation/Learning)
+
+**Four-Step AAR Process**:
+
+**Step 1: Plan**
+- Define scope and objectives
+- Identify participants
+- Schedule timing (during or immediately after event)
+
+**Step 2: Prepare**
+- Review commander's intent/objectives
+- Gather relevant data and observations
+- Prepare guiding questions
+
+**Step 3: Conduct**
+- Review what was supposed to happen
+- Establish what actually happened
+- Determine strengths and weaknesses
+- Discuss how to sustain strengths and improve weaknesses
+- Link to subsequent training/operations
+
+**Step 4: Follow Up**
+- Document lessons learned
+- Implement improvements
+- Share across organization
+- Track implementation
+
+**Types of AARs**:
+
+**Formal AARs**:
+- Structured setup with established procedures
+- Large-scale events, operations, projects
+- Comprehensive documentation
+- Multiple stakeholders
+
+**Informal AARs**:
+- Spontaneous discussion
+- Immediately after task/operation
+- Small teams
+- Minimal documentation
+
+**Key Characteristics**:
+- Conducted during or immediately after events
+- Focus on objectives and task standards
+- Involve all participants equally
+- Use open-ended questions
+- Encourage initiative and innovation
+- Determine observed strengths and weaknesses
+- Link to subsequent activities
+
+**Ground Rules**:
+- Encourage candor and openness
+- All participants have equal ownership
+- Focus on improving performance, not placing blame
+- Keep discussions confidential
+- End on positive note
+
+**When to Use**:
+- After major projects or initiatives
+- Following significant events (launches, incidents)
+- During long projects (milestone AARs)
+- Training and simulation exercises
+- Process improvement initiatives
+- Crisis response and incident management
+
+**Trade-offs**:
+- ✅ Simple, proven methodology (50+ years)
+- ✅ Promotes psychological safety and learning culture
+- ✅ Captures both tacit and explicit knowledge
+- ✅ Actionable insights for immediate improvement
+- ✅ Low cost, high impact
+- ❌ Requires cultural shift (blame-free environment)
+- ❌ Effectiveness depends on facilitator skill
+- ❌ Can be uncomfortable (discussing failures)
+- ❌ Lessons may not be implemented without follow-through
+
+**Critical Success Factors**:
+- Leadership commitment to learning culture
+- Skilled, neutral facilitation
+- Participation from all levels
+- Documentation and sharing of lessons
+- Accountability for implementing improvements
+- Integration with organizational processes
+
+**Citations**:
+- [After-action review - Wikipedia](https://en.wikipedia.org/wiki/After-action_review)
+- [The Leader's Guide to After-Action Reviews - Pinnacle Leaders](https://pinnacle-leaders.com/wp-content/uploads/2018/02/Leaders_Guide_to_AAR.pdf)
+- [After-Action Reviews: A Simple Yet Powerful Tool - Wharton](https://executiveeducation.wharton.upenn.edu/thought-leadership/wharton-at-work/2021/07/after-action-reviews-simple-tool/)
+
+---
+
+#### 4. Lessons Learned Systems
+
+**Purpose**: Systematic processes for identifying, capturing, storing, disseminating, and applying knowledge gained from experience
+
+**Best Practice Lifecycle**:
+
+**1. Capture**
+- Conduct throughout project lifecycle (not just at end)
+- Identify opportunities for improvement
+- Document successes for replication
+- Capture both positive and negative lessons
+
+**3 Quick Steps**:
+1. **Identify** lessons learned (what worked, what didn't, why)
+2. **Document** lessons learned (structured templates)
+3. **Analyze** lessons learned (root causes, patterns, recommendations)
+
+**2. Storage**
+- Create centralized knowledge repository
+- Use knowledge management systems
+- Internal wikis or shared drives
+- Searchable databases with metadata
+- Categorize by project type, domain, lesson type
+
+**3. Dissemination**
+- **Planned Dissemination**: Built into projects from start
+- **Context-Aware**: Tailor to audience and situation
+- **Leadership Responsibility**: Leaders champion sharing
+- **Systematic Strategies**: Active processes for distribution
+- **Multiple Channels**: Meetings, reports, training, newsletters
+
+**4. Application**
+- Input into new project planning
+- Reference during similar initiatives
+- Training materials for teams
+- Process improvement inputs
+- Proposal development
+
+**Common Capture Techniques**:
+
+**Retrospectives** (Agile):
+- End of each sprint
+- What went well, what needs improvement
+- Action items for next sprint
+
+**After-Action Reviews (AARs)**:
+- Structured reviews (see AAR section)
+- 4 core questions
+- Immediate application
+
+**Root Cause Analysis (RCA)**:
+- Investigate problems deeply
+- Identify systemic issues
+- Prevent recurrence
+
+**SWOT Analysis**:
+- Strengths, Weaknesses, Opportunities, Threats
+- Strategic lessons
+- Environmental factors
+
+**Best Practices**:
+
+**Management Support**:
+- Executive sponsorship essential
+- Demand contribution from all projects
+- Allocate resources for LL systems
+
+**Non-Attribution Culture**:
+- Focus on learning, not blame
+- Encourage honest sharing
+- Psychological safety
+
+**Submission Triggers**:
+- Built into project milestones
+- Mandatory for all project sizes
+- Both successes and failures
+
+**Facilitator Selection**:
+- Use neutral facilitators (not project members)
+- Prepare by meeting with project manager
+- Comfortable setting for sessions
+- Guard against negative/positive bias
+
+**When to Use**:
+- End of projects (formal closeout)
+- Sprint retrospectives (iterative development)
+- After major incidents or problems
+- Following successful innovations
+- During organizational change
+- Before similar projects begin
+
+**Trade-offs**:
+- ✅ Prevents repeating mistakes
+- ✅ Accelerates replication of successes
+- ✅ Builds organizational memory
+- ✅ Improves decision-making over time
+- ❌ Often insufficient dissemination (major challenge)
+- ❌ Requires cultural commitment to sharing
+- ❌ Can create "lesson fatigue" if not curated
+- ❌ Storage without application provides no value
+
+**Key Challenge** (Construction Industry Institute Study):
+Investigation of 2,400 organizations found most using insufficient dissemination processes. Capturing lessons is common; systematic sharing and application is rare.
+
+**Recommendations**:
+- Disseminate with eye toward use
+- Channel into new project planning
+- Make searchable and accessible
+- Curate for relevance (remove outdated)
+- Integrate with project templates
+- Train teams to consult before starting work
+
+**Citations**:
+- [A Guide to Capturing Lessons Learned - Conservation Gateway](https://www.conservationgateway.org/ConservationPlanning/partnering/cpc/Documents/Capturing_Lessons_Learned_Final.pdf)
+- [3 Quick Steps to Capture Lessons Learned - Brightwork](https://www.brightwork.com/blog/3-quick-steps-to-capture-lessons-learned)
+- [Lessons learned--the army way - PMI](https://www.pmi.org/learning/library/project-lessons-learned-army-way-7)
+
+---
+
+#### 5. Best Practice Transfer Protocols
+
+**Purpose**: Systematic approaches to transferring knowledge, skills, and proven methods from sources to recipients
+
+**Knowledge Types in Transfer**:
+
+1. **Explicit Knowledge**: Easy to articulate (documents, procedures, manuals)
+2. **Implicit Knowledge**: Application of explicit knowledge (skills, techniques)
+3. **Tacit Knowledge**: Personal experience (intuition, judgment, expertise)
+
+**Transfer Complexity Spectrum**:
+
+**Simple Knowledge** → **Concise Documentation**
+- Procedures, FAQs, checklists
+- Self-service resources
+- Quick reference guides
+- Standard Operating Procedures (SOPs)
+
+**Complex Knowledge** → **Interactive Transfer**
+- Mentoring and coaching
+- Shadowing and observation
+- Guided practice
+- Communities of practice
+- Apprenticeship models
+
+**Transfer Methods**:
+
+**1. Training Programs**
+- Structured learning sessions
+- Formal curricula
+- Certification programs
+- Classroom and virtual training
+
+**2. Documentation**
+- Manuals and guides
+- Standard Operating Procedures (SOPs)
+- Process documentation
+- Knowledge bases
+
+**3. Workshops and Seminars**
+- Interactive sessions
+- Hands-on practice
+- Group problem-solving
+- Expert-led discussions
+
+**4. Knowledge Management Systems**
+- Digital platforms
+- Searchable repositories
+- Wikis and intranets
+- Learning management systems
+
+**5. Mentoring and Coaching**
+- One-on-one guidance
+- Ongoing relationship
+- Tacit knowledge transfer
+- Context-specific learning
+
+**6. Peer-to-Peer Networks**
+- Communities of practice
+- Collaborative relationships
+- Knowledge sharing forums
+- Social learning
+
+**Best Practices for Effective Transfer**:
+
+**1. Foster Organizational Buy-in**
+- Leadership sponsorship
+- Team engagement
+- Clear value proposition
+
+**2. Clarify Knowledge as Shared Asset**
+- Knowledge belongs to organization
+- Sharing is expected and rewarded
+- Intellectual property policies
+
+**3. Promote Trust and Transparency**
+- Open communication channels
+- Psychological safety
+- No-blame culture
+
+**4. Embrace Diversity**
+- Accommodate different learning styles
+- Multiple transfer methods
+- Cultural sensitivity
+
+**5. Define Clear Objectives**
+- What knowledge to transfer
+- Who needs it
+- When transfer occurs
+- Success criteria
+
+**6. Assign Roles and Responsibilities**
+- Knowledge sources (subject matter experts)
+- Recipients (learners)
+- Facilitators (coordinators)
+- Sponsors (leadership)
+
+**Knowledge Transfer Plan Components**:
+- Scope and objectives
+- Knowledge inventory
+- Transfer methods and timelines
+- Roles and responsibilities
+- Success metrics
+- Documentation storage location
+
+**Challenges and Barriers**:
+
+**Structural Hurdles**:
+- Organizational silos
+- Geographic dispersion
+- Technology limitations
+- Resource constraints
+
+**Behavioral Hurdles**:
+- Source unwillingness to share (job security fears)
+- Recipient unwillingness to learn (not-invented-here)
+- Lack of incentives
+- Time pressure
+
+**Knowledge Characteristics**:
+- Tacit knowledge difficult to articulate
+- Context-dependent application
+- Relationship-based transfer needed
+
+**Real-World Examples**:
+
+**Toyota Production System (TPS)**:
+- "Kaizen" philosophy (continuous improvement)
+- Knowledge sharing at all levels
+- Document, share, implement ideas
+- Systematic capture and transfer
+
+**NASA Engineering Network (NEN)**:
+- Centralized repository
+- Technical reports and lessons learned
+- Best practices from past missions
+- Apply knowledge to new challenges
+
+**When to Use**:
+- Employee onboarding
+- Succession planning (retirements)
+- Cross-functional team collaboration
+- Scaling best practices across units
+- Post-acquisition integration
+- Process standardization initiatives
+
+**Trade-offs**:
+- ✅ Prevents knowledge loss from turnover
+- ✅ Accelerates competency development
+- ✅ Standardizes performance across organization
+- ✅ Preserves critical organizational knowledge
+- ❌ Time-intensive for both source and recipient
+- ❌ Tacit knowledge transfer requires close relationships
+- ❌ Source resistance if not properly incentivized
+- ❌ Context differences may limit applicability
+
+**Success Factors**:
+- Relationship between knowledgeable source and willing recipient
+- Constant connections to guide people to expertise
+- Recipient motivation to learn
+- Source motivation to share
+- Organizational incentives aligned
+- Adequate time and resources allocated
+
+**Citations**:
+- [8 Strategies for Successful Knowledge Transfer - IMD](https://www.imd.org/blog/leadership/knowledge-transfer/)
+- [Knowledge Transfer: A Comprehensive Guide - Tettra](https://tettra.com/article/knowledge-transfer/)
+- [What is Knowledge Transfer? - APQC](https://www.apqc.org/blog/what-knowledge-transfer)
+
+---
+
+#### 6. Expert Locator Systems (Yellow Pages)
+
+**Purpose**: Tools and systems to identify and connect people with required expertise within organizations
+
+**Terminology**:
+- **Expert Locator**: Recommendation engine pointing to people with expertise
+- **Skills Inventory**: Database of employee competencies and expertise
+- **Electronic Yellow Pages**: Directory of organizational expertise
+- **Knowledge Yellow Pages**: Repository of "who knows what"
+- **People-Finder Systems**: Pointers to experts possessing specific knowledge
+- **Expertise Finder**: Search systems for discovering experts
+
+**Core Value Proposition**:
+> "Knowing who knows what is often more valuable than knowing how to do."
+
+**System Types**:
+
+**1. Profile-Based Systems**
+- Employees create/maintain expertise profiles
+- Self-reported skills and experience
+- Searchable databases
+- Examples: Internal directories, LinkedIn-style systems
+
+**2. Automated Discovery Systems**
+- Mine documents, emails, communications
+- Algorithmic expertise detection
+- Activity-based profiling
+- Social network analysis
+
+**3. Hybrid Systems**
+- Combine self-reporting with automated detection
+- Community endorsements and validation
+- Activity signals from collaboration tools
+- Examples: Microsoft Delve, expertise graphs
+
+**Detection Signals**:
+
+**Industrial Systems** (e.g., LinkedIn):
+- User-generated content (profiles)
+- Community-generated content (endorsements, recommendations)
+- Skills validation
+- Personalized signals (social connections, interaction history)
+- Content creation and engagement
+
+**Internal Systems**:
+- Document authorship
+- Project participation
+- Email and communication patterns
+- Wiki contributions
+- Blog posts and comments
+- Training/certification records
+- Performance reviews
+
+**Commercial Tools**:
+- TACIT ActiveNet™
+- AskMe
+- Autonomy IDOL K2
+- Endeca
+- Recommind
+- Triviumsoft's SEE-K
+- Entopia Expertise Location
+
+**Example: NASA Expert Seeker**:
+- Organizational People-Finder KMS
+- Locates subject matter experts at NASA
+- Searchable by technical domain
+- Links expertise to projects and publications
+
+**Implementation Approaches**:
+
+**Self-Maintained Profiles**:
+- ✅ User control and accuracy
+- ✅ Contextual information
+- ❌ Maintenance burden
+- ❌ Out-of-date risk
+- ❌ Voluntary participation issues
+
+**Automated Scanning**:
+- ✅ Always current
+- ✅ No user maintenance
+- ❌ Privacy concerns
+- ❌ Acceptance resistance
+- ❌ Accuracy challenges
+
+**Social/Community Validation**:
+- ✅ Crowd-sourced accuracy
+- ✅ Reputation signals
+- ✅ Natural engagement indicators
+- ❌ Popularity vs. expertise confusion
+- ❌ Gaming potential
+
+**Key Challenges**:
+
+**1. Currency and Maintenance**:
+- Keeping information up-to-date
+- Capturing evolving expertise
+- Removing outdated entries
+
+**2. Expertise Classification**:
+- How to categorize skills/knowledge
+- Granularity levels
+- Taxonomy design
+
+**3. Ranking and Assessment**:
+- How to assess expertise objectively
+- Subjective vs. objective measures
+- Social vs. technical validation
+- Consequences of public rankings
+
+**4. Privacy and Acceptance**:
+- Employee concerns about monitoring
+- Voluntary vs. required participation
+- Work/personal boundary issues
+
+**When to Use**:
+- Large organizations (difficulty finding expertise)
+- Geographically distributed teams
+- Knowledge-intensive industries (consulting, R&D)
+- Matrix organizations (cross-functional work)
+- Project-based work (team formation)
+- Innovation initiatives (connecting diverse expertise)
+
+**Trade-offs**:
+- ✅ Reduces time to find expertise
+- ✅ Breaks down organizational silos
+- ✅ Enables serendipitous connections
+- ✅ Supports collaboration and innovation
+- ❌ Privacy and surveillance concerns
+- ❌ Maintenance overhead (profile-based)
+- ❌ Potential for interruption (being found too much)
+- ❌ Expertise assessment challenges
+
+**Best Practices**:
+- Integrate with natural workflows (don't create separate systems)
+- Mine blogs, wikis, collaborative platforms
+- Use social validation (endorsements)
+- Make participation voluntary when possible
+- Respect privacy boundaries
+- Provide value to both seekers and experts
+- Include context (projects, publications, not just titles)
+- Enable rich profiles (not just skill lists)
+
+**Modern Trends**:
+- Integration with collaboration platforms (Teams, Slack)
+- AI-powered expertise recommendations
+- Graph-based knowledge networks
+- Activity-based inference (reduce manual updating)
+- Federated search across systems
+
+**Citations**:
+- [KM Component 35 – Expertise Locators and Ask the Expert - Lucidea](https://lucidea.com/blog/km-component-35-expertise-locators-and-ask-the-expert/)
+- [Expertise Locators and Ask the Expert - Stan Garfield](https://stangarfield.medium.com/expertise-locators-and-ask-the-expert-f273db1e227c)
+- [Expert Finding Systems - MITRE Technical Report](https://www.mitre.org/sites/default/files/pdf/06_1115.pdf)
+- [Expertise finding - Wikipedia](https://en.wikipedia.org/wiki/Expertise_finding)
+
+---
+
+## L2: Strategic Protocol Selection for Jerry Framework
+
+### Decision Framework for Protocol Selection
+
+#### Context: Jerry's Unique KM Requirements
+
+Jerry operates as a **meta-framework** for AI agent behavior and workflow guardrails. Key characteristics:
+
+1. **Filesystem as Infinite Memory**: Knowledge persisted in structured file hierarchy
+2. **Agent-Based Execution**: Multiple specialized agents with defined roles
+3. **Problem-Solving Domain**: Systematic research, analysis, synthesis, validation
+4. **Knowledge Accumulation**: Building wisdom and experience over time
+5. **Context Rot Mitigation**: Offloading state to files to preserve working memory
+
+#### Recommended Protocol Portfolio for Jerry
+
+Based on these characteristics, Jerry should implement a **layered KM protocol strategy**:
+
+---
+
+### Tier 1: Immediate Implementation (High Value, Low Complexity)
+
+#### 1. After Action Reviews (AARs) - PRIMARY PROTOCOL
+
+**Why**: Perfect fit for Jerry's workflow structure
+
+**Implementation**:
+- Conduct AAR after each completed WORK item
+- Document in `docs/experience/aar-{work-id}.md`
+- Use standardized 4-question template
+- Feed insights into `docs/wisdom/` and `docs/knowledge/`
+
+**Jerry-Specific Adaptation**:
+```markdown
+# AAR Template for Jerry
+
+## Work Item: {WORK-ID}
+## Date: {YYYY-MM-DD}
+
+### 1. What did we intend to accomplish?
+- Original problem statement
+- Intended outcomes
+- Success criteria
+
+### 2. What did we do?
+- Actual approach taken
+- Agents/skills utilized
+- Deliverables created
+
+### 3. Why did it happen that way?
+- Deviations from plan
+- Unexpected challenges
+- Favorable conditions
+
+### 4. What will we do next time?
+- Process improvements
+- Agent refinements
+- Documentation updates
+- Knowledge gaps identified
+```
+
+**Expected Benefits**:
+- Captures both process and content knowledge
+- Minimal overhead (already aligned with work completion)
+- Feeds continuous improvement
+- Creates searchable experience repository
+
+---
+
+#### 2. Knowledge Mapping (Lightweight)
+
+**Why**: Jerry already has structured documentation; maps make it navigable
+
+**Implementation**:
+- Create visual maps linking:
+  - `docs/` hierarchy structure
+  - Skills → Use Cases → Agents
+  - Problem domains → Relevant knowledge files
+  - Expertise areas → Specific documentation
+
+**Tools**:
+- Start with Markdown-based concept maps (mermaid.js)
+- Graduate to CmapTools for complex domains if needed
+
+**Jerry-Specific Application**:
+```mermaid
+graph TD
+    A[Problem-Solving Skill] --> B[ps-orchestrator]
+    B --> C[ps-researcher]
+    B --> D[ps-analyst]
+    B --> E[ps-synthesizer]
+    B --> F[ps-validator]
+    C --> G[docs/research/]
+    D --> H[docs/analysis/]
+    E --> I[docs/synthesis/]
+    F --> J[docs/decisions/]
+```
+
+**Expected Benefits**:
+- Onboarding new agents/users
+- Quick reference for skill selection
+- Reveals knowledge gaps visually
+
+---
+
+#### 3. Lessons Learned System
+
+**Why**: Jerry already creates deliverables; systematic capture ensures reuse
+
+**Implementation**:
+- Template: `docs/experience/lessons-learned-{topic}.md`
+- Aggregate lessons quarterly: `docs/experience/YYYY-QN-lessons.md`
+- Cross-reference in relevant `docs/knowledge/` files
+- Index in Work Tracker for discoverability
+
+**Dissemination Strategy**:
+- Include lessons in agent prompts (e.g., "Past teams learned...")
+- Link from `CLAUDE.md` to most critical lessons
+- Incorporate into skill refinements
+
+**Expected Benefits**:
+- Prevents repeating mistakes
+- Accelerates similar future work
+- Builds organizational memory despite ephemeral sessions
+
+---
+
+### Tier 2: Medium-Term Implementation (Moderate Complexity)
+
+#### 4. Knowledge Audit (Quarterly or Semi-Annual)
+
+**Why**: Periodic assessment ensures knowledge architecture stays aligned with needs
+
+**Implementation**:
+- Conduct audit every 6 months or after major milestones
+- Assess: `docs/knowledge/`, `docs/wisdom/`, `docs/experience/`
+- Identify: Gaps, redundancies, outdated content, missing connections
+
+**6-Step Process for Jerry**:
+1. **Goals**: Assess knowledge coverage for core problem-solving domains
+2. **Method**: Automated analysis (file counts, age) + manual review
+3. **Ideal State**: Comprehensive coverage of domains, no stale content
+4. **Audit**: Compare current state to ideal
+5. **Document**: Create `docs/governance/knowledge-audit-YYYY-QN.md`
+6. **Strategic Position**: Prioritize knowledge creation efforts
+
+**Expected Benefits**:
+- Proactive gap identification
+- Prevents knowledge rot
+- Guides content creation priorities
+
+---
+
+#### 5. Dublin Core Metadata (File Frontmatter)
+
+**Why**: Standardized metadata enables search, categorization, and tool integration
+
+**Implementation**:
+- Add Dublin Core metadata to all `docs/` markdown files
+- Use YAML frontmatter
+
+**Template**:
+```yaml
+---
+title: "Knowledge Management Protocols Research"
+creator: "ps-researcher v2.0.0"
+subject: ["knowledge management", "protocols", "standards"]
+description: "Comprehensive research on KM standards, protocols, and methodologies"
+date: "2026-01-08"
+type: "Research Report"
+identifier: "work-032-e-002"
+language: "en"
+relation: ["work-032", "ADR-032"]
+coverage: "Knowledge Management domain"
+rights: "Internal Jerry Framework"
+---
+```
+
+**Expected Benefits**:
+- Machine-readable metadata
+- Future tool integration (search, categorization)
+- Interoperability with external systems
+
+---
+
+### Tier 3: Long-Term Implementation (Strategic Maturity)
+
+#### 6. ISO 30401:2018 Alignment (Aspirational)
+
+**Why**: Provides comprehensive KM framework for mature system
+
+**Phased Approach**:
+- **Phase 1** (Year 1): Informal assessment against ISO 30401 requirements
+- **Phase 2** (Year 2): Address major gaps in systematic KM
+- **Phase 3** (Year 3+): Full alignment (optional certification)
+
+**Expected Benefits**:
+- Industry-standard KM practices
+- Systematic approach to knowledge governance
+- Potential competitive advantage (if Jerry becomes product)
+
+---
+
+#### 7. APQC Maturity Assessment
+
+**Why**: Benchmark progress and guide multi-year roadmap
+
+**Implementation**:
+- Annual maturity assessment using APQC model
+- Track progression: Initiate → Develop → Standardize → Optimize → Innovate
+- Document in `docs/governance/km-maturity-YYYY.md`
+
+**Jerry's Current State**: **Develop** (structured approaches emerging)
+
+**Target State** (2-3 years): **Standardize** (consistent practices, documented processes)
+
+**Expected Benefits**:
+- Clear progression path
+- Prioritization of KM investments
+- Measurable improvement over time
+
+---
+
+#### 8. Expert Locator (Agent Capabilities Registry)
+
+**Why**: Jerry has multiple specialized agents; locating right agent for task is key
+
+**Implementation**:
+- Maintain `AGENTS.md` registry with:
+  - Agent names and versions
+  - Expertise domains
+  - Capabilities and limitations
+  - Example use cases
+  - Performance history
+
+**Searchable Fields**:
+- Domain (research, analysis, synthesis, validation, security, QA)
+- Model (Opus, Sonnet, Haiku)
+- Skills (technical writing, code review, testing, security auditing)
+
+**Expected Benefits**:
+- Optimal agent selection for tasks
+- Avoid agent misuse
+- Identify capability gaps
+
+---
+
+### Decision Matrix: When to Use Which Protocol
+
+| Protocol | Use When... | Don't Use When... | Complexity | ROI |
+|----------|-------------|-------------------|------------|-----|
+| **After Action Review** | Completing work items, projects, incidents | Trivial tasks, routine operations | Low | Very High |
+| **Knowledge Mapping** | Onboarding, planning, gap analysis | Content is simple/linear | Low-Med | High |
+| **Lessons Learned** | Completing projects, post-incident, quarterly reviews | No actionable insights available | Low | High |
+| **Knowledge Audit** | Initiating KM, every 6-12 months, before major changes | Knowledge base is small/new | Medium | Medium-High |
+| **Dublin Core Metadata** | All documentation creation | Temporary/scratch files | Low | Medium |
+| **Best Practice Transfer** | Onboarding, process standardization, scaling | Knowledge is highly tacit/contextual | Medium | Medium |
+| **Expert Locator** | Large agent ecosystem, task assignment | Few agents/simple assignments | Low-Med | Medium |
+| **SKOS Taxonomy** | Complex multi-domain knowledge, tool integration | Simple file hierarchy suffices | High | Low-Med |
+| **ISO 30401 Alignment** | Mature KM system, seeking certification | Early-stage KM, small scale | High | Low-High* |
+| **Maturity Assessment** | Annual planning, benchmarking, roadmap creation | Frequent changes, unstable system | Low-Med | Medium |
+
+*ROI of ISO 30401 depends heavily on organizational scale and certification value
+
+---
+
+### Protocol Selection Flowchart
+
+```
+START: Need to manage knowledge
+│
+├─ Reactive (issue occurred) ───→ After Action Review
+│
+├─ Proactive Planning ───→ Is knowledge complex/multi-domain?
+│                          │
+│                          ├─ Yes ───→ Knowledge Mapping
+│                          └─ No  ───→ Structured Documentation
+│
+├─ Periodic Review ───→ How much content?
+│                      │
+│                      ├─ Large ───→ Knowledge Audit
+│                      └─ Small ───→ Manual Review + Lessons Learned
+│
+├─ Finding Expertise ───→ Expert Locator / Agent Registry
+│
+├─ Transferring Knowledge ───→ Tacit or Explicit?
+│                              │
+│                              ├─ Tacit ───→ Mentoring/Shadowing
+│                              └─ Explicit ───→ Documentation + Training
+│
+├─ Organizing Vocabulary ───→ Simple hierarchy?
+│                             │
+│                             ├─ Yes ───→ File folders + metadata
+│                             └─ No  ───→ SKOS Taxonomy
+│
+└─ Strategic Maturity ───→ APQC Assessment + ISO 30401 Roadmap
+```
+
+---
+
+### Trade-off Analysis: Codification vs. Personalization for Jerry
+
+#### The Core Strategic Choice
+
+**Codification Strategy** (People → Documents):
+- Capture, codify, store, disseminate, reuse explicit knowledge
+- Emphasizes knowledge bases, documentation, templates
+- Scales well, accessible 24/7
+
+**Personalization Strategy** (People → People):
+- Facilitate knowledge transfer through relationships
+- Emphasizes mentoring, communities, storytelling
+- Rich tacit knowledge transfer
+
+#### Jerry's Context
+
+**Competitive Strategy**: Systematic problem-solving through documented processes
+**Product Type**: Structured workflows with accumulated knowledge
+**Innovation Level**: Moderate (methodological innovation, not radical invention)
+**Knowledge Nature**: Mix of explicit (processes, frameworks) and tacit (agent tuning, prompt engineering)
+
+#### Recommended Balance: **70% Codification / 30% Personalization**
+
+**Rationale**:
+- Jerry emphasizes **file persistence** (P-002 in Constitution)
+- Ephemeral agent sessions require documented knowledge
+- Processes and frameworks are highly codifiable
+- BUT: Agent tuning and skill development require experimentation (tacit)
+
+**Codification Elements (70%)**:
+- Process documentation (`docs/knowledge/`)
+- Agent definitions (`.claude/agents/`)
+- ADRs and design decisions (`docs/design/`)
+- Research reports (`docs/research/`)
+- Templates and skills (`skills/`)
+
+**Personalization Elements (30%)**:
+- User-agent interaction refinement
+- Skill development through experimentation
+- Prompt engineering tacit knowledge
+- Community of practice (future: Jerry users)
+- Oral tradition through `docs/wisdom/` narratives
+
+**Implementation**:
+- Primary: Comprehensive documentation (codification)
+- Secondary: Capture tacit insights in `docs/wisdom/` and `docs/experience/`
+- Balance: Document processes, but encourage experimentation and adaptation
+
+---
+
+### Comparison Matrix: Standards and Protocols
+
+| Dimension | ISO 30401 | APQC Framework | After Action Review | Knowledge Audit | Dublin Core | SKOS |
+|-----------|-----------|----------------|---------------------|-----------------|-------------|------|
+| **Type** | Standard | Framework | Protocol | Protocol | Standard | Standard |
+| **Scope** | Enterprise KM System | KM Program Implementation | Event Learning | KM Assessment | Metadata | Taxonomy |
+| **Formality** | Very High | Medium-High | Low-Medium | Medium | High | High |
+| **Effort** | High | High | Low | Medium | Low | Medium |
+| **Time to Value** | 12-24 months | 6-12 months | Immediate | 1-3 months | Immediate | 3-6 months |
+| **Best For** | Large orgs, compliance | KM from scratch | Continuous learning | Baseline assessment | Interoperability | Controlled vocabularies |
+| **Worst For** | Small orgs, startups | Agile/rapid change | Trivial events | Small knowledge bases | Complex semantics | Simple hierarchies |
+| **Certification Available** | Yes (optional) | No | No | No | No (inherent standard) | No (W3C Rec) |
+| **Tool Support** | Consulting firms | APQC resources | Templates | Frameworks/consultants | Universal | RDF tools |
+| **Maintenance** | Continuous | Continuous | Per-event | Periodic | Per-document | Periodic |
+| **Jerry Fit** | Long-term | Medium-term | Immediate | Medium-term | Immediate | Optional |
+
+---
+
+### Implementation Roadmap for Jerry (24 Months)
+
+#### Q1 2026 (Immediate): Foundation
+- ✅ Implement AAR template and process
+- ✅ Create basic knowledge maps (skills/agents/docs)
+- ✅ Establish lessons learned repository structure
+- ✅ Add Dublin Core metadata to new documents
+
+#### Q2 2026: Systematization
+- Conduct first Knowledge Audit
+- Standardize all `docs/` frontmatter with metadata
+- Create Agent Capabilities Registry (Expert Locator)
+- Document KM processes in `docs/knowledge/`
+
+#### Q3-Q4 2026: Maturity
+- Conduct APQC maturity self-assessment
+- Quarterly lessons learned aggregation
+- Expand knowledge maps to cover all domains
+- Refine AAR process based on experience
+
+#### Q1 2027: Optimization
+- Second Knowledge Audit (compare to baseline)
+- Implement automated metadata validation
+- Pilot SKOS taxonomy for complex domains
+- Annual maturity assessment
+
+#### Q2-Q4 2027: Advanced Practices
+- Evaluate ISO 30401 alignment (gap analysis)
+- Implement best practice transfer protocols
+- Advanced knowledge mapping (cross-domain)
+- Knowledge flow optimization
+
+---
+
+## Full Citations and References
+
+### Standards Documentation
+
+1. **ISO 30401:2018 - Knowledge Management Systems**
+   - [Official Standard - ISO](https://www.iso.org/standard/68683.html)
+   - [The essence of ISO 30401 - RealKM](https://realkm.com/2022/02/02/the-essence-of-the-iso-30401-knowledge-management-standard/)
+   - [ISO 30401:2018/Amd 1:2022](https://www.iso.org/standard/79489.html)
+   - [BSI Knowledge - BS ISO 30401:2018](https://knowledge.bsigroup.com/products/knowledge-management-systems-requirements-1)
+
+2. **ISO 9001:2015 - Organizational Knowledge**
+   - [Organizational knowledge in ISO 9001:2015 - Cognidox](https://www.cognidox.com/blog/2015/08/organizational-knowledge-in-iso-90012015)
+   - [Requirement of Knowledge Management in ISO 9001:2015 - Qualityze](https://www.qualityze.com/blogs/requirement-of-knowledge-management-iso-90012015)
+   - [How Does ISO 9001:2015 Relate to Organizational Knowledge? - NQA](https://www.nqa.com/en-us/resources/blog/january-2016/effective-organizational-knowledge)
+   - [Knowledge Management and ISO 9001:2015 - RealKM](https://realkm.com/2015/10/14/knowledge-management-and-iso-90012015/)
+
+3. **APQC Knowledge Management Framework**
+   - [APQC's Knowledge Management Framework](https://www.apqc.org/resource-library/resource-listing/apqcs-knowledge-management-framework)
+   - [Knowledge Management Strategic Framework - APQC](https://www.apqc.org/expertise/knowledge-management/interactive-km-framework)
+   - [APQC's Knowledge Flow Process Framework](https://www.apqc.org/resource-library/resource-listing/apqcs-knowledge-flow-process-framework)
+   - [APQC's Levels of Knowledge Management Maturity](https://www.apqc.org/resource-library/resource-listing/apqcs-levels-knowledge-management-maturity)
+
+4. **KM Maturity Models**
+   - [Knowledge Management Maturity Models - Stan Garfield, Medium](https://stangarfield.medium.com/knowledge-management-maturity-models-fd094ed49e48)
+   - [Knowledge Management Maturity Models – A Morphological Analysis](https://journals.klalliance.org/index.php/JKMP/article/download/228/222/462)
+   - [A Model of Organisational Knowledge Management Maturity - ResearchGate](https://www.researchgate.net/publication/263803353_A_Model_of_Organisational_Knowledge_Management_Maturity_Based_on_People_Process_and_Technology)
+
+5. **Dublin Core Metadata Initiative**
+   - [Dublin Core Metadata Initiative - Official Site](https://www.dublincore.org/)
+   - [Dublin Core - Wikipedia](https://en.wikipedia.org/wiki/Dublin_Core)
+   - [DCMI: About DCMI](https://www.dublincore.org/about/)
+   - [DCMI: Dublin Core Metadata Element Set, Version 1.1](https://www.dublincore.org/specifications/dublin-core/dces/)
+
+6. **SKOS - Simple Knowledge Organization System**
+   - [SKOS Simple Knowledge Organization System - W3C](https://www.w3.org/2004/02/skos/)
+   - [SKOS Reference - W3C Recommendation](https://www.w3.org/TR/skos-reference/)
+   - [Simple Knowledge Organization System - Wikipedia](https://en.wikipedia.org/wiki/Simple_Knowledge_Organization_System)
+   - [SKOS Namespace Document](https://www.w3.org/2009/08/skos-reference/skos.html)
+
+### Protocols and Methods
+
+7. **Knowledge Audits**
+   - [Knowledge Audit Concepts, Processes and Practice - ResearchGate](https://www.researchgate.net/publication/264096059_Knowledge_audit_concepts_processes_and_practice)
+   - [Knowledge Management Audit Framework - Emerald Insight](https://www.emerald.com/insight/content/doi/10.1108/17468770911013546/full/html)
+   - [A Model and Methodology to Knowledge Auditing - ResearchGate](https://www.researchgate.net/publication/237438182_A_Model_and_Methodology_to_Knowledge_Auditing_Considering_Core_Processes)
+   - [How to Conduct a Knowledge Management Assessment in 5 Steps - Shelf](https://shelf.io/blog/knowledge-management-assessement/)
+
+8. **Knowledge Mapping**
+   - [Concept Maps: Integrating Knowledge and Information Visualization - Springer](https://link.springer.com/chapter/10.1007/11510154_11)
+   - [CmapTools - Official Site](https://cmap.ihmc.us/)
+   - [CmapTools - Wikipedia](https://en.wikipedia.org/wiki/CmapTools)
+   - [Everything You Need to Know about Knowledge Mapping - Tettra](https://tettra.com/article/knowledge-mapping/)
+
+9. **After Action Reviews (AAR)**
+   - [After-action review - Wikipedia](https://en.wikipedia.org/wiki/After-action_review)
+   - [The Leader's Guide to After-Action Reviews - Pinnacle Leaders](https://pinnacle-leaders.com/wp-content/uploads/2018/02/Leaders_Guide_to_AAR.pdf)
+   - [After-Action Reviews: A Simple Yet Powerful Tool - Wharton](https://executiveeducation.wharton.upenn.edu/thought-leadership/wharton-at-work/2021/07/after-action-reviews-simple-tool/)
+   - [After Action Reviews - Nano Tools for Leaders](https://executiveeducation.wharton.upenn.edu/thought-leadership/wharton-at-work/2012/04/after-action-reviews/)
+
+10. **Lessons Learned Systems**
+    - [A Guide to Capturing Lessons Learned - Conservation Gateway](https://www.conservationgateway.org/ConservationPlanning/partnering/cpc/Documents/Capturing_Lessons_Learned_Final.pdf)
+    - [3 Quick Steps to Capture Lessons Learned - Brightwork](https://www.brightwork.com/blog/3-quick-steps-to-capture-lessons-learned)
+    - [Lessons learned--the army way - PMI](https://www.pmi.org/learning/library/project-lessons-learned-army-way-7)
+    - [Spreading Lessons Learned and Best Practices - Nurse Key](https://nursekey.com/spreading-lessons-learned-and-best-practices-dissemination/)
+
+11. **Best Practice Transfer**
+    - [8 Strategies for Successful Knowledge Transfer - IMD](https://www.imd.org/blog/leadership/knowledge-transfer/)
+    - [Knowledge Transfer: A Comprehensive Guide - Tettra](https://tettra.com/article/knowledge-transfer/)
+    - [What is Knowledge Transfer? - APQC](https://www.apqc.org/blog/what-knowledge-transfer)
+    - [Knowledge Transfer Process: 6-Step Guide - MyHub](https://www.myhubintranet.com/knowledge-transfer/)
+
+12. **Expert Locator Systems**
+    - [KM Component 35 – Expertise Locators and Ask the Expert - Lucidea](https://lucidea.com/blog/km-component-35-expertise-locators-and-ask-the-expert/)
+    - [Expertise Locators and Ask the Expert - Stan Garfield, Medium](https://stangarfield.medium.com/expertise-locators-and-ask-the-expert-f273db1e227c)
+    - [Expert Finding Systems - MITRE Technical Report](https://www.mitre.org/sites/default/files/pdf/06_1115.pdf)
+    - [Expertise finding - Wikipedia](https://en.wikipedia.org/wiki/Expertise_finding)
+
+### Decision Frameworks and Strategy
+
+13. **KM Framework Selection**
+    - [A Guide to Choosing a Knowledge Management Framework - InvGate](https://blog.invgate.com/knowledge-management-framework)
+    - [Knowledge Management Frameworks: 6 Types & 5 Models - Slite](https://slite.com/en/learn/knowledge-management-frameworks)
+    - [KM Component 12 – Knowledge Management Methodologies - Lucidea](https://lucidea.com/blog/km-component-12-knowledge-management-methodologies/)
+    - [Knowledge Management Tools and Techniques Manual - APO](https://www.apo-tokyo.org/wp-content/uploads/2020/02/KM-Tools-and-Texhniques-Manual.pdf)
+
+14. **Codification vs. Personalization**
+    - [Don't fall for that false dichotomy! Codification vs. personalization - KMWorld](https://www.kmworld.com/Articles/Editorial/Features/Dont-fall-for-that-false-dichotomy!-Codification-vs.-personalization--9272.aspx)
+    - [Knowledge management, codification and tacit knowledge - Information Research](https://informationr.net/ir/18-2/paper577.html)
+    - [Developing a Codification Strategy in Knowledge Management - Bloomfire](https://bloomfire.com/blog/codification-strategy-in-knowledge-management/)
+    - [Tacit Knowledge Vs. Explicit Knowledge - AIIM](https://info.aiim.org/aiim-blog/tacit-knowledge-vs-explicit-knowledge)
+
+---
+
+## Appendices
+
+### Appendix A: Glossary of KM Terms
+
+**After Action Review (AAR)**: Structured review process to analyze what happened during an event, why it happened, and how to improve future performance
+
+**Codification Strategy**: KM approach emphasizing capture and storage of explicit knowledge in documents and databases
+
+**Dublin Core**: Set of 15 metadata elements for describing digital and physical resources
+
+**Explicit Knowledge**: Knowledge that can be easily articulated, documented, and shared (procedures, facts, principles)
+
+**Expert Locator**: System for identifying individuals with specific expertise within an organization
+
+**Knowledge Audit**: Systematic assessment of organizational knowledge needs, resources, and flows
+
+**Knowledge Flow**: Movement of knowledge through creation, identification, collection, review, sharing, access, and use
+
+**Knowledge Mapping**: Visualization of knowledge location, relationships, and flows within organizations
+
+**Knowledge Maturity**: Degree to which KM practices are systematic, disciplined, and aligned with strategy
+
+**Lessons Learned**: Insights and knowledge gained from experience, captured for future application
+
+**Personalization Strategy**: KM approach emphasizing people-to-people knowledge transfer through relationships
+
+**SKOS**: W3C standard for representing thesauri and taxonomies as linked data
+
+**Tacit Knowledge**: Personal, experience-based knowledge that is difficult to articulate or codify
+
+### Appendix B: Jerry-Specific Templates
+
+#### AAR Template
+```markdown
+# After Action Review: {WORK-ID}
+
+**Date**: {YYYY-MM-DD}
+**Facilitator**: {Agent Name}
+**Participants**: {User, Agents involved}
+
+## 1. What did we intend to accomplish?
+
+**Original Goal**:
+[Problem statement from WORK file]
+
+**Success Criteria**:
+- [Criterion 1]
+- [Criterion 2]
+
+## 2. What did we do?
+
+**Approach Taken**:
+[Description of methodology]
+
+**Agents/Skills Used**:
+- {Agent 1}: {Role}
+- {Agent 2}: {Role}
+
+**Deliverables Created**:
+- [{File path 1}]
+- [{File path 2}]
+
+## 3. Why did it happen that way?
+
+**What Went Well**:
+- [Strength 1]
+- [Strength 2]
+
+**What Didn't Go Well**:
+- [Challenge 1]
+- [Challenge 2]
+
+**Unexpected Outcomes**:
+- [Outcome 1]
+
+## 4. What will we do next time?
+
+**Process Improvements**:
+- [Improvement 1]
+
+**Agent/Skill Refinements**:
+- [Refinement 1]
+
+**Documentation Updates Needed**:
+- [Update 1]
+
+**Knowledge Gaps Identified**:
+- [Gap 1]
+
+## Lessons Learned
+
+**Key Takeaways**:
+1. [Lesson 1]
+2. [Lesson 2]
+
+**Apply To**:
+- [Future work type 1]
+- [Future work type 2]
+
+## Follow-Up Actions
+
+- [ ] Update {skill/agent/doc} based on findings
+- [ ] Add lesson to docs/wisdom/{topic}.md
+- [ ] Cross-reference in WORKTRACKER
+
+---
+**Filed**: docs/experience/aar-{work-id}.md
+**Related**: {Links to work deliverables, ADRs, related AARs}
+```
+
+#### Knowledge Audit Template
+```markdown
+# Knowledge Audit Report
+
+**Audit Period**: {Start Date} - {End Date}
+**Auditor**: {Name/Agent}
+**Date**: {YYYY-MM-DD}
+
+## Executive Summary
+
+[2-3 paragraphs summarizing findings and recommendations]
+
+## 1. Audit Goals and Scope
+
+**Objectives**:
+- [Objective 1]
+- [Objective 2]
+
+**Scope**:
+- Directories audited: {list}
+- Time period: {range}
+- Focus areas: {domains}
+
+## 2. Current State Assessment
+
+### Knowledge Inventory
+
+| Domain | File Count | Last Updated | Completeness |
+|--------|------------|--------------|--------------|
+| {Domain 1} | {N} | {Date} | {%} |
+| {Domain 2} | {N} | {Date} | {%} |
+
+### Knowledge Flows
+
+**Creation**: {Assessment of how knowledge is created}
+**Capture**: {Assessment of capture mechanisms}
+**Storage**: {Assessment of organization and storage}
+**Access**: {Assessment of discoverability}
+**Use**: {Assessment of application}
+
+## 3. Ideal State Definition
+
+**Desired Coverage**:
+- [Domain 1: Description of ideal state]
+- [Domain 2: Description of ideal state]
+
+**Desired Flows**:
+- [Flow improvement 1]
+- [Flow improvement 2]
+
+## 4. Gap Analysis
+
+### Critical Gaps
+1. **{Gap 1 Name}**
+   - **Impact**: {High/Medium/Low}
+   - **Description**: {Details}
+   - **Recommendation**: {Action}
+
+2. **{Gap 2 Name}**
+   - **Impact**: {High/Medium/Low}
+   - **Description**: {Details}
+   - **Recommendation**: {Action}
+
+### Redundancies
+- [{Redundancy 1}]
+- [{Redundancy 2}]
+
+### Outdated Content
+- [{File 1}]: Last updated {date}, {reason outdated}
+- [{File 2}]: Last updated {date}, {reason outdated}
+
+## 5. Knowledge Map
+
+[Insert or link to visual knowledge map]
+
+## 6. Recommendations
+
+### Priority 1 (Immediate)
+- [Action 1]
+- [Action 2]
+
+### Priority 2 (Short-term, 1-3 months)
+- [Action 1]
+- [Action 2]
+
+### Priority 3 (Medium-term, 3-6 months)
+- [Action 1]
+- [Action 2]
+
+## 7. Metrics
+
+**Knowledge Coverage**:
+- Total files: {N}
+- Average age: {N days}
+- Files updated in last 30 days: {N}
+- Files older than 6 months: {N}
+
+**Knowledge Quality** (sample review):
+- Complete and accurate: {%}
+- Needs update: {%}
+- Outdated/deprecated: {%}
+
+## 8. Next Audit
+
+**Recommended Date**: {6 months from now}
+**Focus Areas**: {Based on this audit's findings}
+
+---
+**Filed**: docs/governance/knowledge-audit-{YYYY-QN}.md
+**Related**: {Previous audit, action items created}
+```
+
+---
+
+## Document Metadata
+
+```yaml
+---
+title: "Knowledge Management Protocols and Standards Research"
+creator: "ps-researcher v2.0.0"
+subject: ["knowledge management", "protocols", "standards", "ISO 30401", "APQC", "AAR", "lessons learned"]
+description: "Comprehensive research on KM standards (ISO 30401, ISO 9001, APQC, maturity models, Dublin Core, SKOS), protocols (knowledge audits, mapping, AAR, lessons learned, best practice transfer, expert locators), and decision frameworks for protocol selection"
+date: "2026-01-08"
+type: "Research Report"
+format: "text/markdown"
+identifier: "work-032-e-002"
+source: "Web research via ps-researcher agent"
+language: "en"
+relation: ["work-032", "e-002", "knowledge management"]
+coverage: "Knowledge Management standards, protocols, methodologies"
+rights: "Internal Jerry Framework documentation"
+---
+```
+
+**Word Count**: ~12,500 words
+**Research Sources**: 75+ citations
+**Completion Date**: 2026-01-08
+**Agent**: ps-researcher v2.0.0

--- a/docs/archive/projects-archive/research/work-032-e-003-km-products.md
+++ b/docs/archive/projects-archive/research/work-032-e-003-km-products.md
@@ -1,0 +1,1550 @@
+# Knowledge Management Products and Solutions Research
+
+**PS ID:** work-032
+**Entry ID:** e-003
+**Research Date:** 2026-01-08
+**Researcher:** ps-researcher v2.0.0
+
+---
+
+## L0: Executive Summary
+
+### Market Overview
+
+The knowledge management (KM) market is experiencing explosive growth driven by AI and LLM integration. The AI-driven KM systems market is projected to grow from **$3.0 billion in 2024 to $102.1 billion by 2034** at a CAGR of 42.30%. The broader knowledge management software market is expected to reach $59.51 billion by 2033, growing at 12.3% CAGR.
+
+### Key Market Trends (2024-2025)
+
+1. **AI/LLM Integration Imperative**: 92% of Fortune 500 companies report using generative AI in workflows
+2. **RAG Architecture Dominance**: Retrieval-Augmented Generation (RAG) is becoming the strategic imperative for enterprise KM
+3. **Graph-based Knowledge**: Graph databases (Neo4j, TigerGraph) enabling knowledge graphs and GraphRAG implementations
+4. **Data Quality Priority**: Clean, structured data is critical - many 2024 AI initiatives stalled due to data quality issues
+5. **Cloud-First Deployment**: 49% of enterprise LLM implementations are cloud-based
+6. **Market Fragmentation**: Gartner discontinued unified KM Magic Quadrants due to market fragmentation
+
+### Top Recommendations by Use Case
+
+| Use Case | Recommended Solution | Rationale |
+|----------|---------------------|-----------|
+| **Enterprise Documentation** | Confluence | Deep Atlassian integration, proven at scale, strong for technical teams |
+| **Microsoft-Centric Org** | SharePoint | Included in M365, tight integration, compliance-ready |
+| **Agile Startups** | Notion | Flexible, rapid deployment, unified workspace, modern UX |
+| **AI-Powered Search** | Glean | Purpose-built for enterprise knowledge discovery, 100+ app connectors |
+| **Graph-Based KM** | Neo4j | Mature technology, 75% Fortune 500 adoption, native graph processing |
+| **Personal KM** | Obsidian | Local-first, extensible, superior mobile, thriving community |
+| **Open Source** | BookStack | Simple, book-like structure, MIT license, actively maintained |
+
+### Strategic Fit Analysis for Jerry
+
+**Jerry's KM Requirements:**
+- Local-first architecture (filesystem as infinite memory)
+- Structured knowledge hierarchy (`docs/` directory)
+- Markdown-based documentation
+- Integration with agent workflows
+- Zero external dependencies in core
+- Support for problem-solving workflows
+
+**Top 3 Recommended Solutions for Jerry:**
+
+1. **Obsidian** (Personal KM Layer)
+   - ✅ Markdown-native with local file storage
+   - ✅ Plugin ecosystem for extensibility
+   - ✅ Graph view for knowledge connections
+   - ✅ Can integrate with Jerry's `docs/` hierarchy
+   - ⚠️ Proprietary (but uses plain markdown)
+
+2. **Neo4j Community Edition** (Knowledge Graph Layer)
+   - ✅ Open source option available
+   - ✅ Perfect for ps-researcher citation graphs
+   - ✅ Can model problem-solving relationships
+   - ✅ Python client library available
+   - ⚠️ Adds infrastructure dependency
+
+3. **Wiki.js** (Team Collaboration Layer)
+   - ✅ Fully open source (MIT license)
+   - ✅ Markdown support with Git backing
+   - ✅ Modern UI with REST API
+   - ✅ Self-hostable, aligns with Jerry philosophy
+   - ✅ Can sync with Jerry's file-based architecture
+
+**Implementation Recommendation:**
+Hybrid approach combining Jerry's existing file-based system with optional Obsidian for visualization and Wiki.js for team collaboration. Defer graph database until knowledge corpus reaches critical mass (>1000 documents).
+
+---
+
+## L1: Product Catalog with Comparison Matrix
+
+### Category 1: Enterprise KM Platforms
+
+#### Confluence (Atlassian)
+
+**Overview:**
+Confluence dominates enterprise documentation with deep Atlassian integrations, making it ideal for development teams already using Jira and other Atlassian tools.
+
+**Core Capabilities:**
+- Centralized knowledge repository for team documentation
+- Rich collaborative editing with real-time updates
+- Deep integration with Jira, Bitbucket, and Atlassian ecosystem
+- Enterprise-grade permissions for complex organizational structures
+- AI-powered content generation (Confluence AI with GPT-4 integration, August 2024)
+- Advanced versioning and page history
+- Customizable templates and macros
+
+**Pricing Model:**
+- Free: Up to 10 users (basic storage, page history)
+- Standard: $5.16/user/month (billed annually)
+- Premium: $9.73/user/month (advanced controls, analytics, AI)
+- Enterprise: Custom pricing (dedicated support, unlimited storage)
+
+**Integration Options:**
+- Native: Jira, Bitbucket, Trello, all Atlassian products
+- Marketplace: 3,000+ apps including GitHub, Slack, Microsoft Teams
+- API: REST API for custom integrations
+
+**Strengths:**
+- User-friendly and easier to scale than SharePoint
+- Best-in-class for technical documentation
+- Strong community and ecosystem
+- Excellent for agile/DevOps workflows
+- Robust permission model
+
+**Weaknesses:**
+- Advanced features locked behind Premium/Enterprise tiers
+- Marketplace apps significantly increase total cost of ownership
+- Can become cluttered without governance
+- Search functionality less powerful than specialized tools
+
+**Use Case Fit:**
+Perfect for software development teams, technical organizations, and companies already invested in Atlassian ecosystem.
+
+---
+
+#### Microsoft SharePoint
+
+**Overview:**
+SharePoint stands out as a powerful document management and intranet platform designed for organizations that need tight control over files, structured governance, compliance, and enterprise-grade workflows.
+
+**Core Capabilities:**
+- Enterprise document management with version control
+- Integration with OneDrive for file sync and simultaneous editing
+- Advanced compliance and governance features
+- Process automation through Power Automate
+- Intranet and portal capabilities
+- Integration with Microsoft Teams for collaboration
+- Advanced security and information rights management
+- Records management and retention policies
+
+**Pricing Model:**
+- Included in Microsoft 365 Business plans starting at $5/user/month
+- Business Standard: $12.50/user/month (SharePoint Plan 1 + Teams, OneDrive, web Office)
+- Office 365 E1: $7.75/user/month (web Office apps, SharePoint Plan 1)
+- Office 365 E3: $20.75/user/month (desktop Office, advanced security, SharePoint Plan 2)
+- Office 365 E5: $35.75/user/month (advanced analytics, voice features)
+
+**Integration Options:**
+- Native: All Microsoft 365 apps (Teams, OneDrive, Outlook, Power Platform)
+- Third-party: Extensive connector ecosystem
+- API: Microsoft Graph API for programmatic access
+
+**Strengths:**
+- Unmatched document management and governance capabilities
+- Deep Microsoft ecosystem integration
+- Enterprise-grade compliance features
+- Powerful workflow automation with Power Automate
+- Strong for regulated industries (healthcare, finance, government)
+
+**Weaknesses:**
+- Complex and requires professional implementation
+- Steep learning curve for end users
+- Requires dedicated administrative resources
+- Pricing is complex and confusing
+- Less intuitive for knowledge creation vs. document management
+
+**Use Case Fit:**
+Large enterprises, organizations heavily using Microsoft 365, and companies with complex compliance requirements.
+
+---
+
+#### Notion
+
+**Overview:**
+Notion provides a flexible all-in-one workspace that combines knowledge management with project management, note-taking, and database functionality. Since 2024, Notion added Calendar, Sites, Forms, Charts, and in 2025 Mail, extending beyond docs and databases.
+
+**Core Capabilities:**
+- Unified workspace combining docs, databases, and wikis
+- Linked databases for relational knowledge
+- Drag-and-drop page building with blocks
+- Real-time collaboration
+- AI assistant for content generation and analysis
+- Custom views (table, kanban, calendar, gallery, timeline)
+- Public pages and websites
+- Templates and database templates
+
+**Pricing Model:**
+- Free: Personal plan with unlimited pages/blocks
+- Plus: $8/user/month (annual) or $10/month (monthly) - unlimited file uploads
+- Business: $15/user/month (annual) or $18/month (monthly) - Notion AI, SAML SSO, analytics
+- Enterprise: Custom pricing (advanced security, dedicated success manager)
+
+**Integration Options:**
+- Native: Slack, Google Workspace, Figma, GitHub
+- API: Public API for custom integrations
+- Zapier/Make.com for workflow automation
+- Embed support for 50+ services
+
+**Strengths:**
+- Highly flexible and customizable
+- Modern, intuitive interface
+- Fast onboarding and adoption
+- Excellent for remote/async teams
+- Strong community and template marketplace
+- Unified workspace reduces tool sprawl
+
+**Weaknesses:**
+- Less enterprise-grade control than SharePoint/Confluence
+- Weaker compliance features
+- Limited versioning compared to enterprise platforms
+- Advanced features (AI, security) locked behind higher tiers
+- Performance can degrade with very large databases
+
+**Use Case Fit:**
+Startups, creative teams, SMBs, and organizations seeking rapid deployment with flexible structures.
+
+---
+
+### Category 2: Knowledge Base Software
+
+#### Guru
+
+**Overview:**
+Guru is an AI-powered enterprise search, intranet, and wiki platform designed to facilitate knowledge management with real-time verification and proactive information delivery.
+
+**Core Capabilities:**
+- AI-powered enterprise search across company knowledge
+- Browser extension for contextual knowledge delivery
+- Knowledge verification processes with subject matter experts
+- Knowledge triggers for proactive, context-specific information
+- Collections and boards for structured organization
+- Three products on one platform: wiki, intranet, enterprise AI search
+- Real-time suggestions eliminate constant searching
+
+**Pricing Model:**
+- Free: Available for startups and small teams
+- Paid plans: Starting at $15/user/month
+- Free trial available
+
+**Integration Options:**
+- Seamless integration with Slack, Microsoft Teams
+- Browser extensions (Chrome, Firefox, Edge)
+- API for custom integrations
+
+**Strengths:**
+- AI-powered suggestions reduce search friction
+- Verification system ensures information stays current
+- Browser extension provides knowledge in workflow context
+- Free plan available for small teams
+- Three-in-one platform (wiki, intranet, search)
+
+**Weaknesses:**
+- Higher price point ($15/user/month) vs. competitors
+- May be overkill for simple knowledge base needs
+
+**Use Case Fit:**
+Enterprises needing AI-driven knowledge sharing with real-time content verification, especially sales and support teams.
+
+---
+
+#### Tettra
+
+**Overview:**
+Tettra is a Slack-first internal knowledge base platform with AI-powered instant answers through its AI bot, Kai.
+
+**Core Capabilities:**
+- AI bot (Kai) provides instant answers by searching existing content
+- Strong Slack and Microsoft Teams integration
+- Content verification workflows with subject matter experts
+- User-friendly editor supporting Google Docs and markdown
+- Question-and-answer within Slack/Teams
+
+**Pricing Model:**
+- Basic: $4/user/month (minimum 10 users)
+- No free plan available
+
+**Integration Options:**
+- Primary: Slack, Microsoft Teams
+- Also: Google Workspace, Notion, Zapier, GitHub, Trello, Jira, Asana, Confluence
+
+**Strengths:**
+- Most affordable option at $4/user/month
+- Excellent Slack integration for chat-first teams
+- AI-powered instant answers reduce interruptions
+- Simple, focused feature set
+
+**Weaknesses:**
+- Text-based documentation only (limited multimedia)
+- Fewer integrations outside core tools
+- Basic project management features
+- Minimum 10 users required
+
+**Use Case Fit:**
+SMBs with Slack-first culture looking for affordable internal knowledge base with AI-powered answers.
+
+---
+
+#### Slite
+
+**Overview:**
+Slite is an AI-powered knowledge-sharing platform designed for remote and asynchronous teams with real-time collaboration capabilities.
+
+**Core Capabilities:**
+- AI-powered editor for effortless document creation
+- Real-time collaboration with simultaneous editing
+- Advanced AI search for relevant information discovery
+- Document history and versioning
+- Shortcut commands for productivity
+- Mobile accessibility
+- Kanban boards for managing documentation gaps
+
+**Pricing Model:**
+- Free: Basic plan available
+- Standard: $8/user/month
+- Premium: $12.50/user/month
+- Enterprise: Custom pricing
+
+**Integration Options:**
+- Airtable, Google Workspace, Slack, Figma, Loom
+- Trello, Asana, GitHub, Google Docs, Okta
+
+**Strengths:**
+- AI-powered editor improves documentation speed
+- Strong real-time collaboration
+- Good for remote/async teams
+- Free plan available
+
+**Weaknesses:**
+- Considered pricey by some users
+- Platform still evolving (relatively new)
+- Some users report it's too basic for complex needs
+- Limited advanced functionality
+
+**Use Case Fit:**
+Remote and asynchronous teams needing structured knowledge-sharing with AI assistance.
+
+---
+
+### Category 3: Graph-Based KM
+
+#### Neo4j
+
+**Overview:**
+Neo4j is the pioneer in graph databases, renowned for its mature technology and native graph processing capabilities. Adopted by over 75% of Fortune 500 companies, it's the most popular graph database management system.
+
+**Core Capabilities:**
+- Native graph processing with high-performance transactional engine
+- Cypher query language for intuitive graph queries
+- ACID-compliant transaction processing
+- Causal consistency for distributed deployments
+- Graph visualization capabilities
+- Pattern detection and real-time recommendations
+- Support for knowledge graphs and GraphRAG architectures
+- Python, Java, JavaScript, .NET client libraries
+
+**Pricing Model:**
+- Community Edition: Free, open source
+- Enterprise Edition: Commercial license based on servers/instances
+- AuraDB (Cloud): Pay-as-you-go starting at $0
+  - Business Critical: For mission-critical applications, 24/7 support
+  - Virtual Dedicated Cloud: Dedicated VPC infrastructure, premium support
+- Contact sales for specific enterprise pricing
+
+**Integration Options:**
+- Native drivers for Python, Java, JavaScript, .NET, Go
+- Integration with Apache Spark, Kafka, GraphQL
+- AWS, Azure, GCP deployment options
+- REST API and Bolt protocol
+
+**Strengths:**
+- Most mature and widely adopted graph database
+- Intuitive Cypher query language
+- Excellent visualization tools
+- Strong community and ecosystem
+- Best for transactional workloads (fraud detection, recommendations)
+- Rich documentation and learning resources
+
+**Weaknesses:**
+- Enterprise edition can be expensive at scale
+- Community edition lacks clustering and high availability
+- Steeper licensing costs for small to medium businesses
+
+**Use Case Fit:**
+Fraud detection, social networking, knowledge graphs, logistics, recommendations, pattern detection. Ideal for organizations needing ACID compliance and mature graph technology.
+
+---
+
+#### TigerGraph
+
+**Overview:**
+TigerGraph is a distributed, native graph database engine designed for high-performance analytics on very large graphs with parallel processing capabilities.
+
+**Core Capabilities:**
+- Native parallel processing for real-time analytics
+- GSQL query language (SQL-inspired with procedural logic)
+- Specialized storage engine for deep traversal
+- Distributed workloads and parallel computation
+- Support for algorithmic workflows and multi-phase analytics
+- GraphRAG support for knowledge graphs
+- Massive scalability (trillions of relationships)
+
+**Pricing Model:**
+- Contact vendor for enterprise pricing
+- Cloud and on-premise deployment options
+- Pricing based on deployment size and requirements
+
+**Integration Options:**
+- REST API and client libraries
+- Integration with Apache Kafka, Spark
+- Cloud deployment on AWS, Azure, GCP
+- Python, Java connectors
+
+**Strengths:**
+- Exceptional performance for complex queries at scale
+- Real-time analytics on massive datasets
+- Deep link analysis capabilities
+- Strong for algorithmic/analytical workloads
+- Excellent for telecom, fraud detection, supply chain
+
+**Weaknesses:**
+- Proprietary GSQL has steep learning curve
+- Higher infrastructure requirements
+- Complex setup and configuration
+- Cost concerns for smaller organizations
+
+**Use Case Fit:**
+Telecom network analysis, real-time fraud detection, recommendation engines, pharmaceutical research, financial compliance, supply chain optimization. Best for analytical workloads on very large graphs.
+
+---
+
+#### Amazon Neptune
+
+**Overview:**
+Amazon Neptune is a fully managed graph database service on AWS with native support for both property graphs (Gremlin) and RDF (SPARQL), ideal for organizations invested in AWS ecosystem.
+
+**Core Capabilities:**
+- Dual support: Property graphs (Gremlin) and RDF (SPARQL)
+- Fully managed service (automated backups, patching, scaling)
+- Read replicas for high availability
+- Point-in-time recovery and continuous backup
+- Integration with AWS services (IAM, KMS, CloudWatch, SageMaker, Lambda)
+- Serverless architecture option
+- VPC isolation and encryption
+
+**Pricing Model:**
+- Pay-as-you-go pricing
+- Instance-based: Starting at ~$0.10/hour for smallest instance
+- Serverless: Pay for capacity units consumed
+- Storage: $0.10/GB-month
+- I/O: $0.20 per million requests
+- Data transfer charges apply
+
+**Integration Options:**
+- Deep AWS integration: IAM, KMS, CloudWatch, Kinesis, SageMaker, Lambda
+- Gremlin and SPARQL endpoints
+- VPC networking
+- Direct Connect for hybrid deployments
+
+**Strengths:**
+- Fully managed reduces operational overhead
+- Seamless AWS ecosystem integration
+- Support for both property graphs and RDF/ontologies
+- Good for knowledge graphs and semantic search
+- Automated backups and high availability
+
+**Weaknesses:**
+- Single-writer design limits write throughput
+- Can become costly at scale
+- Less flexibility for customization than self-hosted
+- Vendor lock-in to AWS
+- Performance may lag specialized solutions for specific workloads
+
+**Use Case Fit:**
+AWS-centric organizations, knowledge graphs, ontology-driven systems, semantic search, regulatory compliance. Best for teams wanting managed service without operational burden.
+
+---
+
+### Category 4: AI-Powered KM
+
+#### Glean
+
+**Overview:**
+Glean is recognized by Gartner as an Emerging Leader in the 2025 AI Knowledge Management Apps/General Productivity eMQ. Purpose-built for enterprise knowledge discovery across all tools.
+
+**Core Capabilities:**
+- AI-powered intelligent search across 100+ business apps
+- Personal AI assistants with context-aware summaries
+- Knowledge graph for effective personalization
+- Real-time indexed, permission-aware results
+- Generative AI-powered summaries
+- Google-like search experience inside company
+- No manual tagging required
+
+**Pricing Model:**
+- Contact vendor for pricing
+- Enterprise-focused pricing model
+
+**Integration Options:**
+- 100+ business app connectors
+- Gmail, Google Docs, Slack, Jira, Confluence
+- API for custom integrations
+- SSO integration
+
+**Strengths:**
+- Purpose-built for enterprise knowledge discovery
+- Extensive app connectivity (100+ tools)
+- Permission-aware security
+- AI-powered personalization via knowledge graph
+- Recognized by Gartner as Emerging Leader
+
+**Weaknesses:**
+- Pricing not transparent (contact sales)
+- Focused on search/retrieval, not content creation
+- Enterprise-focused (may be overkill for SMBs)
+
+**Use Case Fit:**
+Large enterprises with complex tool ecosystems needing unified AI-powered search for finding existing knowledge.
+
+---
+
+#### Coveo
+
+**Overview:**
+Coveo is a cloud-based AI search platform designed for employee enablement, customer service, and e-commerce personalization, excelling at delivering relevant content based on user behavior.
+
+**Core Capabilities:**
+- Semantic search with NLP capabilities
+- Behavior-based learning for dynamic personalization
+- Content recommendations based on user intent
+- Unified search across internal and external sources
+- Real-time ranking adjustments
+- Multi-channel support (internal, customer service, e-commerce)
+- Click and time-on-page tracking for adaptation
+
+**Pricing Model:**
+- Contact vendor for pricing
+- Cloud-based subscription model
+
+**Integration Options:**
+- Integration with CRM, customer service platforms
+- E-commerce platform connectors
+- API for custom integrations
+- Support for external websites
+
+**Strengths:**
+- Behavior-based personalization at scale
+- Unified search for internal and external use cases
+- Strong for customer-facing applications
+- Real-time learning and adaptation
+
+**Weaknesses:**
+- Pricing not publicly available
+- May require significant configuration
+- Focus on structured content
+
+**Use Case Fit:**
+Organizations needing AI search for both internal workflows and customer-facing experiences, especially e-commerce and customer service.
+
+---
+
+#### Lucidworks Fusion
+
+**Overview:**
+Lucidworks Fusion is built on Apache Solr with AI-driven capabilities, designed for large organizations needing highly configurable workflows, regulatory compliance, and multilingual search.
+
+**Core Capabilities:**
+- Apache Solr foundation with AI enhancement
+- Machine learning models for personalization
+- Natural language processing for plain-language queries
+- Behavior signal analysis
+- Content modeling and analytics
+- Team-specific experiences across departments
+- Regulatory compliance support
+- Multilingual search capabilities
+
+**Pricing Model:**
+- Contact vendor for enterprise pricing
+- On-premise and cloud deployment options
+
+**Integration Options:**
+- Apache Solr ecosystem integrations
+- Custom connectors and APIs
+- Enterprise system integrations
+
+**Strengths:**
+- Extensive customization capabilities
+- Scalable for large enterprises
+- Strong compliance and security features
+- Multilingual support
+- Detailed content analytics
+
+**Weaknesses:**
+- Requires technical knowledge for setup and maintenance
+- Higher complexity than turnkey solutions
+- Longer implementation timeline
+
+**Use Case Fit:**
+Large enterprises with strict data/security policies, regulated industries, organizations needing extensive customization and multilingual support.
+
+---
+
+### Category 5: Personal KM Tools
+
+#### Obsidian
+
+**Overview:**
+Obsidian treats knowledge as a collection of interconnected documents, similar to a personal Wikipedia, with a markdown editor and powerful linking capabilities. Offers superior mobile experience and polished sync options.
+
+**Core Capabilities:**
+- Local-first markdown file storage
+- Bidirectional linking between notes
+- Graph view for knowledge visualization
+- Rich plugin ecosystem (1,000+ community plugins)
+- Canvas for visual knowledge mapping
+- Templates and daily notes
+- Quick capture and search
+- Vim mode and advanced customization
+
+**Pricing Model:**
+- Free: Personal use (unlimited vaults, plugins, local storage)
+- Sync: $8/month (end-to-end encrypted sync)
+- Publish: $16/month (publish notes to web)
+- Commercial license: $50/user/year for business use
+
+**Integration Options:**
+- File-based: Works with any file sync (Dropbox, iCloud, OneDrive)
+- Plugin ecosystem for Git, Readwise, Zotero, and more
+- REST API via plugins
+- Export to markdown, PDF
+
+**Strengths:**
+- Superior mobile experience currently
+- Polished sync options for non-technical users
+- Better performance at scale vs. competitors
+- More approachable for beginners
+- Larger community with more resources
+- More refined and usable graph view
+- Complete data ownership (plain markdown)
+
+**Weaknesses:**
+- Proprietary software (though uses open format)
+- Sync and Publish are paid features
+- Requires plugins for advanced features
+- Learning curve for power features
+
+**Use Case Fit:**
+Document-based knowledge work, writers, researchers, knowledge workers seeking local-first with extensive customization. Perfect for building a "second brain."
+
+---
+
+#### Roam Research
+
+**Overview:**
+Roam Research pioneered bidirectional linking and outliner-based knowledge management. Excellent for researchers, writers, and academics who embrace block-reference-heavy workflows.
+
+**Core Capabilities:**
+- Outliner-based, block-level thinking
+- Bidirectional linking between blocks
+- Daily notes page as primary interface
+- Network of interconnected thoughts
+- Block references and embeds
+- Graph visualization
+- Queries for dynamic views
+
+**Pricing Model:**
+- $15/month per user
+- No free tier
+
+**Integration Options:**
+- API available
+- Export to JSON, markdown
+- Limited third-party integrations
+
+**Strengths:**
+- Pioneered modern PKM movement
+- Powerful for networked thinking
+- Strong for academic research
+- Daily notes workflow
+
+**Weaknesses:**
+- High price ($15/month) with no free tier
+- Dated interface
+- Development has slowed significantly
+- Raises concerns about long-term viability
+- Less feature development than competitors
+
+**Use Case Fit:**
+Researchers, writers, academics embracing outliner-based, block-reference-heavy workflows. Harder to recommend given price and development concerns vs. free alternatives.
+
+---
+
+#### Logseq
+
+**Overview:**
+Logseq is an open-source, local-first outliner prioritizing privacy and user control. Built for students and researchers with unique features like flashcard creation, whiteboards, and PDF annotation.
+
+**Core Capabilities:**
+- Block-based outliner structure
+- Daily journal as primary interface
+- Block references and embeds
+- Bidirectional linking
+- Flashcard creation for spaced repetition
+- Whiteboards for visual thinking
+- PDF annotation
+- Completely free and open source
+
+**Pricing Model:**
+- Free: Completely free, open source (MIT license)
+- Sync: $5/month (optional encrypted sync service)
+
+**Integration Options:**
+- Git synchronization
+- Plugin system
+- Export to markdown, OPML
+- Works with plain Markdown or Org-mode files
+
+**Strengths:**
+- Superior for task management out of the box
+- Completely free with no paid tiers
+- Open source guarantees no lock-in
+- Excellent for students (flashcards, PDF annotation)
+- Block-level thinking and rapid capture
+- Privacy-focused, local-first architecture
+
+**Weaknesses:**
+- Mobile experience less polished than Obsidian
+- Fewer plugins than Obsidian ecosystem
+- Graph view less refined than Obsidian
+- Steeper learning curve for outliner paradigm
+
+**Use Case Fit:**
+Students, researchers, task-focused knowledge workers, those prioritizing privacy and open source. Excellent for rapid capture, flashcard learning, and block-level thinking.
+
+---
+
+### Category 6: Open Source KM
+
+#### BookStack
+
+**Overview:**
+BookStack is a free, open-source, self-hosted wiki platform with a clean, book-like structure (shelves → books → chapters → pages) built on PHP and Laravel. Actively maintained with stable August 2025 release.
+
+**Core Capabilities:**
+- Hierarchical organization (shelves, books, chapters, pages)
+- WYSIWYG and Markdown editors
+- Built-in diagrams.net integration
+- Full-text search
+- Role-based permissions
+- Multi-language support (30+ languages)
+- REST API for integrations
+- Image management with drawing editor
+
+**Pricing Model:**
+- Free and open source (MIT license)
+- Self-hosted (requires server/hosting costs)
+
+**Integration Options:**
+- REST API for custom integrations
+- LDAP/SAML authentication
+- Webhooks for automation
+- Export to PDF, HTML, markdown, plain text
+
+**Strengths:**
+- Simple, intuitive book-like structure
+- Minimal fuss for startups and small teams
+- Free and open source (MIT)
+- Actively maintained (August 2025 release)
+- Multi-language support
+- Clean, professional interface
+
+**Weaknesses:**
+- Requires self-hosting and technical knowledge
+- PHP/Laravel stack (may not fit all tech stacks)
+- Limited real-time collaboration vs. cloud solutions
+- Fewer integrations than commercial platforms
+
+**Use Case Fit:**
+Internal wikis for startups and dev teams, documentation projects, organizations seeking simplicity and open source. Great for getting running quickly with minimal configuration.
+
+---
+
+#### Wiki.js
+
+**Overview:**
+Wiki.js is an open-source, self-hosted wiki built on Node.js with a modern interface and modular architecture. Ideal for Markdown fans and developers preferring version-controllable content.
+
+**Core Capabilities:**
+- Modern, sleek interface
+- Markdown-native editing
+- Git backing for version control
+- Modular architecture
+- Multi-language support
+- Search with ElasticSearch or database
+- Authentication (local, LDAP, OAuth, SAML)
+- REST API and GraphQL
+
+**Pricing Model:**
+- Free and open source (AGPL-3.0 license)
+- Self-hosted (requires server/hosting costs)
+
+**Integration Options:**
+- Git synchronization (GitHub, GitLab, Gitea)
+- REST API and GraphQL
+- Authentication providers (OAuth, SAML, LDAP)
+- Storage backends (local, S3, Azure, etc.)
+
+**Strengths:**
+- Modern, polished UI
+- Git backing enables version control workflows
+- Markdown support with preview
+- Modular, extensible architecture
+- Developer-friendly
+- Can sync with file-based systems
+
+**Weaknesses:**
+- Requires technical expertise for self-hosting
+- Node.js stack (resource intensive at scale)
+- Smaller community than BookStack
+
+**Use Case Fit:**
+Internal wikis where collaboration is important, developer-focused teams, organizations wanting Git-backed documentation. Perfect for Jerry's file-based architecture with Git integration.
+
+---
+
+#### Outline
+
+**Overview:**
+Outline is an open source knowledge base with a modern interface offering flexible deployment: cloud hosting ($10/month), free self-hosted Community Edition, or managed hosting via Elestio.
+
+**Core Capabilities:**
+- Hierarchical structure (Collections → Documents → Nested Documents)
+- Drag-and-drop organization
+- Slash commands for rapid formatting
+- Real-time collaboration with live updates
+- Commenting and discussions
+- Built-in progress tracking
+- Markdown support
+- Search with full-text indexing
+
+**Pricing Model:**
+- Cloud: $10/user/month
+- Community Edition: Free, self-hosted (limited features, single workspace)
+- Managed hosting: Available via Elestio
+
+**Integration Options:**
+- Slack integration
+- API for custom integrations
+- SSO support
+- Export capabilities
+
+**Strengths:**
+- Modern, clean interface
+- Real-time collaboration
+- Flexible deployment options
+- Drag-and-drop organization
+- Good for non-engineers
+
+**Weaknesses:**
+- Community Edition limited to one workspace
+- No theming/customization in free version
+- Self-hosting requires technical expertise
+- Fewer features in free tier vs. cloud
+
+**Use Case Fit:**
+Larger companies with non-engineers contributing, internal wikis prioritizing collaboration, teams wanting modern interface with optional cloud hosting.
+
+---
+
+## L2: Strategic Fit Analysis for Jerry
+
+### Jerry's Current Architecture
+
+**Knowledge Management Approach:**
+- **Filesystem as infinite memory**: Docs stored in hierarchical `docs/` directory
+- **Markdown-based**: All documentation in `.md` format
+- **Git-backed**: Version control for all knowledge artifacts
+- **Agent-readable**: Structured for LLM context loading
+- **Categories**: `docs/design/`, `docs/experience/`, `docs/knowledge/`, `docs/plans/`, `docs/research/`, `docs/wisdom/`
+
+**Core Requirements:**
+1. Local-first architecture (no cloud dependencies in core)
+2. Plain text/Markdown for agent accessibility
+3. Git integration for versioning
+4. Hierarchical organization for context management
+5. Zero external dependencies in domain layer
+6. Support for problem-solving workflows (ps-researcher, ps-analyst, etc.)
+7. Citation and reference management
+8. Knowledge graph potential for agent reasoning
+
+### Gap Analysis
+
+| Requirement | Current State | Gap | Priority |
+|------------|---------------|-----|----------|
+| **Local-first storage** | ✅ Filesystem | None | - |
+| **Markdown support** | ✅ Native | None | - |
+| **Version control** | ✅ Git | None | - |
+| **Visualization** | ❌ No graph view | Need knowledge graph visualization | Medium |
+| **Search** | ⚠️ Basic grep | Need semantic search capability | High |
+| **Cross-references** | ⚠️ Manual links | Need automated link detection | Medium |
+| **Agent integration** | ✅ Direct file access | None | - |
+| **Citation management** | ⚠️ Manual | Need structured citation graph | High |
+| **Team collaboration** | ❌ Git-only | Need web UI for non-technical users | Low |
+| **Knowledge graph** | ❌ Not implemented | Need relationship modeling | High |
+
+### Integration Scenarios
+
+#### Scenario 1: Minimal Enhancement (Obsidian)
+
+**Approach:** Use Obsidian vault pointing to Jerry's `docs/` directory
+
+**Implementation:**
+```
+/home/user/jerry/docs/ → Obsidian vault
+├── .obsidian/          # Obsidian config (gitignored)
+├── design/             # Existing Jerry structure preserved
+├── experience/
+├── knowledge/
+├── plans/
+├── research/
+└── wisdom/
+```
+
+**Pros:**
+- ✅ Zero changes to Jerry's architecture
+- ✅ Adds graph visualization immediately
+- ✅ Plugin ecosystem (dataview, citation manager, etc.)
+- ✅ Works with existing markdown files
+- ✅ Local-first aligns with Jerry philosophy
+
+**Cons:**
+- ⚠️ Proprietary software (though open format)
+- ⚠️ Sync costs $8/month for multi-device
+- ⚠️ Not scriptable for agent workflows without plugins
+
+**Cost:** Free for single-user, $8/month for sync
+
+**Implementation Effort:** 1 day (vault setup + plugin configuration)
+
+---
+
+#### Scenario 2: Graph Database Layer (Neo4j Community)
+
+**Approach:** Add Neo4j for knowledge graph while maintaining filesystem as source of truth
+
+**Implementation:**
+```python
+# Jerry architecture with Neo4j
+jerry/
+├── src/
+│   ├── domain/
+│   │   └── knowledge/
+│   │       ├── graph.py          # Graph domain model
+│   │       └── citation.py       # Citation entities
+│   ├── infrastructure/
+│   │   └── knowledge/
+│   │       ├── neo4j_adapter.py  # Graph DB adapter (port)
+│   │       └── file_indexer.py   # Index docs/ into graph
+│   └── application/
+│       └── knowledge/
+│           └── graph_query.py    # Query use cases
+└── docs/                         # Source of truth (unchanged)
+```
+
+**Use Cases:**
+- Citation graph for ps-researcher outputs
+- Cross-reference discovery between ADRs and research
+- Agent reasoning path visualization
+- Knowledge retrieval for RAG implementations
+
+**Pros:**
+- ✅ Powerful graph queries for agent reasoning
+- ✅ Community Edition is free and open source
+- ✅ Python driver readily available
+- ✅ Can model complex agent workflows
+- ✅ Supports GraphRAG for future AI integration
+
+**Cons:**
+- ⚠️ Adds infrastructure dependency (Docker recommended)
+- ⚠️ Requires synchronization with filesystem
+- ⚠️ Operational overhead for backups/maintenance
+- ⚠️ May be premature optimization (current corpus ~50 docs)
+
+**Cost:** Free (Community Edition) + infrastructure costs
+
+**Implementation Effort:** 2 weeks (adapter, indexer, query layer, testing)
+
+**Recommendation:** Defer until knowledge corpus >1000 documents or agent workflows require complex graph traversal.
+
+---
+
+#### Scenario 3: Team Collaboration Layer (Wiki.js)
+
+**Approach:** Wiki.js as web interface for Jerry's docs, Git-backed for bidirectional sync
+
+**Implementation:**
+```
+Jerry filesystem ←→ Git ←→ Wiki.js
+   (agents)              (humans)
+```
+
+**Configuration:**
+- Wiki.js storage backend: Git
+- Git repository: Jerry's docs/ directory
+- Sync frequency: Real-time (webhook-triggered)
+- Authentication: Local or SSO for team access
+
+**Pros:**
+- ✅ Modern web UI for non-technical collaborators
+- ✅ Git-backed preserves filesystem as source of truth
+- ✅ Open source (MIT license)
+- ✅ REST API for agent integration
+- ✅ Markdown-native with preview
+- ✅ Multi-user collaboration without Git knowledge
+
+**Cons:**
+- ⚠️ Requires Node.js infrastructure
+- ⚠️ Sync complexity between filesystem and Wiki.js
+- ⚠️ Potential for merge conflicts with concurrent edits
+- ⚠️ Resource-intensive at scale
+
+**Cost:** Free (self-hosted) + server costs (~$10-20/month for small VPS)
+
+**Implementation Effort:** 3-5 days (deployment, Git sync, permissions, testing)
+
+**Recommendation:** Implement when team expands beyond 3 developers or non-technical stakeholders need documentation access.
+
+---
+
+### Recommended Implementation Roadmap
+
+#### Phase 1: Immediate (Q1 2026)
+**Goal:** Enhance individual developer experience with zero architectural changes
+
+**Action:** Obsidian vault on `docs/` directory
+- Setup time: 1 day
+- Cost: Free (defer sync decision)
+- Benefit: Instant graph visualization, better navigation
+
+**Plugins to Install:**
+1. Dataview - Query docs as database
+2. Citation - Manage research references
+3. Graph Analysis - Enhanced graph algorithms
+4. Templater - Templates for ADRs, research docs
+5. Git - Automated commit/push from Obsidian
+
+---
+
+#### Phase 2: Near-term (Q2 2026)
+**Goal:** Implement semantic search and improve agent knowledge retrieval
+
+**Action:** Vector database for semantic search (evaluate: Chroma, Weaviate, Qdrant)
+- All are open source and Python-native
+- Can embed Jerry's markdown docs as vectors
+- Enable semantic search for agents
+- Support RAG workflows without full knowledge graph
+
+**Implementation:**
+```python
+# src/infrastructure/knowledge/vector_store.py
+from chromadb import Client  # Example: using Chroma
+
+class VectorKnowledgeStore:
+    """Semantic search over Jerry's knowledge base."""
+
+    def index_documents(self, docs_path: Path) -> None:
+        """Index markdown files as vectors."""
+
+    def semantic_search(self, query: str, top_k: int = 5) -> List[Document]:
+        """Retrieve relevant docs for query."""
+```
+
+**Cost:** Free (self-hosted) + minimal compute
+**Effort:** 1 week
+
+---
+
+#### Phase 3: Medium-term (Q3-Q4 2026)
+**Goal:** Decision point based on scale and team growth
+
+**Option A - Stay File-Based (corpus <500 docs, team <5 people):**
+- Continue with Obsidian + vector search
+- Add more sophisticated file organization
+- Implement automated cross-reference detection
+
+**Option B - Add Knowledge Graph (corpus >500 docs OR complex agent reasoning needs):**
+- Deploy Neo4j Community Edition
+- Build indexing pipeline from docs/ → graph
+- Enable graph-based agent reasoning
+
+**Option C - Add Team Collaboration (team >5 people OR non-technical stakeholders):**
+- Deploy Wiki.js with Git sync
+- Train team on collaborative workflows
+- Implement review/approval processes
+
+---
+
+### Competitive Analysis: Jerry vs. Commercial KM
+
+| Aspect | Jerry (Current) | Confluence | SharePoint | Notion | Glean |
+|--------|----------------|------------|------------|---------|-------|
+| **Local-first** | ✅ Yes | ❌ Cloud | ⚠️ Hybrid | ❌ Cloud | ❌ Cloud |
+| **Open source** | ✅ Yes | ❌ No | ❌ No | ❌ No | ❌ No |
+| **Agent-native** | ✅ Yes | ⚠️ API | ⚠️ API | ⚠️ API | ⚠️ API |
+| **Cost** | $0 | $5.16+/user/mo | $5+/user/mo | $8+/user/mo | Enterprise |
+| **Graph view** | ❌ Need | ⚠️ Limited | ❌ No | ⚠️ Limited | ⚠️ Yes |
+| **Semantic search** | ❌ Need | ✅ Yes | ✅ Yes | ✅ Yes | ✅✅ Best |
+| **Markdown** | ✅ Native | ⚠️ Export | ❌ No | ⚠️ Blocks | ❌ No |
+| **Git integration** | ✅ Native | ⚠️ Plugin | ❌ No | ⚠️ API | ❌ No |
+| **Customization** | ✅✅ Full | ⚠️ Limited | ⚠️ Complex | ⚠️ Limited | ❌ No |
+
+**Jerry's Competitive Advantages:**
+1. **Zero cost** for core KM functionality
+2. **Agent-native** architecture (direct file access vs. API calls)
+3. **Local-first** with complete data ownership
+4. **Git-backed** versioning without configuration
+5. **Infinite customization** through Python ecosystem
+
+**Areas for Improvement:**
+1. **Semantic search** - Gap vs. Glean/Coveo (addressable with vector DB)
+2. **Graph visualization** - Gap vs. Neo4j (addressable with Obsidian or graph DB)
+3. **Team collaboration** - Gap vs. Notion/Confluence (addressable with Wiki.js if needed)
+4. **AI-powered insights** - Opportunity to leverage agent architecture for unique capabilities
+
+---
+
+### Strategic Recommendations
+
+#### 1. Preserve File-Based Architecture ✅
+**Rationale:** Jerry's filesystem approach is a competitive advantage, not a limitation. It provides:
+- Agent accessibility without API overhead
+- Complete data ownership and portability
+- Git versioning without additional tooling
+- Zero cost at any scale
+
+**Action:** DO NOT migrate to cloud KM platforms. Enhance the file-based approach instead.
+
+---
+
+#### 2. Implement Hybrid Enhancement Strategy ✅
+**Approach:** "Filesystem as source of truth + optional visualization/indexing layers"
+
+**Components:**
+```
+┌─────────────────────────────────────────┐
+│  Presentation Layer (Optional)          │
+│  - Obsidian (graph view)                │
+│  - Wiki.js (team collaboration)         │
+└─────────────────┬───────────────────────┘
+                  │
+┌─────────────────▼───────────────────────┐
+│  Indexing Layer (Recommended)           │
+│  - Vector DB (semantic search)          │
+│  - Neo4j (optional graph, future)       │
+└─────────────────┬───────────────────────┘
+                  │
+┌─────────────────▼───────────────────────┐
+│  Source of Truth (Core)                 │
+│  - Filesystem: docs/*.md                │
+│  - Git version control                  │
+│  - Direct agent access                  │
+└─────────────────────────────────────────┘
+```
+
+---
+
+#### 3. Prioritize Semantic Search Over Graph Database ✅
+**Rationale:**
+- Current corpus (~50 docs) doesn't justify graph DB overhead
+- Semantic search provides 80% of value with 20% of complexity
+- Vector databases (Chroma, Weaviate) are lightweight and Python-native
+- Supports RAG workflows for agent enhancement
+
+**Action:** Implement vector database in Q2 2026 before considering graph database.
+
+---
+
+#### 4. Leverage Agent Architecture for Unique KM Capabilities ✅
+**Opportunity:** Jerry's agent-native architecture enables KM capabilities no commercial platform offers:
+
+**Unique Capabilities to Build:**
+1. **Auto-documentation agents** - ps-documenter extracts knowledge from commits
+2. **Citation graph automation** - ps-researcher auto-builds citation networks
+3. **Cross-reference detection** - Agent scans for implicit connections between docs
+4. **Knowledge gap detection** - Agent identifies missing documentation
+5. **Automated summarization** - ps-synthesizer creates L0/L1/L2 summaries
+6. **Knowledge gardening** - Agents suggest reorganization, merges, deprecations
+
+**Competitive Moat:** No commercial KM platform has native agent workforce for knowledge curation.
+
+---
+
+#### 5. Evaluation Criteria for Future KM Decisions ✅
+
+Before adopting ANY external KM tool, evaluate against Jerry principles:
+
+| Criterion | Weight | Threshold |
+|-----------|--------|-----------|
+| **Preserves local-first architecture** | 🔴 Hard | Must preserve filesystem as source of truth |
+| **Open source or open format** | 🟡 Med | Prefer open source; require open format minimum |
+| **Zero-dependency core** | 🔴 Hard | Core knowledge access cannot depend on external service |
+| **Agent accessibility** | 🔴 Hard | Agents must access knowledge without API/auth overhead |
+| **Cost at scale** | 🟡 Med | Must remain $0 for core functionality |
+| **Git compatibility** | 🟡 Med | Must integrate with Git workflows |
+| **Incremental adoption** | 🟢 Soft | Can adopt gradually without migration |
+
+---
+
+## Pricing Comparison Table
+
+### Enterprise KM Platforms
+
+| Platform | Free Tier | Starter | Professional | Enterprise | Notes |
+|----------|-----------|---------|--------------|------------|-------|
+| **Confluence** | Up to 10 users | $5.16/user/mo | $9.73/user/mo | Custom | Advanced features in Premium+ only |
+| **SharePoint** | No | $5/user/mo (M365) | $12.50-20.75/user/mo | $35.75/user/mo | Bundled with Microsoft 365 |
+| **Notion** | Personal (unlimited) | $8/user/mo | $15/user/mo | Custom | Business includes AI features |
+
+### Knowledge Base Software
+
+| Platform | Free Tier | Paid Plans | Notes |
+|----------|-----------|------------|-------|
+| **Guru** | Yes (small teams) | $15/user/mo | Free plan available |
+| **Tettra** | No | $4/user/mo (min 10 users) | Most affordable option |
+| **Slite** | Yes | $8-12.50/user/mo | Standard to Premium |
+
+### Graph-Based KM
+
+| Platform | Free Tier | Cloud Pricing | Enterprise | Notes |
+|----------|-----------|---------------|------------|-------|
+| **Neo4j** | Community Edition (OSS) | AuraDB: Pay-as-you-go | Contact sales | Community lacks clustering |
+| **TigerGraph** | Developer Edition | Contact sales | Contact sales | Enterprise-focused |
+| **Amazon Neptune** | No free tier | ~$0.10/hr + storage | Same | AWS infrastructure costs |
+
+### AI-Powered KM
+
+| Platform | Free Tier | Pricing | Notes |
+|----------|-----------|---------|-------|
+| **Glean** | No | Contact sales | Enterprise-focused |
+| **Coveo** | No | Contact sales | Enterprise-focused |
+| **Lucidworks** | No | Contact sales | Enterprise-focused |
+
+### Personal KM Tools
+
+| Platform | Free Tier | Subscription | Notes |
+|----------|-----------|--------------|-------|
+| **Obsidian** | Yes (unlimited) | Sync: $8/mo, Publish: $16/mo | Commercial use: $50/user/year |
+| **Roam Research** | No | $15/mo | No free tier |
+| **Logseq** | Yes (fully free) | Sync: $5/mo (optional) | Open source (MIT) |
+
+### Open Source KM
+
+| Platform | Cost | Infrastructure | License | Notes |
+|----------|------|----------------|---------|-------|
+| **BookStack** | $0 | Self-hosting costs | MIT | PHP/Laravel stack |
+| **Wiki.js** | $0 | Self-hosting costs | AGPL-3.0 | Node.js stack |
+| **Outline** | Community: $0, Cloud: $10/user/mo | Self-hosting or cloud | BSD-3-Clause | Flexible deployment |
+
+### Total Cost of Ownership (TCO) Comparison
+
+**Scenario: 10-person team, 3-year horizon**
+
+| Solution | Licensing | Infrastructure | Maintenance | 3-Year TCO |
+|----------|-----------|----------------|-------------|------------|
+| **Confluence Standard** | $620/user/yr × 10 × 3 | $0 (cloud) | $0 (managed) | **$18,600** |
+| **SharePoint (M365 Business)** | $144/user/yr × 10 × 3 | $0 (cloud) | $0 (managed) | **$4,320** |
+| **Notion Business** | $180/user/yr × 10 × 3 | $0 (cloud) | $0 (managed) | **$5,400** |
+| **Obsidian + Sync** | $96/user/yr × 10 × 3 | $0 (local) | $0 | **$2,880** |
+| **Logseq (free)** | $0 | $0 (local) | $0 | **$0** |
+| **Wiki.js** | $0 | $240/yr × 3 (VPS) | 20 hrs/yr × $100/hr × 3 | **$6,720** |
+| **Jerry + Obsidian** | $0 (no sync, local vaults) | $0 | 0 | **$0** |
+| **Jerry + Vector DB** | $0 (OSS Chroma) | $120/yr × 3 (small server) | 40 hrs setup + 10 hrs/yr × $100/hr | **$7,360** |
+| **Jerry + Neo4j Community** | $0 (OSS) | $480/yr × 3 (medium server) | 80 hrs setup + 20 hrs/yr × $100/hr | **$15,440** |
+
+**Key Insights:**
+1. **Cloud platforms** have lowest upfront cost but highest ongoing cost at scale
+2. **Open source self-hosted** solutions have moderate TCO when factoring maintenance
+3. **Jerry's file-based approach** has near-zero cost but requires building custom tooling
+4. **Obsidian** provides excellent value for small teams ($2,880 vs. $18,600 for Confluence)
+5. **Vector database** addition to Jerry is cost-effective for semantic search capability
+
+---
+
+## Market Trends and Analysis
+
+### 1. AI/LLM Integration is Mandatory
+
+**Market Data:**
+- AI-driven KM systems market growing at **42.3% CAGR** (2024-2034)
+- **92% of Fortune 500** companies using generative AI in workflows
+- Enterprise LLM spending: **$8.4B in mid-2025** (up from $3.5B in late 2024)
+
+**Implications:**
+- Every major KM platform is adding AI features (Confluence AI with GPT-4, Notion AI, etc.)
+- AI features often locked behind premium tiers
+- Semantic search is table stakes for new KM implementations
+
+**Jerry Opportunity:**
+- Agent architecture provides unique advantage
+- Can integrate open-source LLMs without vendor lock-in
+- Potential to build AI features competitors can't match (agent-curated knowledge)
+
+---
+
+### 2. RAG (Retrieval-Augmented Generation) is the Strategic Imperative
+
+**Market Data:**
+- **63.6% of implementations** use GPT-based models
+- **80.5% rely on standard retrieval** (FAISS, Elasticsearch)
+- Production RAG reduces post-deployment issues by **50-70%**
+- GraphRAG emerging as advanced technique for structured knowledge
+
+**Implications:**
+- KM platforms are evolving into RAG data sources
+- Knowledge graphs becoming critical for advanced RAG
+- Traditional keyword search being replaced by semantic/vector search
+
+**Jerry Opportunity:**
+- Markdown corpus is ideal RAG source material
+- Can implement RAG without vendor platform
+- Agent architecture enables continuous RAG evaluation and improvement
+
+---
+
+### 3. Data Quality is the New Bottleneck
+
+**Market Data:**
+- **Many AI initiatives stalled in 2024** due to data quality issues
+- MIT research: Knowledge base integration **reduces LLM hallucinations**
+- Clean data is prerequisite for successful AI/KM integration
+
+**Implications:**
+- Organizations investing heavily in data cleaning before AI
+- Structured knowledge architectures (graphs, taxonomies) gaining importance
+- Manual knowledge curation still critical despite AI advances
+
+**Jerry Opportunity:**
+- Agent workforce can automate knowledge quality checks
+- Structured `docs/` hierarchy provides clean foundation
+- ps-validator role can ensure knowledge base integrity
+
+---
+
+### 4. Graph Databases Moving Mainstream for KM
+
+**Market Data:**
+- Graph databases central to **Knowledge RAG** architectures
+- Neo4j adopted by **75% of Fortune 500** companies
+- GraphRAG techniques showing **significant improvements** over traditional RAG
+
+**Implications:**
+- Knowledge graphs becoming standard for enterprise KM
+- Graph visualization expected by users
+- Relationship modeling as important as content storage
+
+**Jerry Opportunity:**
+- Citation graphs for research tracking
+- Agent workflow graphs for process visualization
+- Cross-reference graphs for knowledge discovery
+
+---
+
+### 5. Market Fragmentation Creates Opportunity
+
+**Market Data:**
+- Gartner **discontinued unified KM Magic Quadrants** due to fragmentation
+- No single technology market for knowledge management
+- KM evaluated within specific contexts (search, collaboration, DX)
+
+**Implications:**
+- No dominant KM platform (like Salesforce for CRM)
+- Organizations combining multiple tools for KM
+- Opportunity for specialized/vertical KM solutions
+
+**Jerry Opportunity:**
+- Purpose-built for software development knowledge
+- Agent-native architecture is differentiator
+- Can be best-in-class for specific use case vs. general-purpose
+
+---
+
+### 6. Local-First and Privacy Concerns Rising
+
+**Market Data:**
+- Obsidian and Logseq gaining traction with **local-first** architecture
+- Data sovereignty concerns limiting cloud adoption in some sectors
+- Open source KM tools maturing rapidly
+
+**Implications:**
+- Not all organizations comfortable with cloud KM platforms
+- Compliance/regulatory requirements favor on-premise/local solutions
+- Privacy-conscious users seeking alternatives to cloud platforms
+
+**Jerry Opportunity:**
+- Local-first is core architecture, not afterthought
+- Complete data ownership and control
+- Can add cloud features optionally without compromising local-first principle
+
+---
+
+### 7. Personal KM Tools Influencing Enterprise
+
+**Market Data:**
+- Obsidian, Roam, Logseq pioneering new interaction models
+- Bidirectional linking now expected in enterprise tools
+- Graph visualizations standard in modern KM UIs
+
+**Implications:**
+- Enterprise KM platforms adopting personal KM innovations
+- Users expecting Obsidian-like experience in corporate tools
+- Knowledge graphs and network views becoming standard
+
+**Jerry Opportunity:**
+- Can adopt personal KM best practices without enterprise bloat
+- Markdown + linking model aligns with personal KM tools
+- Can integrate with Obsidian for best-of-both-worlds
+
+---
+
+### 8. Cloud vs. Self-Hosted Pendulum Swinging
+
+**Market Data:**
+- **49% of enterprise LLM** market is cloud-based (2024)
+- BUT: Self-hosted open source seeing resurgence
+- Hybrid deployments becoming common
+
+**Implications:**
+- Cloud convenience vs. data control trade-off
+- Organizations willing to trade convenience for control in KM
+- Managed open source (e.g., Outline via Elestio) gaining traction
+
+**Jerry Opportunity:**
+- Self-hosted aligns with data sovereignty trends
+- Can offer optional cloud features without requiring them
+- Hybrid approach (local core + optional cloud services) is competitive
+
+---
+
+## Full Citations
+
+### Enterprise KM Platforms
+
+1. [SharePoint Knowledge Base: 2025 Review & Alternatives](https://www.featurebase.app/blog/sharepoint-knowledge-base)
+2. [15 Best Knowledge Management Software Solutions for 2025](https://www.lupahire.com/blog/best-knowledge-management-software-solutions)
+3. [Best Knowledge Base Software: 12 Top Tools for 2025](https://www.plain.com/blog/best-knowledge-base-software-12-top-tools-for-2025)
+4. [8 Best Confluence Alternatives in 2025](https://document360.com/blog/confluence-alternatives/)
+5. [Notion vs SharePoint: Benefits, Pros, Cons, and Integrations](https://blog.virtosoftware.com/notion-vs-sharepoint/)
+6. [Confluence vs SharePoint: Which Platform Is Better for Knowledge Management](https://ikuteam.com/blog/confluence-vs-sharepoint)
+7. [Confluence vs Notion: Which Knowledge Management Tool Is Better?](https://seibert.group/products/blog/confluence-vs-notion-which-tool-is-better/)
+8. [The 16 Best SharePoint Alternatives for Knowledge Management in 2025](https://www.stravito.com/resources/best-sharepoint-alternatives)
+
+### Knowledge Base Software
+
+9. [14 Best Knowledge Base Software for Businesses](https://www.featurebase.app/blog/best-knowledge-base-software)
+10. [Top 8 Knowledge Base Software for 2025](https://slite.com/en/learn/knowledge-base-softwares)
+11. [24 Best Knowledge Management Software Reviewed in 2026](https://peoplemanagingpeople.com/tools/best-knowledge-management-software/)
+12. [9 Best Tettra Alternatives for Knowledge Management](https://www.sweetprocess.com/tettra-alternatives/)
+13. [11 Best Knowledge Base Tools in 2024](https://tettra.com/article/best-knowledge-base-software/)
+14. [Top 14 Tettra Alternatives for your Knowledge Base in 2026](https://www.featurebase.app/blog/tettra-alternatives)
+
+### Graph-Based KM
+
+15. [AI Knowledge Graph Platforms: Comparing Neo4j, TigerGraph, and AWS Neptune](https://skillup.ccccloud.com/2025/07/01/ai-knowledge-graph-platforms-comparing-neo4j-tigergraph-and-aws-neptune-for-scalable-ai-applications/)
+16. [TigerGraph vs Amazon Neptune: Key Differences & Comparison](https://www.puppygraph.com/blog/tigergraph-vs-neptune)
+17. [How to choose a graph database: We compare 8 favorites](https://cambridge-intelligence.com/choosing-graph-database/)
+18. [When to Use a Graph Database Like Neo4j on AWS](https://aws.amazon.com/blogs/apn/when-to-use-a-graph-database-like-neo4j-on-aws/)
+19. [The Top Graph Database Companies to Watch in 2025](https://www.syntaxia.com/post/the-top-graph-database-companies-to-watch-in-2025)
+20. [Amazon Neptune vs. Neo4j vs. TigerGraph Comparison](https://db-engines.com/en/system/Amazon+Neptune%3BNeo4j%3BTigerGraph)
+21. [AWS Neptune vs Neo4j: Which Graph DB is Better?](https://www.puppygraph.com/blog/aws-neptune-vs-neo4j)
+22. [Neo4j vs. Amazon Neptune: Graph Databases in Data Engineering](https://www.analyticsvidhya.com/blog/2024/08/neo4j-vs-amazon-neptune/)
+
+### AI-Powered KM
+
+23. [Top 9 enterprise search software Tools and Solution in 2025](https://www.glean.com/blog/top-enterprise-search-software)
+24. [Glean Named as Emerging Leader in 2025 Gartner® eMQ](https://www.glean.com/blog/gartner-innovation-guide-gen-ai-knowledge-management-2025)
+25. [Glean Review - Features, Benefits And Alternatives In 2025](https://www.revoyant.com/blog/glean-review-features-and-alternatives)
+26. [10 Best Glean Competitors & Alternatives in 2025](https://qatalog.com/blog/post/glean-alternatives/)
+27. [Top 10 Enterprise Search Software in 2025](https://slite.com/en/learn/top-enterprise-search-software)
+28. [12 Best Glean Alternatives for Knowledge Management in 2025](https://capacity.com/blog/glean-alternatives/)
+29. [The 16 Best Enterprise Search Software Solutions in 2026](https://www.getguru.com/reference/best-enterprise-search-software)
+30. [15 Best AI Knowledge Management Software Reviewed in 2025](https://peoplemanagingpeople.com/tools/best-ai-knowledge-management-software/)
+
+### Personal KM Tools
+
+31. [Obsidian vs LogSeq: Which PKM Tool is right for you?](https://www.glukhov.org/post/2025/11/obsidian-vs-logseq-comparison/)
+32. [15 Best Personal Knowledge Management Apps](https://www.kosmik.app/blog/best-pkm-apps)
+33. [12 Best Personal Knowledge Management Tools for 2025](https://blog.obsibrain.com/other-articles/personal-knowledge-management-tools)
+34. [Best AI Knowledge Management Tools 2025](https://aloa.co/ai/comparisons/ai-note-taker-comparison/best-ai-knowledge-management-tools)
+35. [Logseq vs Obsidian - which PKM tool should you use?](https://www.logseqmastery.com/blog/logseq-vs-obsidian/)
+36. [Personal Knowledge Management - Goals, Methods and Tools to use in 2025](https://www.glukhov.org/post/2025/07/personal-knowledge-management/)
+37. [Obsidian vs Roam Research vs LogSeq vs RemNote](https://support.noduslabs.com/hc/en-us/articles/6490899641234-Obsidian-vs-Roam-Research-vs-LogSeq-vs-RemNote)
+38. [I migrated my notes from Obsidian to Logseq](https://www.xda-developers.com/migrated-notes-to-logseq-from-obsidian-dont-regret-it/)
+
+### Open Source KM
+
+39. [8 Best Outline Alternatives for your Knowledge Base](https://www.featurebase.app/blog/outline-alternatives)
+40. [10 Best Open Source Knowledge Base Software (Mostly Free)](https://herothemes.com/blog/open-source-knowledge-base/)
+41. [9 Best Open Source Knowledge Base Software for Software Companies in 2025](https://ferndesk.com/blog/open-source-knowledge-base-software)
+42. [12 Best Wiki Software For 2025 (Mostly Free)](https://herothemes.com/blog/wiki-software/)
+43. [Other Open Source Documentation Platforms · BookStack](https://www.bookstackapp.com/about/bookstack-alternatives/)
+44. [BookStack: Open-Source Wiki System](https://blog.octabyte.io/posts/applications/bookstack/bookstack-open-source-wiki-system-for-efficient-documentation-and-knowledge-management/)
+45. [Top 5 Alternatives to BookStack](https://docmost.com/blog/bookstack-alternatives/)
+
+### Market Analysis & Trends
+
+46. [Knowledge Management Magic Quadrant Explained](https://kminsider.com/blog/knowledge-management-magic-quadrant-explained/)
+47. [Microsoft Named Leader in 2025 Gartner® MQ for CRM Customer Engagement](https://www.microsoft.com/en-us/dynamics-365/blog/business-leader/2025/11/06/microsoft-is-named-a-leader-in-2025-gartner-magic-quadrant-for-crm-customer-engagement-center/)
+48. [Quick Answer: Why Isn't There a Magic Quadrant for Knowledge Management?](https://www.gartner.com/en/documents/4003610)
+49. [Glean Named as Emerging Leader (Press Release)](https://www.glean.com/press/glean-named-as-one-of-the-emerging-leaders-in-the-gartner-r-emerging-market-quadrant-of-the-2025-innovation-guide-for-generative-ai-knowledge-management-apps)
+50. [AI-driven Knowledge Management Systems Market CAGR of 42%](https://market.us/report/ai-driven-knowledge-management-systems-market/)
+51. [How AI is shaping the Future of AI Knowledge Management](https://www.clearpeople.com/blog/ai-future-knowledge-management-systems)
+52. [AI Knowledge Management in 2025](https://indatalabs.com/blog/ai-knowledge-management)
+53. [Enterprise LLM Market Size & Share, Statistics Report 2025-2034](https://www.gminsights.com/industry-analysis/enterprise-llm-market)
+54. [The 7 Knowledge Management Trends Shaping 2025](https://bloomfire.com/blog/knowledge-management-trends/)
+55. [AI in Knowledge Management Market Size | CAGR of 25%](https://market.us/report/ai-in-knowledge-management-market/)
+56. [Knowledge Management Software Market Size, Trends, Forecast to 2033](https://straitsresearch.com/report/knowledge-management-software-market)
+57. [Leaders predict AI to continue permeating all aspects of KM in 2026](https://www.kmworld.com/Articles/Editorial/ViewPoints/Leaders-predict-AI-to-continue-permeating-all-aspects-of-KM-in-2026-172594.aspx)
+58. [LLM Market Landscape 2025](https://powerdrill.ai/blog/llm-market-landscape)
+
+### RAG and Implementation
+
+59. [Retrieval-Augmented Generation (RAG): Complete AI Guide for 2025](https://latenode.com/blog/retrieval-augmented-generation-rag-complete-ai-guide-for-2025)
+60. [The 2025 Guide to Retrieval-Augmented Generation (RAG)](https://www.edenai.co/post/the-2025-guide-to-retrieval-augmented-generation-rag)
+61. [RAG in 2025: Bridging Knowledge and Generative AI](https://squirro.com/squirro-blog/state-of-rag-genai)
+62. [Retrieval Augmented Generation: Your 2025 AI Guide](https://collabnix.com/retrieval-augmented-generation-rag-complete-guide-to-building-intelligent-ai-systems-in-2025/)
+63. [The Next Frontier of RAG: How Enterprise Knowledge Systems Will Evolve](https://nstarxinc.com/blog/the-next-frontier-of-rag-how-enterprise-knowledge-systems-will-evolve-2026-2030/)
+64. [RAG and LLMs for Enterprise Knowledge Management: Systematic Literature Review](https://www.mdpi.com/2076-3417/16/1/368)
+65. [Retrieval-Augmented Generation (RAG): 2025 Definitive Guide](https://www.chitika.com/retrieval-augmented-generation-rag-the-definitive-guide-2025/)
+
+### Pricing and Comparison
+
+66. [enterprise knowledge management pricing comparison](https://www.featurebase.app/blog/sharepoint-knowledge-base)
+67. [Confluence vs Notion pricing comparison](https://www.joinsecret.com/compare/notion-vs-confluence)
+68. [Notion vs Confluence: Which is best for your team's knowledge in 2025?](https://www.eesel.ai/blog/notion-vs-confluence)
+69. [Best Graph Database for Enterprise: Comparison](https://www.nebula-graph.io/posts/best-graph-database-for-enterprise)
+70. [Cloud & Self-Hosted Graph Database Platform Pricing | Neo4j](https://neo4j.com/pricing/)
+71. [Neo4j Graph Database Pricing 2025](https://www.g2.com/products/neo4j-graph-database/pricing)
+
+---
+
+**End of Research Document**
+
+**Metadata:**
+- Total sources cited: 71
+- Research time: 2026-01-08
+- Product categories covered: 6
+- Products analyzed: 18
+- Market size data: AI-driven KM systems ($3B → $102.1B, 2024-2034)
+- Primary recommendation: Obsidian for immediate value, Vector DB for Q2 2026, defer graph DB
+
+**Next Steps:**
+1. Review recommendations with stakeholders
+2. Pilot Obsidian vault on `docs/` directory
+3. Evaluate vector database options (Chroma, Weaviate, Qdrant)
+4. Define success criteria for KM enhancement initiatives

--- a/docs/archive/projects-archive/research/work-032-e-004-python-km-sdks.md
+++ b/docs/archive/projects-archive/research/work-032-e-004-python-km-sdks.md
@@ -1,0 +1,3249 @@
+# Python Knowledge Management SDKs and Libraries
+
+> **Research ID:** WORK-032-E-004
+> **Research Date:** 2026-01-08
+> **Researcher:** ps-researcher agent (v2.0.0)
+> **Status:** DECISION-GRADE
+> **Purpose:** Research Python libraries for Knowledge Management implementation
+
+---
+
+## Context
+
+This research supports the Knowledge Architecture initiative (WORK-032) by cataloging Python libraries across six critical categories for Knowledge Management:
+
+1. Graph Libraries (data structures & algorithms)
+2. RDF/Semantic Web (standards-based KGs)
+3. Knowledge Graph Construction (NLP-driven extraction)
+4. Vector/Embedding Storage (semantic search)
+5. Ontology/Taxonomy (formal knowledge representation)
+6. Document Processing (knowledge extraction)
+
+This document provides:
+- Comprehensive library catalog with PyPI/GitHub links
+- Capability analysis for each library
+- Jerry compatibility assessment (stdlib preference, dependency analysis)
+- Code examples and usage patterns
+- Architecture fit for hexagonal design and zero-dependency core
+
+---
+
+## L0: Executive Summary (Plain Language)
+
+### Key Findings
+
+#### 1. **No Pure Stdlib Solution Exists**
+
+The Python standard library alone cannot support modern Knowledge Management requirements. All serious KM implementations require external dependencies. This is a fundamental architectural reality, not a gap we can fill.
+
+**Why**: Knowledge Management requires:
+- Graph algorithms (no stdlib implementation)
+- Semantic web standards (RDF, OWL, SPARQL)
+- Neural embeddings (deep learning models)
+- High-performance vector search (C++/Rust backends)
+- NLP pipelines (trained models, tokenizers)
+
+#### 2. **Three-Tier Dependency Strategy**
+
+Libraries naturally fall into three tiers by dependency weight:
+
+**Tier 1: Lightweight (Acceptable for Infrastructure Layer)**
+- NetworkX (pure Python, minimal deps: only decorator libs)
+- RDFLib (pure Python, stdlib + XML/parsing)
+- Small, well-scoped tools with minimal transitive dependencies
+
+**Tier 2: Moderate (Infrastructure Layer with Caution)**
+- FAISS (C++ core, Python bindings, no deep learning framework required)
+- Owlready2 (Python + SQLite, self-contained)
+- spaCy (modular, use only needed pipelines)
+
+**Tier 3: Heavy (Interface Layer Only)**
+- PyTorch Geometric, DGL (full deep learning stacks)
+- ChromaDB, Weaviate, Qdrant (full database systems)
+- LangChain, LlamaIndex (large framework ecosystems)
+
+#### 3. **Graph Library Landscape**
+
+| Library | Best For | Performance | Jerry Fit |
+|---------|----------|-------------|-----------|
+| **NetworkX** | Prototyping, small graphs (<10K nodes) | Slow (pure Python) | ✓ Infrastructure |
+| **igraph** | Medium graphs, balance speed/usability | Fast (C core) | ✓ Infrastructure |
+| **graph-tool** | Large-scale analytics, parallel processing | Fastest (C++) | ⚠ Complex install |
+| **PyTorch Geometric** | GNN research, GPU-accelerated | High (GPU) | ✗ Interface only |
+| **DGL** | Production GNNs, multi-framework | High (GPU) | ✗ Interface only |
+
+**Recommendation**: Start with **NetworkX** in infrastructure layer (hexagonal ports). Swap to igraph/graph-tool if performance demands it. Keep GNN libraries (PyG, DGL) in interface layer only.
+
+#### 4. **Semantic Web: RDFLib is the Foundation**
+
+For standards-based knowledge graphs (RDF, OWL, SPARQL), **RDFLib** is the de facto Python standard:
+- Pure Python (good Jerry fit)
+- 14M+ weekly downloads (ecosystem standard)
+- Supports all major RDF serializations (Turtle, JSON-LD, RDF/XML)
+- Integrates with Owlready2 for OWL ontologies
+
+**Alternative**: pyoxigraph (Rust-based, faster, but heavier dependency)
+
+#### 5. **Vector Search: FAISS for Embeddings, ChromaDB for RAG**
+
+**FAISS** (Facebook AI Similarity Search):
+- Industry standard for vector similarity search
+- C++ core with Python bindings
+- No deep learning framework required (just NumPy)
+- Handles billions of vectors
+- **Best fit for Jerry infrastructure layer**
+
+**ChromaDB**:
+- Open-source embedding database
+- Built for LLM/RAG workflows
+- 6K+ GitHub stars, rapid adoption
+- Good for prototyping, smaller scale
+- **Use in interface layer for LLM integration**
+
+**Pinecone, Weaviate, Qdrant**: Production vector databases, but require external services (not Jerry-compatible for core).
+
+#### 6. **Knowledge Graph Construction: spaCy + Transformers**
+
+**spaCy**:
+- Industrial-strength NLP (NER, dependency parsing)
+- Modular pipeline design (load only what you need)
+- Can extract entities and relationships without LLMs
+- **Acceptable for infrastructure layer** with careful pipeline selection
+
+**Hugging Face Transformers**:
+- State-of-the-art NLP models (REBEL for relation extraction)
+- Large dependency footprint (PyTorch/TensorFlow)
+- **Use in interface layer** or separate extraction service
+
+**LangChain/LlamaIndex**:
+- High-level RAG frameworks
+- Heavy dependencies, rapid API changes
+- **Interface layer only**, prefer thin adapters
+
+#### 7. **Document Processing: Docling (IBM) Leading the Pack**
+
+**Docling** (2025-2026 leader):
+- IBM's open-source framework (LF AI & Data Foundation project)
+- Handles PDF, DOCX, PPTX, HTML, images
+- Unified DoclingDocument format
+- Export to Markdown, HTML, JSON
+- **Best choice for production document processing**
+
+**Marker-PDF**:
+- Fast PDF → Markdown conversion
+- Excellent layout preservation
+- Heavy first-run (1GB model download)
+- **Use for PDF-specific workflows**
+
+**Unstructured**:
+- Multi-format support (PDF, HTML, Word, images)
+- Good for RAG systems (semantic chunking)
+- **Use for diverse document types**
+
+### Top Recommendations for Jerry
+
+#### Immediate Actions (WORK-032 Implementation)
+
+1. **Adopt NetworkX for Core Graph Operations**
+   - Pure Python, minimal dependencies
+   - Place in `src/infrastructure/graph/networkx_adapter.py`
+   - Define port in `src/domain/ports/graph_port.py`
+   - Easy to swap for igraph/graph-tool if needed
+
+2. **Use RDFLib for Semantic Knowledge Graphs**
+   - Place in `src/infrastructure/knowledge/rdflib_adapter.py`
+   - Supports future ontology integration
+   - Standards-compliant (interoperable)
+
+3. **Integrate FAISS for Vector Search**
+   - Lightweight enough for infrastructure layer
+   - Place in `src/infrastructure/embeddings/faiss_adapter.py`
+   - No framework lock-in (just NumPy arrays)
+
+4. **Document Processing: Start with Docling**
+   - Place in `src/infrastructure/documents/docling_adapter.py`
+   - Unified interface for multiple formats
+   - Export to structured formats (JSON, Markdown)
+
+5. **NLP: Careful spaCy Integration**
+   - Use minimal pipeline (`en_core_web_sm` for prototyping)
+   - Place in `src/infrastructure/nlp/spacy_adapter.py`
+   - Consider separate extraction service if models grow large
+
+#### Architectural Strategy
+
+**Hexagonal Ports Pattern:**
+
+```python
+# Domain Layer (src/domain/ports/)
+class GraphPort(ABC):
+    """Port for graph operations (dependency-free)."""
+    @abstractmethod
+    def add_node(self, node_id: str, properties: dict) -> None: ...
+
+    @abstractmethod
+    def add_edge(self, source: str, target: str, edge_type: str) -> None: ...
+
+    @abstractmethod
+    def traverse(self, start: str, pattern: TraversalPattern) -> List[Node]: ...
+
+# Infrastructure Layer (src/infrastructure/graph/)
+class NetworkXAdapter(GraphPort):
+    """NetworkX implementation of graph port."""
+    def __init__(self):
+        import networkx as nx  # Import isolated to adapter
+        self._graph = nx.MultiDiGraph()
+
+    def add_node(self, node_id: str, properties: dict) -> None:
+        self._graph.add_node(node_id, **properties)
+    # ... implement other methods
+```
+
+**Dependency Isolation:**
+- Domain layer: Zero external dependencies
+- Infrastructure layer: Lightweight dependencies (NetworkX, RDFLib, FAISS)
+- Interface layer: Heavy frameworks (LangChain, ChromaDB, transformers)
+
+**Migration Path:**
+- Start: NetworkX (prototyping)
+- Scale: igraph (performance)
+- Advanced: graph-tool (large-scale analytics)
+- Swap adapters, domain layer unchanged
+
+---
+
+## L1: Library Catalog with Code Examples
+
+### 1. Graph Libraries
+
+#### 1.1 NetworkX
+
+**PyPI Package**: `networkx`
+**GitHub**: https://github.com/networkx/networkx (16,295 stars)
+**Current Version**: 3.6.1 (January 2026)
+**Weekly Downloads**: 14.9M
+**Maintenance**: Sustainable (active development)
+
+**Key Capabilities:**
+- Pure Python implementation (easy install, no compilation)
+- Directed, undirected, and multigraphs
+- 100+ graph algorithms (shortest path, centrality, clustering)
+- Graph generators (random, classic, social networks)
+- Drawing/visualization integration (matplotlib, graphviz)
+
+**Jerry Compatibility**: ✓ **Excellent**
+- Pure Python (no C dependencies)
+- Minimal dependencies (only decorator libs)
+- Stdlib-friendly design
+- Easy to isolate in adapter
+
+**Performance Characteristics:**
+- Small graphs (<10K nodes): Acceptable
+- Medium graphs (10K-100K nodes): Slow
+- Large graphs (>100K nodes): Not recommended
+- 40-250x slower than graph-tool for complex algorithms
+
+**Example Usage:**
+
+```python
+import networkx as nx
+
+# Create directed graph
+G = nx.DiGraph()
+
+# Add nodes with properties
+G.add_node("task-001", type="task", status="active", title="Implement KG")
+G.add_node("phase-001", type="phase", name="Development")
+G.add_node("plan-001", type="plan", name="WORK-032")
+
+# Add edges with properties
+G.add_edge("task-001", "phase-001", edge_type="BELONGS_TO", created_at="2026-01-08")
+G.add_edge("phase-001", "plan-001", edge_type="PART_OF")
+
+# Query by property
+tasks = [n for n, attr in G.nodes(data=True) if attr.get('type') == 'task']
+
+# Traverse relationships
+phase = list(G.successors("task-001"))[0]
+print(f"Task belongs to: {G.nodes[phase]['name']}")
+
+# Find all tasks in a plan
+tasks_in_plan = []
+for phase in G.successors("plan-001"):
+    for task in G.predecessors(phase):
+        if G.nodes[task]['type'] == 'task':
+            tasks_in_plan.append(task)
+
+# Export to various formats
+nx.write_graphml(G, "knowledge_graph.graphml")
+nx.write_gexf(G, "knowledge_graph.gexf")
+
+# Algorithms
+# Shortest path
+path = nx.shortest_path(G, "task-001", "plan-001")
+
+# PageRank (for importance scoring)
+ranks = nx.pagerank(G)
+important_nodes = sorted(ranks.items(), key=lambda x: x[1], reverse=True)[:5]
+
+# Community detection
+communities = nx.community.greedy_modularity_communities(G.to_undirected())
+```
+
+**Jerry Adapter Pattern:**
+
+```python
+# src/infrastructure/graph/networkx_adapter.py
+from typing import List, Dict, Any, Optional
+import networkx as nx
+
+from src.domain.ports.graph_port import GraphPort, Node, Edge, TraversalPattern
+
+class NetworkXGraphAdapter(GraphPort):
+    """NetworkX implementation of graph storage."""
+
+    def __init__(self):
+        self._graph = nx.MultiDiGraph()
+
+    def add_node(self, node_id: str, label: str, properties: Dict[str, Any]) -> None:
+        """Add a node to the graph."""
+        self._graph.add_node(node_id, label=label, **properties)
+
+    def add_edge(
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        properties: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Add an edge to the graph."""
+        props = properties or {}
+        self._graph.add_edge(source, target, key=edge_type, edge_type=edge_type, **props)
+
+    def get_node(self, node_id: str) -> Optional[Node]:
+        """Retrieve a node by ID."""
+        if not self._graph.has_node(node_id):
+            return None
+        attrs = self._graph.nodes[node_id]
+        return Node(
+            id=node_id,
+            label=attrs.get('label', 'unknown'),
+            properties=dict(attrs)
+        )
+
+    def traverse_out(self, node_id: str, edge_type: Optional[str] = None) -> List[Node]:
+        """Traverse outgoing edges from a node."""
+        if not self._graph.has_node(node_id):
+            return []
+
+        result = []
+        for successor in self._graph.successors(node_id):
+            # Filter by edge type if specified
+            if edge_type:
+                edge_data = self._graph.get_edge_data(node_id, successor)
+                if not any(data.get('edge_type') == edge_type for data in edge_data.values()):
+                    continue
+
+            node = self.get_node(successor)
+            if node:
+                result.append(node)
+
+        return result
+
+    def query(self, pattern: TraversalPattern) -> List[Node]:
+        """Execute a traversal pattern query."""
+        # Pattern matching implementation
+        # This is where Gremlin-like queries would be translated
+        # For now, simplified implementation
+        nodes = []
+        for node_id, attrs in self._graph.nodes(data=True):
+            if attrs.get('label') == pattern.start_label:
+                nodes.append(Node(id=node_id, label=pattern.start_label, properties=dict(attrs)))
+        return nodes
+
+    def export_to_dict(self) -> Dict[str, Any]:
+        """Export graph to dictionary format."""
+        return nx.node_link_data(self._graph)
+
+    def import_from_dict(self, data: Dict[str, Any]) -> None:
+        """Import graph from dictionary format."""
+        self._graph = nx.node_link_graph(data, multigraph=True, directed=True)
+```
+
+**Citations:**
+- [NetworkX GitHub Repository](https://github.com/networkx/networkx)
+- [NetworkX PyPI Package](https://pypi.org/project/networkx/)
+- [NetworkX Documentation](https://networkx.org/documentation/stable/)
+
+---
+
+#### 1.2 igraph
+
+**PyPI Package**: `python-igraph`
+**GitHub**: https://github.com/igraph/python-igraph (~3K stars, part of igraph org)
+**Current Version**: 0.11.x
+**Core**: C/C++ library with Python bindings
+
+**Key Capabilities:**
+- High-performance graph algorithms (C/C++ core)
+- 8x faster than NetworkX for betweenness centrality
+- Support for large graphs (millions of nodes)
+- Efficient memory usage
+- Cross-platform (R, Python, Mathematica, C/C++)
+
+**Jerry Compatibility**: ✓ **Good**
+- Pre-compiled wheels for most platforms
+- Smaller dependency footprint than graph-tool
+- C extension but well-packaged
+
+**Performance Characteristics:**
+- Small graphs: Overkill but works
+- Medium graphs (10K-1M nodes): Excellent
+- Large graphs (>1M nodes): Very good
+- ~8-10x faster than NetworkX
+
+**Example Usage:**
+
+```python
+from igraph import Graph
+
+# Create directed graph
+g = Graph(directed=True)
+
+# Add vertices with attributes
+g.add_vertices(3)
+g.vs[0]['name'] = 'task-001'
+g.vs[0]['type'] = 'task'
+g.vs[1]['name'] = 'phase-001'
+g.vs[1]['type'] = 'phase'
+g.vs[2]['name'] = 'plan-001'
+g.vs[2]['type'] = 'plan'
+
+# Add edges
+g.add_edge(0, 1, edge_type='BELONGS_TO')
+g.add_edge(1, 2, edge_type='PART_OF')
+
+# Query by attribute
+tasks = g.vs.select(type='task')
+
+# Traverse
+neighbors = g.neighbors(0, mode='out')
+
+# Algorithms (fast!)
+pagerank = g.pagerank(directed=True)
+betweenness = g.betweenness(directed=True)
+
+# Community detection
+communities = g.community_multilevel()
+
+# Export
+g.write_graphml('graph.graphml')
+```
+
+**When to Use igraph Over NetworkX:**
+- Graph has >10K nodes
+- Performance-critical traversals
+- Need community detection on large graphs
+- Running centrality algorithms repeatedly
+
+**Citations:**
+- [igraph Python Package](https://pypi.org/project/python-igraph/)
+- [igraph Documentation](https://igraph.org/python/)
+
+---
+
+#### 1.3 graph-tool
+
+**PyPI Package**: `graph-tool` (complex installation, usually via conda)
+**Website**: https://graph-tool.skewed.de/
+**GitHub**: Part of graph-tool project
+**Core**: C++ with Boost Graph Library
+
+**Key Capabilities:**
+- Fastest Python graph library (C++ + Boost)
+- Parallel processing with OpenMP
+- Advanced algorithms (stochastic block models, graph drawing)
+- Statistical graph analysis
+- Graph filtering without copying
+
+**Jerry Compatibility**: ⚠ **Challenging**
+- Complex installation (C++ compilation, Boost dependency)
+- Best installed via conda, not pip
+- Heavy dependencies
+- Not suitable for lightweight deployments
+
+**Performance Characteristics:**
+- Fastest of all Python graph libraries
+- 40-250x faster than NetworkX
+- OpenMP parallel algorithms (PageRank, betweenness)
+- Handles billion-node graphs
+
+**When to Use:**
+- Large-scale graph analytics (>1M nodes)
+- Need maximum performance
+- Have controlled deployment environment (conda)
+- Running statistical inference on graphs
+
+**Example Usage:**
+
+```python
+from graph_tool.all import Graph, graph_draw
+import graph_tool.centrality as centrality
+
+# Create graph
+g = Graph(directed=True)
+
+# Add vertices
+v1 = g.add_vertex()
+v2 = g.add_vertex()
+v3 = g.add_vertex()
+
+# Properties
+vprop_name = g.new_vertex_property("string")
+vprop_type = g.new_vertex_property("string")
+g.vertex_properties["name"] = vprop_name
+g.vertex_properties["type"] = vprop_type
+
+vprop_name[v1] = "task-001"
+vprop_type[v1] = "task"
+
+# Add edges
+e1 = g.add_edge(v1, v2)
+eprop = g.new_edge_property("string")
+g.edge_properties["edge_type"] = eprop
+eprop[e1] = "BELONGS_TO"
+
+# Fast algorithms
+pr = centrality.pagerank(g)
+betw = centrality.betweenness(g)
+
+# Visualization
+graph_draw(g, vertex_text=vprop_name, output="graph.png")
+```
+
+**Jerry Recommendation**: Use only if performance demands it. Start with NetworkX/igraph.
+
+**Citations:**
+- [graph-tool Performance Benchmarks](https://graph-tool.skewed.de/performance.html)
+- [graph-tool Documentation](https://graph-tool.skewed.de/)
+
+---
+
+#### 1.4 PyTorch Geometric (PyG)
+
+**PyPI Package**: `torch-geometric`
+**GitHub**: https://github.com/pyg-team/pytorch_geometric (~20K stars)
+**Current Version**: 2.x
+**Core**: PyTorch-based Graph Neural Networks
+
+**Key Capabilities:**
+- State-of-the-art GNN implementations (GCN, GAT, GraphSAGE)
+- GPU-accelerated graph learning
+- Message-passing neural networks
+- Integration with PyTorch ecosystem
+- Large model zoo (100+ implementations)
+
+**Jerry Compatibility**: ✗ **Interface Layer Only**
+- Requires full PyTorch stack
+- GPU recommended for performance
+- Large dependency footprint
+- Use only in interface/application layer
+
+**Performance Characteristics:**
+- CPU: Slower than traditional graph libraries
+- GPU: Excellent for deep learning on graphs
+- Best for: Node classification, link prediction, graph classification
+
+**Example Usage:**
+
+```python
+import torch
+from torch_geometric.data import Data
+from torch_geometric.nn import GCNConv
+import torch.nn.functional as F
+
+# Create graph data
+edge_index = torch.tensor([[0, 1, 1, 2],
+                           [1, 0, 2, 1]], dtype=torch.long)
+x = torch.tensor([[-1], [0], [1]], dtype=torch.float)
+
+data = Data(x=x, edge_index=edge_index)
+
+# Define GNN model
+class GCN(torch.nn.Module):
+    def __init__(self, num_features, hidden_channels):
+        super(GCN, self).__init__()
+        self.conv1 = GCNConv(num_features, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, hidden_channels)
+
+    def forward(self, x, edge_index):
+        x = self.conv1(x, edge_index)
+        x = F.relu(x)
+        x = self.conv2(x, edge_index)
+        return x
+
+# Train model
+model = GCN(num_features=1, hidden_channels=16)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+# Use for node embeddings
+model.eval()
+with torch.no_grad():
+    embeddings = model(data.x, data.edge_index)
+```
+
+**When to Use in Jerry:**
+- Need graph embeddings for similarity search
+- Building knowledge graph completion models
+- Link prediction for suggesting relationships
+- **Always isolate in interface layer**
+
+**Citations:**
+- [PyTorch Geometric GitHub](https://github.com/pyg-team/pytorch_geometric)
+- [PyG vs DGL Comparison](https://www.exxactcorp.com/blog/Deep-Learning/pytorch-geometric-vs-deep-graph-library)
+
+---
+
+#### 1.5 Deep Graph Library (DGL)
+
+**PyPI Package**: `dgl`
+**GitHub**: https://github.com/dmlc/dgl (~13K stars)
+**Current Version**: 2.x
+**Core**: Multi-framework GNN library (PyTorch, TensorFlow, MXNet)
+
+**Key Capabilities:**
+- Framework-agnostic (PyTorch/TensorFlow/MXNet backends)
+- Lower-level API (more flexible than PyG)
+- Support for heterogeneous graphs
+- Tree-LSTM and other non-message-passing models
+- Used in AlphaFold (SE3-Transformer), RosettaFold
+
+**Jerry Compatibility**: ✗ **Interface Layer Only**
+- Requires deep learning framework
+- Heavy dependencies
+- Production-oriented (good for deployment)
+
+**Example Usage:**
+
+```python
+import dgl
+import torch
+
+# Create graph
+src = torch.tensor([0, 1, 1, 2])
+dst = torch.tensor([1, 0, 2, 1])
+g = dgl.graph((src, dst))
+
+# Add node features
+g.ndata['feat'] = torch.randn(3, 5)
+
+# Add edge features
+g.edata['weight'] = torch.randn(4, 1)
+
+# Heterogeneous graph (knowledge graph)
+graph_data = {
+    ('task', 'belongs_to', 'phase'): (torch.tensor([0, 1]), torch.tensor([0, 0])),
+    ('phase', 'part_of', 'plan'): (torch.tensor([0]), torch.tensor([0]))
+}
+hetero_g = dgl.heterograph(graph_data)
+
+# Message passing
+import dgl.function as fn
+
+g.update_all(fn.copy_u('feat', 'm'), fn.mean('m', 'feat_agg'))
+```
+
+**When to Use Over PyG:**
+- Need multi-framework support
+- Building complex, non-standard GNN architectures
+- Production deployment with specific framework requirements
+
+**Citations:**
+- [DGL GitHub Repository](https://github.com/dmlc/dgl)
+- [DGL Documentation](https://docs.dgl.ai/)
+
+---
+
+### 2. RDF/Semantic Web Libraries
+
+#### 2.1 RDFLib
+
+**PyPI Package**: `rdflib`
+**GitHub**: https://github.com/RDFLib/rdflib (~2K stars, but de facto standard)
+**Current Version**: 7.x (January 2026)
+**Weekly Downloads**: 14M+
+
+**Key Capabilities:**
+- Pure Python RDF library
+- Support for RDF, RDFS, OWL
+- Parsers/serializers: RDF/XML, Turtle, N-Triples, JSON-LD, N3
+- SPARQL 1.1 query and update
+- Triple/quad store with multiple backends
+- Graph operations (union, intersection, difference)
+
+**Jerry Compatibility**: ✓ **Excellent**
+- Pure Python
+- Minimal dependencies (stdlib + XML/parsing libs)
+- Industry standard (interoperability)
+- Easy to isolate in adapter
+
+**Performance Characteristics:**
+- Small graphs (<100K triples): Good
+- Medium graphs (100K-1M triples): Acceptable
+- Large graphs (>1M triples): Consider triplestore backend
+
+**Example Usage:**
+
+```python
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import RDF, RDFS, OWL
+
+# Create graph
+g = Graph()
+
+# Define namespace
+JERRY = Namespace("http://jerry.ai/ontology/")
+g.bind("jerry", JERRY)
+
+# Add triples (subject, predicate, object)
+task_001 = JERRY.Task_001
+g.add((task_001, RDF.type, JERRY.Task))
+g.add((task_001, JERRY.title, Literal("Implement Knowledge Graph")))
+g.add((task_001, JERRY.status, Literal("active")))
+g.add((task_001, JERRY.belongsTo, JERRY.Phase_001))
+
+phase_001 = JERRY.Phase_001
+g.add((phase_001, RDF.type, JERRY.Phase))
+g.add((phase_001, JERRY.name, Literal("Development")))
+g.add((phase_001, JERRY.partOf, JERRY.Plan_WORK032))
+
+# SPARQL query
+query = """
+    PREFIX jerry: <http://jerry.ai/ontology/>
+
+    SELECT ?task ?title ?phase
+    WHERE {
+        ?task a jerry:Task ;
+              jerry:title ?title ;
+              jerry:belongsTo ?phase .
+        ?phase jerry:partOf jerry:Plan_WORK032 .
+    }
+"""
+results = g.query(query)
+for row in results:
+    print(f"Task: {row.task}, Title: {row.title}, Phase: {row.phase}")
+
+# Serialize to Turtle (human-readable)
+print(g.serialize(format='turtle'))
+
+# Serialize to JSON-LD (LLM-friendly)
+print(g.serialize(format='json-ld'))
+
+# Load from file
+g.parse("knowledge_graph.ttl", format="turtle")
+
+# Reasoning (simple)
+# Add transitivity rule
+for s, o in g.subject_objects(JERRY.partOf):
+    for s2 in g.subjects(JERRY.belongsTo, s):
+        g.add((s2, JERRY.indirectPartOf, o))
+
+# Export to triple store
+g.serialize(destination='knowledge_graph.nt', format='nt')
+```
+
+**Jerry Adapter Pattern:**
+
+```python
+# src/infrastructure/knowledge/rdflib_adapter.py
+from typing import List, Dict, Any, Optional
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import RDF, RDFS
+
+from src.domain.ports.knowledge_port import KnowledgePort, Triple
+
+class RDFLibAdapter(KnowledgePort):
+    """RDFLib implementation of knowledge graph storage."""
+
+    def __init__(self, base_uri: str = "http://jerry.ai/ontology/"):
+        self._graph = Graph()
+        self._namespace = Namespace(base_uri)
+        self._graph.bind("jerry", self._namespace)
+
+    def add_triple(self, subject: str, predicate: str, obj: str) -> None:
+        """Add a triple to the knowledge graph."""
+        s = self._namespace[subject]
+        p = self._namespace[predicate]
+        o = self._namespace[obj] if not self._is_literal(obj) else Literal(obj)
+        self._graph.add((s, p, o))
+
+    def query_sparql(self, query: str) -> List[Dict[str, Any]]:
+        """Execute a SPARQL query."""
+        results = self._graph.query(query)
+        return [dict(row.asdict()) for row in results]
+
+    def export_turtle(self) -> str:
+        """Export graph to Turtle format."""
+        return self._graph.serialize(format='turtle')
+
+    def export_jsonld(self) -> str:
+        """Export graph to JSON-LD format."""
+        return self._graph.serialize(format='json-ld')
+
+    def import_turtle(self, data: str) -> None:
+        """Import graph from Turtle format."""
+        self._graph.parse(data=data, format='turtle')
+
+    def _is_literal(self, value: str) -> bool:
+        """Check if value should be a literal."""
+        # Simple heuristic: if it doesn't look like an identifier, it's a literal
+        return ' ' in value or not value.replace('_', '').replace('-', '').isalnum()
+```
+
+**Citations:**
+- [RDFLib GitHub Repository](https://github.com/RDFLib/rdflib)
+- [RDFLib PyPI Package](https://pypi.org/project/rdflib/)
+- [RDFLib Documentation](https://rdflib.readthedocs.io/)
+
+---
+
+#### 2.2 Owlready2
+
+**PyPI Package**: `owlready2`
+**GitHub**: https://github.com/pwin/owlready2 (~250 stars)
+**Current Version**: 0.49
+**Maintenance**: Active
+
+**Key Capabilities:**
+- Ontology-oriented programming (load OWL as Python objects)
+- Support for OWL 2.0, SWRL
+- Reasoning via HermiT (included)
+- Optimized quadstore (SQLite3-based)
+- Can handle large ontologies
+- SPARQL query support (via RDFLib integration)
+- ORM-like interface for ontologies
+
+**Jerry Compatibility**: ✓ **Good**
+- Pure Python core
+- SQLite backend (stdlib)
+- Self-contained reasoner
+- Moderate dependencies
+
+**Performance Characteristics:**
+- Optimized for large ontologies
+- Faster reasoning than pure RDFLib
+- Quadstore better for versioning/context
+
+**Example Usage:**
+
+```python
+from owlready2 import *
+
+# Create ontology
+onto = get_ontology("http://jerry.ai/ontology/work_tracker.owl")
+
+# Define classes
+with onto:
+    class Task(Thing):
+        pass
+
+    class Phase(Thing):
+        pass
+
+    class Plan(Thing):
+        pass
+
+    # Define properties
+    class belongsTo(ObjectProperty):
+        domain = [Task]
+        range = [Phase]
+
+    class partOf(ObjectProperty):
+        domain = [Phase]
+        range = [Plan]
+
+    class hasTitle(DataProperty):
+        domain = [Task]
+        range = [str]
+
+    class hasStatus(DataProperty):
+        domain = [Task]
+        range = [str]
+
+# Create instances
+task_001 = Task("task_001")
+task_001.hasTitle = ["Implement Knowledge Graph"]
+task_001.hasStatus = ["active"]
+
+phase_001 = Phase("phase_001")
+task_001.belongsTo = [phase_001]
+
+plan_001 = Plan("plan_WORK032")
+phase_001.partOf = [plan_001]
+
+# Reasoning
+with onto:
+    # Define transitive property
+    class indirectPartOf(ObjectProperty, TransitiveProperty):
+        pass
+
+    # Add rule: if A belongsTo B and B partOf C, then A indirectPartOf C
+    # (This would be done via SWRL or reasoning)
+
+# Run reasoner
+sync_reasoner_pellet(infer_property_values=True, infer_data_property_values=True)
+
+# Query
+tasks_in_plan = []
+for task in Task.instances():
+    for phase in task.belongsTo:
+        for plan in phase.partOf:
+            if plan == plan_001:
+                tasks_in_plan.append(task)
+
+# Save ontology
+onto.save(file="work_tracker.owl", format="rdfxml")
+
+# SPARQL via RDFLib integration
+graph = default_world.as_rdflib_graph()
+results = graph.query("""
+    SELECT ?task ?title
+    WHERE {
+        ?task a <http://jerry.ai/ontology/work_tracker.owl#Task> ;
+              <http://jerry.ai/ontology/work_tracker.owl#hasTitle> ?title .
+    }
+""")
+```
+
+**When to Use Over RDFLib:**
+- Need formal reasoning (OWL inference)
+- Working with complex ontologies
+- Want object-oriented interface to RDF
+- Need to define SWRL rules
+
+**Known Limitations:**
+- Does not support OWL Functional Syntax
+- Does not support punned entities
+- RDF/XML, OWL/XML, NTriples only (no Turtle parser)
+
+**Citations:**
+- [Owlready2 PyPI Package](https://pypi.org/project/owlready2/)
+- [Owlready2 Documentation](https://owlready2.readthedocs.io/)
+
+---
+
+#### 2.3 kglab
+
+**PyPI Package**: `kglab`
+**GitHub**: https://github.com/DerwenAI/kglab (~500 stars)
+**License**: MIT
+**Maintenance**: Active (2020-2025)
+
+**Key Capabilities:**
+- Abstraction layer over RDFLib, NetworkX, PyVis, morph-kgc
+- Integrates multiple KG tools under one API
+- Support for Pandas DataFrames ↔ RDF conversion
+- Visualization with PyVis
+- Inference with OWL-RL and skosify
+- Probabilistic Soft Logic (PSL) integration
+- Good Jupyter notebook support
+
+**Jerry Compatibility**: ⚠ **Mixed**
+- Useful as high-level interface
+- Heavy dependencies (pulls in many libraries)
+- Better for exploration than production
+- Consider cherry-picking patterns, not full dependency
+
+**Example Usage:**
+
+```python
+import kglab
+
+# Create knowledge graph
+kg = kglab.KnowledgeGraph()
+
+# Load from Turtle
+kg.load_rdf("knowledge_graph.ttl", format="ttl")
+
+# Query with SPARQL
+sparql = """
+    SELECT ?subject ?predicate ?object
+    WHERE {
+        ?subject ?predicate ?object .
+    }
+    LIMIT 10
+"""
+df = kg.query_as_df(sparql)  # Returns Pandas DataFrame
+
+# Add triples from Pandas
+import pandas as pd
+df = pd.DataFrame({
+    'subject': ['task:001', 'task:002'],
+    'predicate': ['rdf:type', 'rdf:type'],
+    'object': ['jerry:Task', 'jerry:Task']
+})
+# (Would need custom conversion)
+
+# Visualization
+kg.visualize()
+
+# Inference with OWL-RL
+kg.infer_owlrl()
+
+# Export
+kg.save_rdf("output.ttl", format="ttl")
+```
+
+**Jerry Recommendation**: Use for prototyping/exploration, but prefer direct RDFLib for production.
+
+**Citations:**
+- [kglab GitHub Repository](https://github.com/DerwenAI/kglab)
+- [kglab PyPI Package](https://pypi.org/project/kglab/)
+
+---
+
+### 3. Knowledge Graph Construction (NLP)
+
+#### 3.1 spaCy
+
+**PyPI Package**: `spacy`
+**GitHub**: https://github.com/explosion/spacy (~29K stars)
+**Current Version**: 3.x
+**Maintenance**: Active (Explosion AI)
+
+**Key Capabilities:**
+- Industrial-strength NLP pipeline
+- Named Entity Recognition (NER)
+- Dependency parsing (syntax trees)
+- Part-of-speech tagging
+- Sentence segmentation
+- Custom pipeline components
+- Modular design (load only needed components)
+- Pre-trained models for 60+ languages
+- Fast (Cython core)
+
+**Jerry Compatibility**: ✓ **Acceptable with Caution**
+- Core is well-optimized
+- Models are large (100MB - 500MB)
+- Can use small models (`en_core_web_sm`: ~12MB)
+- Modular loading (only load needed pipes)
+- **Recommendation**: Place in infrastructure layer, use smallest models
+
+**Performance Characteristics:**
+- Fast NER and parsing (Cython core)
+- Small model: ~100K words/sec
+- Large model: ~50K words/sec
+- GPU support available
+
+**Example Usage for Knowledge Graph Construction:**
+
+```python
+import spacy
+
+# Load model (use smallest for Jerry)
+nlp = spacy.load("en_core_web_sm")
+
+# Process text
+text = """
+Jerry is a framework for behavior and workflow guardrails.
+It uses NetworkX for graph operations and RDFLib for semantic knowledge.
+The Work Tracker manages tasks, phases, and plans.
+"""
+
+doc = nlp(text)
+
+# Extract entities
+entities = []
+for ent in doc.ents:
+    entities.append({
+        'text': ent.text,
+        'label': ent.label_,
+        'start': ent.start_char,
+        'end': ent.end_char
+    })
+print("Entities:", entities)
+
+# Extract relationships via dependency parsing
+triples = []
+for sent in doc.sents:
+    for token in sent:
+        if token.dep_ in ('nsubj', 'nsubjpass'):
+            subject = token.text
+            predicate = token.head.text
+
+            # Find object
+            for child in token.head.children:
+                if child.dep_ in ('dobj', 'pobj', 'attr'):
+                    obj = child.text
+                    triples.append((subject, predicate, obj))
+
+print("Triples:", triples)
+
+# Advanced: Use custom patterns for relation extraction
+from spacy.matcher import Matcher
+
+matcher = Matcher(nlp.vocab)
+
+# Pattern: ENTITY uses ENTITY
+pattern = [
+    {"ENT_TYPE": {"IN": ["ORG", "PRODUCT"]}},
+    {"LOWER": "uses"},
+    {"ENT_TYPE": {"IN": ["ORG", "PRODUCT"]}}
+]
+matcher.add("USES_RELATION", [pattern])
+
+matches = matcher(doc)
+for match_id, start, end in matches:
+    span = doc[start:end]
+    print(f"Relation found: {span.text}")
+
+# Build knowledge graph from entities
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import RDF
+
+g = Graph()
+JERRY = Namespace("http://jerry.ai/kg/")
+
+for ent in doc.ents:
+    entity_uri = JERRY[ent.text.replace(' ', '_')]
+    g.add((entity_uri, RDF.type, JERRY[ent.label_]))
+    g.add((entity_uri, JERRY.text, Literal(ent.text)))
+
+for subj, pred, obj in triples:
+    s_uri = JERRY[subj.replace(' ', '_')]
+    p_uri = JERRY[pred.replace(' ', '_')]
+    o_uri = JERRY[obj.replace(' ', '_')]
+    g.add((s_uri, p_uri, o_uri))
+
+print(g.serialize(format='turtle'))
+```
+
+**Jerry Adapter Pattern:**
+
+```python
+# src/infrastructure/nlp/spacy_adapter.py
+from typing import List, Dict, Any, Tuple
+import spacy
+
+from src.domain.ports.nlp_port import NLPPort, Entity, Relation
+
+class SpacyNLPAdapter(NLPPort):
+    """spaCy implementation of NLP operations."""
+
+    def __init__(self, model: str = "en_core_web_sm"):
+        """Initialize with specified model."""
+        # Lazy load to keep adapter lightweight
+        self._model_name = model
+        self._nlp = None
+
+    def _ensure_loaded(self):
+        """Lazy load model on first use."""
+        if self._nlp is None:
+            self._nlp = spacy.load(self._model_name)
+
+    def extract_entities(self, text: str) -> List[Entity]:
+        """Extract named entities from text."""
+        self._ensure_loaded()
+        doc = self._nlp(text)
+
+        return [
+            Entity(
+                text=ent.text,
+                label=ent.label_,
+                start=ent.start_char,
+                end=ent.end_char,
+                confidence=1.0  # spaCy doesn't provide confidence scores
+            )
+            for ent in doc.ents
+        ]
+
+    def extract_relations(self, text: str) -> List[Relation]:
+        """Extract subject-verb-object relations from text."""
+        self._ensure_loaded()
+        doc = self._nlp(text)
+
+        relations = []
+        for sent in doc.sents:
+            for token in sent:
+                if token.dep_ in ('nsubj', 'nsubjpass'):
+                    subject = token.text
+                    predicate = token.head.text
+
+                    for child in token.head.children:
+                        if child.dep_ in ('dobj', 'pobj', 'attr'):
+                            relations.append(
+                                Relation(
+                                    subject=subject,
+                                    predicate=predicate,
+                                    object=child.text,
+                                    confidence=0.8  # Heuristic score
+                                )
+                            )
+
+        return relations
+
+    def tokenize(self, text: str) -> List[str]:
+        """Tokenize text into words."""
+        self._ensure_loaded()
+        doc = self._nlp(text)
+        return [token.text for token in doc]
+
+    def sentence_segment(self, text: str) -> List[str]:
+        """Segment text into sentences."""
+        self._ensure_loaded()
+        doc = self._nlp(text)
+        return [sent.text for sent in doc.sents]
+```
+
+**Model Size Recommendations for Jerry:**
+
+| Model | Size | Use Case |
+|-------|------|----------|
+| `en_core_web_sm` | 12 MB | Prototyping, lightweight deployment |
+| `en_core_web_md` | 40 MB | Better accuracy, word vectors included |
+| `en_core_web_lg` | 560 MB | Production quality (consider separate service) |
+
+**Citations:**
+- [spaCy GitHub Repository](https://github.com/explosion/spacy)
+- [spaCy Knowledge Graph Tutorial](https://www.analyticsvidhya.com/blog/2019/10/how-to-build-knowledge-graph-text-using-spacy/)
+
+---
+
+#### 3.2 Hugging Face Transformers
+
+**PyPI Package**: `transformers`
+**GitHub**: https://github.com/huggingface/transformers (~140K stars)
+**Current Version**: 4.x
+**Maintenance**: Active (Hugging Face)
+
+**Key Capabilities:**
+- State-of-the-art transformer models (BERT, GPT, T5, etc.)
+- Relation extraction (REBEL model)
+- Question answering, summarization, translation
+- Named entity recognition (fine-tuned BERT)
+- 100K+ pre-trained models on Hugging Face Hub
+- PyTorch and TensorFlow backends
+
+**Jerry Compatibility**: ✗ **Interface Layer Only**
+- Large models (100MB - several GB)
+- Requires PyTorch or TensorFlow
+- Heavy computational requirements
+- **Use in separate extraction service or interface layer**
+
+**Example Usage for Knowledge Graph Construction:**
+
+```python
+from transformers import pipeline
+
+# Relation extraction with REBEL
+# (REBEL: Relation Extraction By End-to-end Language generation)
+triplet_extractor = pipeline(
+    'text2text-generation',
+    model='Babelscape/rebel-large',
+    tokenizer='Babelscape/rebel-large'
+)
+
+text = """
+Jerry is a framework for behavior and workflow guardrails developed by the Jerry team.
+It uses NetworkX for graph operations and RDFLib for semantic knowledge representation.
+The Work Tracker manages tasks, phases, and plans within the framework.
+"""
+
+# Extract triplets
+extracted_text = triplet_extractor(text, return_tensors=True, return_text=False)[0]['generated_token_ids']
+extracted_triplets = triplet_extractor.tokenizer.batch_decode(extracted_text)
+
+# Parse triplets (REBEL format: <subj> <relation> <obj> <subj> <relation> <obj> ...)
+def extract_triplets_from_rebel(text):
+    triplets = []
+    relations = text.split('<triplet>')
+    for rel in relations:
+        if rel.strip():
+            parts = rel.split('<subj>')[1].split('<obj>')
+            if len(parts) >= 2:
+                subject = parts[0].strip()
+                rest = parts[1].split('<relation>')
+                if len(rest) >= 2:
+                    obj = rest[0].strip()
+                    relation = rest[1].strip()
+                    triplets.append((subject, relation, obj))
+    return triplets
+
+triplets = extract_triplets_from_rebel(extracted_triplets[0])
+print("Extracted triplets:", triplets)
+
+# Named entity recognition with BERT
+ner_pipeline = pipeline("ner", model="dslim/bert-base-NER")
+entities = ner_pipeline(text)
+print("Entities:", entities)
+
+# Build knowledge graph
+from rdflib import Graph, Namespace, Literal
+from rdflib.namespace import RDF
+
+g = Graph()
+JERRY = Namespace("http://jerry.ai/kg/")
+
+for subj, rel, obj in triplets:
+    s_uri = JERRY[subj.replace(' ', '_')]
+    r_uri = JERRY[rel.replace(' ', '_')]
+    o_uri = JERRY[obj.replace(' ', '_')]
+    g.add((s_uri, r_uri, o_uri))
+
+print(g.serialize(format='turtle'))
+```
+
+**When to Use:**
+- Need state-of-the-art relation extraction
+- Building knowledge graph from unstructured text at scale
+- Can afford computational cost (GPU recommended)
+- **Recommendation**: Deploy as separate extraction service, not embedded
+
+**Citations:**
+- [Hugging Face Transformers GitHub](https://github.com/huggingface/transformers)
+- [REBEL for Knowledge Graph Construction](https://medium.com/@sauravjoshi23/building-knowledge-graphs-rebel-llamaindex-and-rebel-llamaindex-8769cf800115)
+
+---
+
+#### 3.3 LangChain
+
+**PyPI Package**: `langchain`
+**GitHub**: https://github.com/langchain-ai/langchain (~90K stars)
+**Current Version**: 0.x (API changes frequently)
+**Maintenance**: Very active
+
+**Key Capabilities:**
+- High-level LLM application framework
+- Document loaders (PDF, HTML, Markdown, etc.)
+- Text splitters (semantic chunking)
+- Vector store integrations (FAISS, Chroma, Pinecone)
+- Chain composition (sequential, parallel, branching)
+- Agents and tools
+- Knowledge graph support (Cypher, SPARQL)
+
+**Jerry Compatibility**: ⚠ **Interface Layer with Thin Adapters**
+- Large framework with many dependencies
+- Rapid API changes (version churn)
+- **Recommendation**: Use for prototyping, then extract patterns into Jerry
+- Prefer thin adapters over deep integration
+
+**Example Usage:**
+
+```python
+from langchain.document_loaders import TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.chains import RetrievalQA
+from langchain.llms import OpenAI
+
+# Load documents
+loader = TextLoader("jerry_docs.txt")
+documents = loader.load()
+
+# Split into chunks
+text_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,
+    chunk_overlap=200
+)
+chunks = text_splitter.split_documents(documents)
+
+# Create embeddings
+embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+
+# Create vector store
+vectorstore = FAISS.from_documents(chunks, embeddings)
+
+# Create retrieval chain
+llm = OpenAI(temperature=0)
+qa_chain = RetrievalQA.from_chain_type(
+    llm=llm,
+    chain_type="stuff",
+    retriever=vectorstore.as_retriever()
+)
+
+# Query
+result = qa_chain.run("What does Jerry use for graph operations?")
+print(result)
+
+# Knowledge graph integration
+from langchain.graphs import NetworkxEntityGraph
+from langchain.chains import GraphQAChain
+
+graph = NetworkxEntityGraph()
+graph_chain = GraphQAChain.from_llm(llm, graph=graph)
+```
+
+**Jerry Recommendation:**
+- Use for **rapid prototyping** of RAG workflows
+- Extract successful patterns into Jerry-native implementations
+- Don't let LangChain become core dependency
+- Create thin adapters in interface layer
+
+**Citations:**
+- [LangChain Documentation](https://python.langchain.com/)
+- [LangChain GitHub Repository](https://github.com/langchain-ai/langchain)
+
+---
+
+#### 3.4 LlamaIndex
+
+**PyPI Package**: `llama-index`
+**GitHub**: https://github.com/run-llama/llama_index (~30K stars)
+**Current Version**: 0.x
+**Maintenance**: Very active (LlamaCloud)
+
+**Key Capabilities:**
+- Data framework for LLM applications
+- Document ingestion and indexing
+- Query engines (vector, tree, graph)
+- Knowledge graph index type
+- Agent framework
+- Integration with LLMs (OpenAI, Anthropic, local models)
+- Hugging Face model support
+
+**Jerry Compatibility**: ⚠ **Interface Layer Only**
+- Enterprise-focused (LlamaCloud)
+- Heavy dependencies
+- Good for data ingestion pipelines
+- **Use in interface layer for document processing**
+
+**Example Usage:**
+
+```python
+from llama_index import SimpleDirectoryReader, VectorStoreIndex, ServiceContext
+from llama_index.llms import HuggingFaceLLM
+
+# Load documents
+documents = SimpleDirectoryReader('docs/').load_data()
+
+# Create index
+index = VectorStoreIndex.from_documents(documents)
+
+# Query
+query_engine = index.as_query_engine()
+response = query_engine.query("What is Jerry's architecture?")
+print(response)
+
+# Knowledge graph construction
+from llama_index.graph_stores import SimpleGraphStore
+from llama_index.indices.knowledge_graph import KnowledgeGraphIndex
+
+graph_store = SimpleGraphStore()
+kg_index = KnowledgeGraphIndex.from_documents(
+    documents,
+    storage_context=graph_store
+)
+
+# Query knowledge graph
+kg_query_engine = kg_index.as_query_engine()
+response = kg_query_engine.query("How are tasks and phases related?")
+```
+
+**When to Use Over LangChain:**
+- Need structured data extraction
+- Building production data pipelines
+- Want enterprise support (LlamaCloud)
+
+**Citations:**
+- [LlamaIndex Documentation](https://developers.llamaindex.ai/)
+- [LlamaIndex Knowledge Graph Examples](https://developers.llamaindex.ai/python/examples/index_structs/knowledge_graph/knowledge_graph2/)
+
+---
+
+### 4. Vector/Embedding Storage Libraries
+
+#### 4.1 FAISS (Facebook AI Similarity Search)
+
+**PyPI Package**: `faiss-cpu` or `faiss-gpu`
+**GitHub**: https://github.com/facebookresearch/faiss (~30K stars)
+**Maintenance**: Active (Meta FAIR)
+**Core**: C++ with Python bindings
+
+**Key Capabilities:**
+- Efficient similarity search for dense vectors
+- Handles billions of vectors
+- Multiple index types (Flat, IVF, HNSW, PQ)
+- CPU and GPU support
+- Sub-10ms latency for million-scale searches
+- Clustering algorithms (k-means)
+- Product quantization for compression
+
+**Jerry Compatibility**: ✓ **Good for Infrastructure Layer**
+- No deep learning framework required (just NumPy)
+- Lightweight Python bindings
+- C++ core (high performance)
+- Pre-compiled wheels available
+- **Recommended for vector search in infrastructure**
+
+**Performance Characteristics:**
+- Flat index: Exact search, O(n) time
+- IVF index: Approximate search, O(√n) time
+- HNSW: Graph-based, fast approximate search
+- GPU: 10-100x faster than CPU for large datasets
+
+**Example Usage:**
+
+```python
+import numpy as np
+import faiss
+
+# Create sample embeddings (e.g., from sentence-transformers)
+dimension = 384  # Embedding dimension
+num_vectors = 10000
+
+# Random embeddings for demonstration
+vectors = np.random.random((num_vectors, dimension)).astype('float32')
+
+# Normalize vectors (for cosine similarity)
+faiss.normalize_L2(vectors)
+
+# Create index - Flat (exact search)
+index = faiss.IndexFlatL2(dimension)
+index.add(vectors)
+
+print(f"Index contains {index.ntotal} vectors")
+
+# Search
+query_vector = np.random.random((1, dimension)).astype('float32')
+faiss.normalize_L2(query_vector)
+
+k = 5  # Number of nearest neighbors
+distances, indices = index.search(query_vector, k)
+
+print(f"Top {k} nearest neighbors:")
+print(f"Indices: {indices[0]}")
+print(f"Distances: {distances[0]}")
+
+# Advanced: IVF index for large datasets
+nlist = 100  # Number of clusters
+quantizer = faiss.IndexFlatL2(dimension)
+index_ivf = faiss.IndexIVFFlat(quantizer, dimension, nlist)
+
+# Train index (required for IVF)
+index_ivf.train(vectors)
+index_ivf.add(vectors)
+
+# Search with probe parameter (trade speed/accuracy)
+index_ivf.nprobe = 10
+distances, indices = index_ivf.search(query_vector, k)
+
+# HNSW index (graph-based, no training required)
+M = 32  # Number of connections per layer
+index_hnsw = faiss.IndexHNSWFlat(dimension, M)
+index_hnsw.add(vectors)
+distances, indices = index_hnsw.search(query_vector, k)
+
+# Save/load index
+faiss.write_index(index, "vector_index.faiss")
+loaded_index = faiss.read_index("vector_index.faiss")
+```
+
+**Jerry Adapter Pattern:**
+
+```python
+# src/infrastructure/embeddings/faiss_adapter.py
+from typing import List, Tuple, Optional
+import numpy as np
+import faiss
+
+from src.domain.ports.vector_store_port import VectorStorePort, SearchResult
+
+class FAISSVectorStore(VectorStorePort):
+    """FAISS implementation of vector storage."""
+
+    def __init__(self, dimension: int, index_type: str = "flat"):
+        """
+        Initialize FAISS index.
+
+        Args:
+            dimension: Embedding dimension
+            index_type: "flat", "ivf", or "hnsw"
+        """
+        self._dimension = dimension
+        self._index_type = index_type
+        self._index = self._create_index(dimension, index_type)
+        self._id_map = []  # Map index position to entity ID
+
+    def _create_index(self, dimension: int, index_type: str):
+        """Create FAISS index based on type."""
+        if index_type == "flat":
+            return faiss.IndexFlatL2(dimension)
+        elif index_type == "ivf":
+            nlist = 100
+            quantizer = faiss.IndexFlatL2(dimension)
+            return faiss.IndexIVFFlat(quantizer, dimension, nlist)
+        elif index_type == "hnsw":
+            M = 32
+            return faiss.IndexHNSWFlat(dimension, M)
+        else:
+            raise ValueError(f"Unknown index type: {index_type}")
+
+    def add_vectors(self, entity_ids: List[str], vectors: np.ndarray) -> None:
+        """Add vectors to the index."""
+        if vectors.dtype != np.float32:
+            vectors = vectors.astype('float32')
+
+        # Normalize for cosine similarity
+        faiss.normalize_L2(vectors)
+
+        # Train IVF index if needed
+        if self._index_type == "ivf" and not self._index.is_trained:
+            self._index.train(vectors)
+
+        # Add to index
+        self._index.add(vectors)
+
+        # Update ID mapping
+        self._id_map.extend(entity_ids)
+
+    def search(
+        self,
+        query_vector: np.ndarray,
+        k: int = 5
+    ) -> List[SearchResult]:
+        """Search for nearest neighbors."""
+        if query_vector.dtype != np.float32:
+            query_vector = query_vector.astype('float32')
+
+        # Ensure 2D array
+        if query_vector.ndim == 1:
+            query_vector = query_vector.reshape(1, -1)
+
+        # Normalize
+        faiss.normalize_L2(query_vector)
+
+        # Search
+        distances, indices = self._index.search(query_vector, k)
+
+        # Convert to results
+        results = []
+        for dist, idx in zip(distances[0], indices[0]):
+            if idx >= 0 and idx < len(self._id_map):
+                results.append(SearchResult(
+                    entity_id=self._id_map[idx],
+                    distance=float(dist),
+                    similarity=1.0 / (1.0 + float(dist))  # Convert distance to similarity
+                ))
+
+        return results
+
+    def save(self, path: str) -> None:
+        """Save index to disk."""
+        faiss.write_index(self._index, path)
+        # Save ID mapping separately
+        np.save(path + ".ids", np.array(self._id_map))
+
+    def load(self, path: str) -> None:
+        """Load index from disk."""
+        self._index = faiss.read_index(path)
+        self._id_map = list(np.load(path + ".ids", allow_pickle=True))
+
+    def size(self) -> int:
+        """Return number of vectors in index."""
+        return self._index.ntotal
+```
+
+**Index Type Selection Guide:**
+
+| Index | Use Case | Training Required | Speed | Accuracy |
+|-------|----------|-------------------|-------|----------|
+| Flat | <100K vectors, exact search | No | Slow | 100% |
+| IVF | 100K-10M vectors, approximate | Yes | Fast | 95-99% |
+| HNSW | Any size, graph-based | No | Very fast | 95-99% |
+| PQ | Compression (100M+ vectors) | Yes | Very fast | 90-95% |
+
+**Jerry Recommendation**: Start with Flat for prototyping, switch to HNSW for production.
+
+**Citations:**
+- [FAISS GitHub Repository](https://github.com/facebookresearch/faiss)
+- [FAISS Documentation](https://faiss.ai/)
+- [FAISS Tutorial](https://www.pinecone.io/learn/series/faiss/faiss-tutorial/)
+
+---
+
+#### 4.2 ChromaDB
+
+**PyPI Package**: `chromadb`
+**GitHub**: https://github.com/chroma-core/chroma (~6K stars)
+**Current Version**: 0.4.x
+**Maintenance**: Very active
+
+**Key Capabilities:**
+- Open-source embedding database
+- Built for LLM applications (RAG)
+- Stores embeddings + metadata + documents
+- Multiple embedding functions (OpenAI, Sentence Transformers, custom)
+- SQL-like query interface
+- Persistent storage (SQLite backend)
+- Client-server mode available
+
+**Jerry Compatibility**: ⚠ **Interface Layer Preferred**
+- Larger dependency footprint than FAISS
+- Database-oriented (not just vector index)
+- Good for LLM integration
+- **Use in interface layer for RAG workflows**
+
+**Performance Characteristics:**
+- Small to medium datasets (<1M vectors)
+- Good for prototyping and development
+- Not as optimized as FAISS for pure vector search
+- Better integration with LLM workflows
+
+**Example Usage:**
+
+```python
+import chromadb
+from chromadb.config import Settings
+
+# Create client
+client = chromadb.Client(Settings(
+    chroma_db_impl="duckdb+parquet",
+    persist_directory="./chroma_db"
+))
+
+# Create or get collection
+collection = client.get_or_create_collection(
+    name="jerry_knowledge",
+    metadata={"description": "Jerry framework knowledge base"}
+)
+
+# Add documents with embeddings (automatic embedding)
+collection.add(
+    documents=[
+        "Jerry is a framework for behavior and workflow guardrails.",
+        "NetworkX is used for graph operations in Jerry.",
+        "RDFLib handles semantic knowledge representation.",
+        "The Work Tracker manages tasks, phases, and plans."
+    ],
+    metadatas=[
+        {"source": "readme", "type": "overview"},
+        {"source": "architecture", "type": "implementation"},
+        {"source": "architecture", "type": "implementation"},
+        {"source": "features", "type": "component"}
+    ],
+    ids=["doc1", "doc2", "doc3", "doc4"]
+)
+
+# Query (semantic search)
+results = collection.query(
+    query_texts=["How does Jerry handle graphs?"],
+    n_results=2
+)
+
+print("Query results:")
+for doc, metadata, distance in zip(
+    results['documents'][0],
+    results['metadatas'][0],
+    results['distances'][0]
+):
+    print(f"Document: {doc}")
+    print(f"Metadata: {metadata}")
+    print(f"Distance: {distance}")
+    print()
+
+# Query with metadata filtering
+results = collection.query(
+    query_texts=["Tell me about architecture"],
+    n_results=2,
+    where={"type": "implementation"}
+)
+
+# Add with custom embeddings
+import numpy as np
+
+custom_embeddings = [np.random.random(384).tolist() for _ in range(2)]
+collection.add(
+    embeddings=custom_embeddings,
+    documents=["Document 1", "Document 2"],
+    ids=["custom1", "custom2"]
+)
+
+# Update documents
+collection.update(
+    ids=["doc1"],
+    documents=["Jerry is an advanced framework for AI behavior guardrails."],
+    metadatas=[{"source": "readme", "type": "overview", "version": "2.0"}]
+)
+
+# Delete documents
+collection.delete(ids=["custom1", "custom2"])
+
+# Persist (automatic with persist_directory)
+# client.persist()  # Explicit persist if needed
+```
+
+**Jerry Integration Example:**
+
+```python
+# src/interface/rag/chroma_rag.py
+import chromadb
+from typing import List, Dict, Any
+
+class ChromaRAGService:
+    """RAG service using ChromaDB."""
+
+    def __init__(self, persist_directory: str = "./data/chroma"):
+        self._client = chromadb.Client(Settings(
+            chroma_db_impl="duckdb+parquet",
+            persist_directory=persist_directory
+        ))
+        self._collection = self._client.get_or_create_collection("jerry_kb")
+
+    def index_documents(self, documents: List[str], metadata: List[Dict[str, Any]]) -> None:
+        """Index documents for retrieval."""
+        ids = [f"doc_{i}" for i in range(len(documents))]
+        self._collection.add(
+            documents=documents,
+            metadatas=metadata,
+            ids=ids
+        )
+
+    def retrieve(self, query: str, k: int = 5, filters: Dict[str, Any] = None) -> List[Dict]:
+        """Retrieve relevant documents."""
+        results = self._collection.query(
+            query_texts=[query],
+            n_results=k,
+            where=filters
+        )
+
+        return [
+            {
+                'document': doc,
+                'metadata': meta,
+                'distance': dist
+            }
+            for doc, meta, dist in zip(
+                results['documents'][0],
+                results['metadatas'][0],
+                results['distances'][0]
+            )
+        ]
+```
+
+**When to Use ChromaDB:**
+- Building RAG applications
+- Need document + embedding + metadata together
+- Want simple, Pythonic API
+- Prototyping LLM applications
+
+**When to Use FAISS Instead:**
+- Pure vector search (no document storage)
+- Maximum performance requirements
+- Handling billions of vectors
+- Infrastructure layer implementation
+
+**Citations:**
+- [ChromaDB GitHub Repository](https://github.com/chroma-core/chroma)
+- [ChromaDB Documentation](https://docs.trychroma.com/)
+
+---
+
+#### 4.3 Qdrant
+
+**PyPI Package**: `qdrant-client`
+**GitHub**: https://github.com/qdrant/qdrant (~9K stars)
+**Core**: Rust (Python client)
+**Maintenance**: Very active
+
+**Key Capabilities:**
+- Vector similarity search engine (Rust-based)
+- HTTP API with Python client
+- Powerful metadata filtering
+- ACID-compliant transactions
+- Distributed deployment
+- Horizontal scaling
+- Payload storage with vectors
+- Hybrid search (vector + keyword)
+
+**Jerry Compatibility**: ⚠ **Requires External Service**
+- Client-server architecture
+- Run as separate service (Docker)
+- Not embeddable like FAISS
+- **Use if building production vector search service**
+
+**Example Usage:**
+
+```python
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams, PointStruct
+
+# Connect to Qdrant (local or cloud)
+client = QdrantClient(host="localhost", port=6333)
+# Or: client = QdrantClient(":memory:")  # In-memory for testing
+
+# Create collection
+client.create_collection(
+    collection_name="jerry_knowledge",
+    vectors_config=VectorParams(size=384, distance=Distance.COSINE)
+)
+
+# Add vectors with payload
+import numpy as np
+
+vectors = [np.random.random(384).tolist() for _ in range(5)]
+payloads = [
+    {"text": "Jerry framework overview", "type": "documentation", "section": "intro"},
+    {"text": "Graph operations with NetworkX", "type": "code", "section": "infrastructure"},
+    {"text": "RDF knowledge representation", "type": "documentation", "section": "knowledge"},
+    {"text": "Work Tracker architecture", "type": "design", "section": "features"},
+    {"text": "Hexagonal architecture pattern", "type": "architecture", "section": "design"}
+]
+
+client.upsert(
+    collection_name="jerry_knowledge",
+    points=[
+        PointStruct(id=i, vector=vec, payload=pay)
+        for i, (vec, pay) in enumerate(zip(vectors, payloads))
+    ]
+)
+
+# Search
+query_vector = np.random.random(384).tolist()
+
+results = client.search(
+    collection_name="jerry_knowledge",
+    query_vector=query_vector,
+    limit=3
+)
+
+for result in results:
+    print(f"ID: {result.id}, Score: {result.score}")
+    print(f"Payload: {result.payload}")
+
+# Search with filtering
+results = client.search(
+    collection_name="jerry_knowledge",
+    query_vector=query_vector,
+    query_filter={
+        "must": [
+            {"key": "type", "match": {"value": "documentation"}}
+        ]
+    },
+    limit=2
+)
+
+# Hybrid search (vector + keyword)
+from qdrant_client.models import Filter, FieldCondition, MatchValue
+
+results = client.search(
+    collection_name="jerry_knowledge",
+    query_vector=query_vector,
+    query_filter=Filter(
+        must=[
+            FieldCondition(
+                key="section",
+                match=MatchValue(value="infrastructure")
+            )
+        ]
+    ),
+    limit=3
+)
+```
+
+**Deployment:**
+
+```bash
+# Run Qdrant with Docker
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+**Jerry Recommendation**: Use if building a dedicated vector search service, otherwise prefer FAISS (embedded) or ChromaDB (simpler).
+
+**Citations:**
+- [Qdrant GitHub Repository](https://github.com/qdrant/qdrant)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)
+
+---
+
+#### 4.4 Comparison Summary: Vector Databases
+
+| Library | Type | Jerry Fit | Best For | Deployment |
+|---------|------|-----------|----------|------------|
+| **FAISS** | Index library | ✓ Infrastructure | Pure vector search, billions of vectors | Embedded |
+| **ChromaDB** | Embedding DB | ⚠ Interface | RAG, prototyping, small-medium scale | Embedded or server |
+| **Qdrant** | Vector DB | ⚠ Service | Production search, metadata filtering | Server (Docker/cloud) |
+| **Weaviate** | Vector DB | ⚠ Service | Hybrid search, enterprise features | Server (Docker/cloud) |
+| **Pinecone** | Vector DB | ✗ Cloud only | Managed service, zero ops | Cloud SaaS |
+
+**Jerry Strategy:**
+1. **Prototyping**: ChromaDB (easy, integrated)
+2. **Production (embedded)**: FAISS (fast, lightweight)
+3. **Production (service)**: Qdrant (scalable, Rust-based)
+
+---
+
+### 5. Ontology/Taxonomy Libraries
+
+#### 5.1 Owlready2 (Covered in Section 2.2)
+
+**See Section 2.2 for detailed coverage.**
+
+**Key Highlights:**
+- Load OWL ontologies as Python objects
+- Reasoning with HermiT
+- SQLite-based quadstore
+- **Best Python library for OWL ontologies**
+
+---
+
+#### 5.2 Pronto
+
+**PyPI Package**: `pronto`
+**GitHub**: https://github.com/althonos/pronto (~200 stars)
+**Current Version**: 2.x
+**Maintenance**: Active
+
+**Key Capabilities:**
+- OBO ontology parser (biomedical focus)
+- Support for OBO, OBOGraph-JSON, RDF/XML
+- Fast parsing with Fastobo (Rust)
+- Pythonic API (iterate terms, relationships)
+- Export to various formats
+- Good for Gene Ontology, biomedical ontologies
+
+**Jerry Compatibility**: ⚠ **Specialized Use Case**
+- Best for OBO format (biomedical domain)
+- Pure Python with Rust parser
+- Not general-purpose (OWL support limited)
+- **Use only if working with biomedical ontologies**
+
+**Example Usage:**
+
+```python
+import pronto
+
+# Load ontology (e.g., Gene Ontology)
+ontology = pronto.Ontology("go-basic.obo")
+
+# Or from URL
+# ontology = pronto.Ontology("http://purl.obolibrary.org/obo/go/go-basic.obo")
+
+# Iterate terms
+for term in ontology.terms():
+    print(f"ID: {term.id}, Name: {term.name}")
+    if term.definition:
+        print(f"Definition: {term.definition}")
+
+# Get specific term
+term = ontology["GO:0008150"]  # Biological process
+print(f"Term: {term.name}")
+
+# Traverse relationships
+for child in term.subclasses():
+    print(f"  Child: {child.name}")
+
+# Find by name
+terms = ontology.search("metabolic process")
+for term in terms:
+    print(f"Found: {term.id} - {term.name}")
+
+# Export
+ontology.dump("output.obo", format="obo")
+```
+
+**Jerry Recommendation**: Skip unless working with biomedical ontologies. Use Owlready2 for general OWL ontologies.
+
+**Citations:**
+- [Pronto GitHub Repository](https://github.com/althonos/pronto)
+- [Pronto Documentation](https://pronto.readthedocs.io/)
+
+---
+
+#### 5.3 EMMOntoPy
+
+**PyPI Package**: `EMMOntoPy`
+**GitHub**: https://github.com/emmo-repo/EMMOntoPy (~50 stars)
+**Maintenance**: Active (European Materials Modelling Ontology project)
+
+**Key Capabilities:**
+- Extends Owlready2 with additional features
+- Access entities by label (skos:prefLabel)
+- Reasoning with FaCT++
+- Manchester syntax parsing
+- Better OWL ontology support than base Owlready2
+- Designed for materials science ontologies
+
+**Jerry Compatibility**: ⚠ **Specialized Extension**
+- Builds on Owlready2
+- Good if Owlready2 is already used
+- Additional features for complex ontologies
+- **Consider if Owlready2 is insufficient**
+
+**Example Usage:**
+
+```python
+from ontopy import get_ontology
+
+# Load ontology
+onto = get_ontology("emmo.owl").load()
+
+# Access by label (instead of IRI)
+atom = onto.Atom  # Access by label
+print(f"Atom IRI: {atom.iri}")
+
+# Reasoning with FaCT++
+onto.sync_reasoner(reasoner="FaCT++")
+
+# Manchester syntax
+# (More user-friendly than RDF/XML)
+```
+
+**Jerry Recommendation**: Use only if already using Owlready2 and need label-based access or FaCT++ reasoning.
+
+**Citations:**
+- [EMMOntoPy GitHub Repository](https://github.com/emmo-repo/EMMOntoPy)
+- [EMMOntoPy Documentation](https://emmo-repo.github.io/EMMOntoPy/)
+
+---
+
+#### 5.4 SKOS Libraries
+
+**SKOS (Simple Knowledge Organization System)** is an RDF vocabulary for taxonomies, thesauri, and classification schemes.
+
+**Primary Approach: Use RDFLib with SKOS namespace**
+
+```python
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import SKOS, RDF
+
+g = Graph()
+
+# Define concept scheme
+scheme = URIRef("http://jerry.ai/taxonomy/")
+g.add((scheme, RDF.type, SKOS.ConceptScheme))
+g.add((scheme, SKOS.prefLabel, Literal("Jerry Taxonomy")))
+
+# Define concepts
+task_concept = URIRef("http://jerry.ai/taxonomy/Task")
+g.add((task_concept, RDF.type, SKOS.Concept))
+g.add((task_concept, SKOS.prefLabel, Literal("Task")))
+g.add((task_concept, SKOS.inScheme, scheme))
+
+# Define hierarchy
+phase_concept = URIRef("http://jerry.ai/taxonomy/Phase")
+g.add((phase_concept, RDF.type, SKOS.Concept))
+g.add((phase_concept, SKOS.prefLabel, Literal("Phase")))
+g.add((task_concept, SKOS.broader, phase_concept))
+
+# Alternative notations
+g.add((task_concept, SKOS.altLabel, Literal("Work Item")))
+
+# Related concepts
+g.add((task_concept, SKOS.related, URIRef("http://jerry.ai/taxonomy/Issue")))
+
+# Export
+print(g.serialize(format='turtle'))
+```
+
+**Jerry Recommendation**: Use RDFLib with SKOS namespace. No additional library needed.
+
+---
+
+### 6. Document Processing Libraries
+
+#### 6.1 Docling (IBM)
+
+**PyPI Package**: `docling`
+**GitHub**: https://github.com/docling-project/docling (~2K stars, new but rising)
+**Maintenance**: Very active (IBM, LF AI & Data Foundation)
+**Current Status**: Leading solution for 2025-2026
+
+**Key Capabilities:**
+- Parse PDF, DOCX, PPTX, XLSX, HTML, images, audio (WAV, MP3)
+- Advanced PDF understanding (layout, tables, figures)
+- Unified DoclingDocument format
+- Export to Markdown, HTML, DocTags, JSON
+- Integration with LangChain, LlamaIndex
+- OCR support
+- Document classification
+
+**Jerry Compatibility**: ✓ **Good for Infrastructure Layer**
+- Well-packaged Python library
+- Modular design
+- Can be used standalone
+- **Recommended for document processing**
+
+**Example Usage:**
+
+```python
+from docling.document_converter import DocumentConverter
+
+# Initialize converter
+converter = DocumentConverter()
+
+# Convert PDF to Markdown
+result = converter.convert("document.pdf")
+
+# Access content
+markdown_content = result.document.export_to_markdown()
+print(markdown_content)
+
+# Export to JSON (structured)
+json_content = result.document.export_to_json()
+
+# Export to HTML
+html_content = result.document.export_to_html()
+
+# Access document structure
+for element in result.document.elements:
+    if element.type == "heading":
+        print(f"Heading: {element.text}")
+    elif element.type == "paragraph":
+        print(f"Paragraph: {element.text}")
+    elif element.type == "table":
+        print(f"Table with {len(element.rows)} rows")
+
+# Process multiple documents
+from pathlib import Path
+
+docs_path = Path("./docs")
+for doc_file in docs_path.glob("*.pdf"):
+    result = converter.convert(str(doc_file))
+    output_file = doc_file.with_suffix(".md")
+    with open(output_file, "w") as f:
+        f.write(result.document.export_to_markdown())
+
+# Integration with LangChain
+from langchain.document_loaders import DoclingLoader
+
+loader = DoclingLoader("document.pdf")
+documents = loader.load()
+```
+
+**Jerry Adapter Pattern:**
+
+```python
+# src/infrastructure/documents/docling_adapter.py
+from typing import List, Dict, Any
+from pathlib import Path
+from docling.document_converter import DocumentConverter
+
+from src.domain.ports.document_port import DocumentPort, Document, DocumentElement
+
+class DoclingAdapter(DocumentPort):
+    """Docling implementation of document processing."""
+
+    def __init__(self):
+        self._converter = DocumentConverter()
+
+    def extract_text(self, file_path: str) -> str:
+        """Extract plain text from document."""
+        result = self._converter.convert(file_path)
+        return result.document.export_to_markdown()
+
+    def extract_structured(self, file_path: str) -> Document:
+        """Extract structured document representation."""
+        result = self._converter.convert(file_path)
+
+        elements = []
+        for elem in result.document.elements:
+            elements.append(DocumentElement(
+                type=elem.type,
+                text=elem.text,
+                metadata=elem.metadata or {}
+            ))
+
+        return Document(
+            path=file_path,
+            title=result.document.metadata.get('title', Path(file_path).name),
+            elements=elements,
+            metadata=result.document.metadata
+        )
+
+    def convert_to_markdown(self, file_path: str, output_path: str) -> None:
+        """Convert document to Markdown."""
+        result = self._converter.convert(file_path)
+        markdown = result.document.export_to_markdown()
+
+        with open(output_path, 'w') as f:
+            f.write(markdown)
+
+    def batch_process(self, input_dir: str, output_dir: str) -> None:
+        """Batch process documents in directory."""
+        input_path = Path(input_dir)
+        output_path = Path(output_dir)
+        output_path.mkdir(exist_ok=True)
+
+        for doc_file in input_path.glob("*.*"):
+            if doc_file.suffix.lower() in ['.pdf', '.docx', '.pptx', '.html']:
+                result = self._converter.convert(str(doc_file))
+                out_file = output_path / (doc_file.stem + ".md")
+
+                with open(out_file, 'w') as f:
+                    f.write(result.document.export_to_markdown())
+```
+
+**Performance:**
+- Moderate speed (balances accuracy and performance)
+- 1GB+ model download on first run
+- CPU-based (no GPU required)
+- Good quality output (layout preservation)
+
+**Jerry Recommendation**: **Primary choice for document processing** in infrastructure layer.
+
+**Citations:**
+- [Docling GitHub Repository](https://github.com/docling-project/docling)
+- [Docling Documentation](https://github.com/docling-project/docling)
+- [Docling Tutorial](https://www.codecademy.com/article/docling-ai-a-complete-guide-to-parsing)
+
+---
+
+#### 6.2 Marker-PDF
+
+**PyPI Package**: `marker-pdf`
+**GitHub**: https://github.com/VikParuchuri/marker (~10K stars)
+**Maintenance**: Active
+**Focus**: Fast, high-quality PDF to Markdown
+
+**Key Capabilities:**
+- Fast PDF to Markdown conversion
+- Excellent layout preservation
+- Supports all languages
+- Handles tables, forms, math, links, code blocks
+- Extracts images
+- Removes headers/footers/artifacts
+- Customizable formatting
+- GPU acceleration available
+
+**Jerry Compatibility**: ⚠ **Specialized for PDFs**
+- Large first-run download (1GB model)
+- Best for PDF-only workflows
+- Good output quality
+- **Use for PDF-heavy workflows**
+
+**Example Usage:**
+
+```python
+from marker.convert import convert_single_pdf
+from marker.models import load_all_models
+
+# Load models (first run downloads ~1GB)
+model_list = load_all_models()
+
+# Convert PDF
+full_text, images, out_meta = convert_single_pdf(
+    "document.pdf",
+    model_list
+)
+
+print("Markdown content:")
+print(full_text)
+
+print(f"\nExtracted {len(images)} images")
+print(f"Metadata: {out_meta}")
+
+# Save output
+with open("document.md", "w") as f:
+    f.write(full_text)
+
+# Save images
+for i, img in enumerate(images):
+    img.save(f"image_{i}.png")
+```
+
+**Performance:**
+- Very fast (12 seconds for typical PDF)
+- 122 pages/second on H100 GPU
+- Excellent quality (layout-perfect)
+- Heavy first run (model download)
+
+**Jerry Recommendation**: Use if PDFs are primary document type and quality is critical. Otherwise, use Docling for broader format support.
+
+**Citations:**
+- [Marker-PDF PyPI Package](https://pypi.org/project/marker-pdf/)
+- [Marker GitHub Repository](https://github.com/VikParuchuri/marker)
+
+---
+
+#### 6.3 Unstructured
+
+**PyPI Package**: `unstructured`
+**GitHub**: https://github.com/Unstructured-IO/unstructured (~6K stars)
+**Maintenance**: Very active (Unstructured.io)
+
+**Key Capabilities:**
+- Multi-format support (PDF, HTML, Word, images, etc.)
+- Semantic chunking for RAG
+- Element-based parsing (title, text, table, etc.)
+- OCR support (Tesseract)
+- Partition strategies (fast, hi_res)
+- Integration with LangChain, LlamaIndex
+- Good for diverse document types
+
+**Jerry Compatibility**: ⚠ **Interface Layer Preferred**
+- Many dependencies (Tesseract, poppler, etc.)
+- Good for RAG workflows
+- Semantic chunking useful for embeddings
+- **Use in interface layer for LLM workflows**
+
+**Example Usage:**
+
+```python
+from unstructured.partition.auto import partition
+
+# Auto-detect format and parse
+elements = partition("document.pdf")
+
+# Iterate elements
+for element in elements:
+    print(f"Type: {element.category}")
+    print(f"Text: {element.text}")
+    print()
+
+# Get only specific types
+titles = [el.text for el in elements if el.category == "Title"]
+tables = [el for el in elements if el.category == "Table"]
+
+# Partition with strategy
+elements = partition(
+    "document.pdf",
+    strategy="hi_res",  # Use OCR for better quality
+    languages=["eng"]
+)
+
+# Chunk for RAG
+from unstructured.chunking.title import chunk_by_title
+
+chunks = chunk_by_title(
+    elements,
+    max_characters=1000,
+    combine_text_under_n_chars=100
+)
+
+# Integration with LangChain
+from langchain.document_loaders import UnstructuredPDFLoader
+
+loader = UnstructuredPDFLoader("document.pdf")
+documents = loader.load()
+```
+
+**Performance:**
+- Moderate speed (depends on strategy)
+- "fast" strategy: Quick but lower quality
+- "hi_res" strategy: Slower but better quality (OCR)
+- Good semantic chunking
+
+**Jerry Recommendation**: Use for RAG workflows in interface layer when semantic chunking is needed. Prefer Docling for general document processing.
+
+**Citations:**
+- [Unstructured GitHub Repository](https://github.com/Unstructured-IO/unstructured)
+- [Unstructured Documentation](https://unstructured-io.github.io/unstructured/)
+
+---
+
+#### 6.4 Document Processing Comparison
+
+| Library | Formats | Best For | Performance | Jerry Fit |
+|---------|---------|----------|-------------|-----------|
+| **Docling** | PDF, DOCX, PPTX, HTML, images | All-in-one solution | Moderate | ✓ Infrastructure |
+| **Marker-PDF** | PDF only | High-quality PDF extraction | Fast | ⚠ Specialized |
+| **Unstructured** | PDF, HTML, Word, images | RAG workflows, semantic chunking | Moderate | ⚠ Interface |
+| **pymupdf4llm** | PDF | Fast, simple PDF parsing | Very fast (0.12s) | ✓ Lightweight |
+| **pypdf** | PDF | Basic PDF text extraction | Fast | ✓ Stdlib-friendly |
+
+**Jerry Strategy:**
+1. **General use**: Docling (infrastructure layer)
+2. **PDF-only, quality critical**: Marker-PDF
+3. **RAG with semantic chunking**: Unstructured (interface layer)
+4. **Lightweight PDF extraction**: pymupdf or pypdf
+
+---
+
+## L2: Architecture Fit for Jerry
+
+### Hexagonal Architecture Integration
+
+Jerry's architecture follows the **Hexagonal (Ports & Adapters)** pattern with strict dependency rules:
+
+```
+┌─────────────────────────────────────────────────┐
+│              Interface Layer                     │
+│  (CLI, API, Agents, Skills)                     │
+│  Heavy frameworks: LangChain, LlamaIndex, PyG   │
+└─────────────────────────────────────────────────┘
+                     ↓
+┌─────────────────────────────────────────────────┐
+│           Application Layer (CQRS)              │
+│  Use Cases: Commands & Queries                  │
+│  No external dependencies                       │
+└─────────────────────────────────────────────────┘
+                     ↓
+┌─────────────────────────────────────────────────┐
+│         Infrastructure Layer (Adapters)         │
+│  Lightweight libs: NetworkX, RDFLib, FAISS      │
+│  Implements ports from domain                   │
+└─────────────────────────────────────────────────┘
+                     ↓
+┌─────────────────────────────────────────────────┐
+│         Domain Layer (Business Logic)           │
+│  Pure Python, NO external dependencies          │
+│  Defines ports (interfaces)                     │
+└─────────────────────────────────────────────────┘
+```
+
+### Dependency Tier Assignment
+
+**Tier 1: Infrastructure Layer (✓ Acceptable)**
+- NetworkX (pure Python, minimal deps)
+- RDFLib (pure Python, stdlib-based)
+- FAISS (C++ core, Python bindings, no framework)
+- Owlready2 (Python + SQLite)
+- spaCy (with small models, <50MB)
+- Docling (well-packaged, modular)
+
+**Tier 2: Infrastructure with Caution (⚠ Evaluate)**
+- igraph (C core, pre-compiled wheels)
+- ChromaDB (larger footprint, but useful for RAG)
+- Marker-PDF (large models, but excellent quality)
+
+**Tier 3: Interface Layer Only (✗ Never in Core)**
+- PyTorch Geometric (full deep learning stack)
+- DGL (multi-framework)
+- LangChain (heavy framework, rapid changes)
+- LlamaIndex (enterprise ecosystem)
+- Transformers (large models, PyTorch/TensorFlow)
+- Weaviate, Qdrant, Pinecone (external services)
+
+### Port Definitions (Domain Layer)
+
+```python
+# src/domain/ports/graph_port.py
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional
+from dataclasses import dataclass
+
+@dataclass
+class Node:
+    id: str
+    label: str
+    properties: Dict[str, Any]
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    edge_type: str
+    properties: Dict[str, Any]
+
+class GraphPort(ABC):
+    """Port for graph storage and traversal operations."""
+
+    @abstractmethod
+    def add_node(self, node_id: str, label: str, properties: Dict[str, Any]) -> None:
+        """Add a node to the graph."""
+        pass
+
+    @abstractmethod
+    def add_edge(
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        properties: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Add an edge to the graph."""
+        pass
+
+    @abstractmethod
+    def get_node(self, node_id: str) -> Optional[Node]:
+        """Retrieve a node by ID."""
+        pass
+
+    @abstractmethod
+    def traverse_out(self, node_id: str, edge_type: Optional[str] = None) -> List[Node]:
+        """Traverse outgoing edges from a node."""
+        pass
+
+    @abstractmethod
+    def query(self, pattern: 'TraversalPattern') -> List[Node]:
+        """Execute a traversal pattern query."""
+        pass
+```
+
+```python
+# src/domain/ports/knowledge_port.py
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+
+class KnowledgePort(ABC):
+    """Port for semantic knowledge graph operations (RDF/OWL)."""
+
+    @abstractmethod
+    def add_triple(self, subject: str, predicate: str, obj: str) -> None:
+        """Add a triple to the knowledge graph."""
+        pass
+
+    @abstractmethod
+    def query_sparql(self, query: str) -> List[Dict[str, Any]]:
+        """Execute a SPARQL query."""
+        pass
+
+    @abstractmethod
+    def export_turtle(self) -> str:
+        """Export graph to Turtle format."""
+        pass
+
+    @abstractmethod
+    def export_jsonld(self) -> str:
+        """Export graph to JSON-LD format."""
+        pass
+```
+
+```python
+# src/domain/ports/vector_store_port.py
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+import numpy as np
+from dataclasses import dataclass
+
+@dataclass
+class SearchResult:
+    entity_id: str
+    distance: float
+    similarity: float
+
+class VectorStorePort(ABC):
+    """Port for vector similarity search."""
+
+    @abstractmethod
+    def add_vectors(self, entity_ids: List[str], vectors: np.ndarray) -> None:
+        """Add vectors to the store."""
+        pass
+
+    @abstractmethod
+    def search(self, query_vector: np.ndarray, k: int = 5) -> List[SearchResult]:
+        """Search for nearest neighbors."""
+        pass
+
+    @abstractmethod
+    def save(self, path: str) -> None:
+        """Persist vectors to disk."""
+        pass
+
+    @abstractmethod
+    def load(self, path: str) -> None:
+        """Load vectors from disk."""
+        pass
+```
+
+```python
+# src/domain/ports/document_port.py
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+from dataclasses import dataclass
+
+@dataclass
+class DocumentElement:
+    type: str  # "heading", "paragraph", "table", etc.
+    text: str
+    metadata: Dict[str, Any]
+
+@dataclass
+class Document:
+    path: str
+    title: str
+    elements: List[DocumentElement]
+    metadata: Dict[str, Any]
+
+class DocumentPort(ABC):
+    """Port for document processing operations."""
+
+    @abstractmethod
+    def extract_text(self, file_path: str) -> str:
+        """Extract plain text from document."""
+        pass
+
+    @abstractmethod
+    def extract_structured(self, file_path: str) -> Document:
+        """Extract structured document representation."""
+        pass
+
+    @abstractmethod
+    def convert_to_markdown(self, file_path: str, output_path: str) -> None:
+        """Convert document to Markdown."""
+        pass
+```
+
+### Adapter Implementation Strategy
+
+**Directory Structure:**
+
+```
+src/infrastructure/
+├── graph/
+│   ├── networkx_adapter.py      # NetworkX implementation
+│   ├── igraph_adapter.py        # igraph implementation (future)
+│   └── gremlin_adapter.py       # Gremlin implementation (future)
+├── knowledge/
+│   ├── rdflib_adapter.py        # RDFLib implementation
+│   └── owlready_adapter.py      # Owlready2 implementation (optional)
+├── embeddings/
+│   ├── faiss_adapter.py         # FAISS implementation
+│   └── chroma_adapter.py        # ChromaDB implementation (interface)
+├── nlp/
+│   └── spacy_adapter.py         # spaCy implementation
+└── documents/
+    ├── docling_adapter.py       # Docling implementation
+    ├── marker_adapter.py        # Marker-PDF implementation (optional)
+    └── unstructured_adapter.py  # Unstructured implementation (interface)
+```
+
+**Adapter Swapping:**
+
+```python
+# src/infrastructure/graph/factory.py
+from src.domain.ports.graph_port import GraphPort
+from typing import Literal
+
+GraphBackend = Literal["networkx", "igraph", "gremlin"]
+
+def create_graph_adapter(backend: GraphBackend = "networkx") -> GraphPort:
+    """Factory to create graph adapter."""
+    if backend == "networkx":
+        from src.infrastructure.graph.networkx_adapter import NetworkXGraphAdapter
+        return NetworkXGraphAdapter()
+    elif backend == "igraph":
+        from src.infrastructure.graph.igraph_adapter import IGraphAdapter
+        return IGraphAdapter()
+    elif backend == "gremlin":
+        from src.infrastructure.graph.gremlin_adapter import GremlinAdapter
+        return GremlinAdapter()
+    else:
+        raise ValueError(f"Unknown graph backend: {backend}")
+```
+
+**Configuration:**
+
+```yaml
+# config/infrastructure.yaml
+graph:
+  backend: networkx  # or igraph, gremlin
+
+knowledge:
+  backend: rdflib  # or owlready
+  base_uri: "http://jerry.ai/ontology/"
+
+vector_store:
+  backend: faiss  # or chroma
+  dimension: 384
+  index_type: hnsw
+
+nlp:
+  backend: spacy
+  model: en_core_web_sm
+
+document:
+  backend: docling  # or marker, unstructured
+```
+
+### Dependency Management
+
+**requirements/base.txt** (Domain + Application):
+```txt
+# NO external dependencies for domain/application layers
+```
+
+**requirements/infrastructure.txt**:
+```txt
+# Lightweight infrastructure dependencies
+networkx>=3.0
+rdflib>=7.0
+faiss-cpu>=1.7.0
+spacy>=3.0
+docling>=0.1.0
+owlready2>=0.40  # optional
+```
+
+**requirements/interface.txt**:
+```txt
+# Heavy interface dependencies
+torch>=2.0
+torch-geometric>=2.0  # optional
+chromadb>=0.4.0  # optional
+langchain>=0.1.0  # optional
+transformers>=4.30.0  # optional
+```
+
+**Installation Strategy:**
+
+```bash
+# Core installation (always)
+pip install -r requirements/base.txt
+pip install -r requirements/infrastructure.txt
+
+# Optional: Interface layer features
+pip install -r requirements/interface.txt
+
+# Minimal installation (no ML/AI)
+pip install networkx rdflib
+```
+
+### Migration Path
+
+**Phase 1: Prototyping (Current)**
+- NetworkX for graph operations
+- RDFLib for semantic knowledge
+- FAISS for vector search (when needed)
+- Docling for document processing
+
+**Phase 2: Scaling (10K-1M nodes)**
+- **Swap NetworkX → igraph** (via adapter factory)
+- Keep RDFLib (or consider triplestore backend)
+- Optimize FAISS index type (Flat → HNSW)
+
+**Phase 3: Large-Scale (>1M nodes)**
+- **Swap igraph → graph-tool** (if analytics-heavy)
+- **OR: Swap to Gremlin** (distributed graph DB)
+- Consider external triplestore (Virtuoso, Stardog)
+- Qdrant for vector search (if service-based)
+
+**Key Principle**: Domain layer never changes. Only swap adapters.
+
+---
+
+## L3: Dependency Analysis
+
+### Zero-Dependency Libraries (Domain Layer)
+
+**None.** Modern KM requires external libraries. Focus on **minimal dependencies** instead.
+
+### Minimal Dependency Libraries (Infrastructure Layer)
+
+#### NetworkX
+```
+networkx==3.6.1
+├── no required dependencies (pure Python)
+└── optional: numpy, scipy, matplotlib, pandas
+```
+**Analysis**: Cleanest dependency graph. Ideal for Jerry.
+
+#### RDFLib
+```
+rdflib==7.0.0
+├── pyparsing>=2.1.0  (parsing library)
+├── isodate>=0.6.0    (date parsing)
+└── optional: html5lib, SPARQLWrapper
+```
+**Analysis**: Minimal, stdlib-friendly dependencies. Good fit.
+
+#### FAISS
+```
+faiss-cpu==1.8.0
+├── numpy>=1.16  (arrays)
+└── no other dependencies (C++ core)
+```
+**Analysis**: Lightweight for vector search. Excellent fit.
+
+### Moderate Dependency Libraries
+
+#### spaCy (small model)
+```
+spacy==3.7.0
+├── spacy-legacy>=3.0.0
+├── spacy-loggers>=1.0.0
+├── murmurhash>=0.28.0  (hashing)
+├── cymem>=2.0.2  (memory management)
+├── preshed>=3.0.2  (hash tables)
+├── thinc>=8.2.0  (ML library)
+├── wasabi>=0.9.1  (pretty printing)
+├── srsly>=2.4.3  (serialization)
+├── catalogue>=2.0.6  (registry)
+├── weasel>=0.1.0  (CLI)
+├── typer>=0.3.0  (CLI)
+├── pydantic>=1.7.4  (validation)
+├── jinja2  (templating)
+├── setuptools  (stdlib)
+├── packaging  (stdlib)
+└── langcodes>=3.2.0  (language codes)
+
+Model: en_core_web_sm (12 MB)
+```
+**Analysis**: More dependencies than ideal, but manageable. Core is optimized (Cython). Use smallest model.
+
+#### Owlready2
+```
+owlready2==0.49
+└── no required dependencies (uses stdlib sqlite3)
+```
+**Analysis**: Surprisingly clean. Self-contained reasoner. Good fit.
+
+#### Docling
+```
+docling==1.x
+├── various parsing libraries
+├── pillow (image processing)
+├── numpy
+└── model dependencies (~1GB first run)
+```
+**Analysis**: Heavier than ideal, but comprehensive. Well-packaged. Acceptable for infrastructure.
+
+### Heavy Dependency Libraries (Interface Layer Only)
+
+#### PyTorch Geometric
+```
+torch-geometric==2.x
+├── torch>=2.0  (~2GB)
+├── torch-scatter
+├── torch-sparse
+├── torch-cluster
+├── torch-spline-conv
+└── numpy, scipy, tqdm, etc.
+```
+**Analysis**: Massive dependency tree. GPU-focused. Interface layer only.
+
+#### LangChain
+```
+langchain==0.1.x
+├── langchain-core
+├── langchain-community
+├── pydantic>=2.0
+├── SQLAlchemy>=1.4
+├── requests
+├── PyYAML
+├── numpy
+├── aiohttp
+├── tenacity
+└── many integration packages
+```
+**Analysis**: Large framework with many dependencies. Rapid version changes. Use thin adapters only.
+
+#### ChromaDB
+```
+chromadb==0.4.x
+├── requests>=2.28
+├── pydantic>=1.9
+├── chroma-hnswlib>=0.7
+├── fastapi>=0.95.2
+├── uvicorn>=0.18.3
+├── numpy>=1.21.6
+├── posthog>=2.4.0
+├── typing_extensions>=4.5.0
+├── pulsar-client>=3.1.0
+├── onnxruntime>=1.14.1
+├── tokenizers>=0.13.2
+├── pypika>=0.48.9
+├── overrides>=7.3.1
+└── importlib-resources  (if Python < 3.9)
+```
+**Analysis**: Heavy for an "embedding database." Includes server components. Interface layer preferred.
+
+### Transitive Dependency Concerns
+
+**NumPy Conflict**: Many libraries depend on NumPy. Ensure version compatibility:
+- FAISS: numpy>=1.16
+- spaCy: numpy (via thinc)
+- ChromaDB: numpy>=1.21
+- PyTorch: includes own numpy-compatible tensors
+
+**PyTorch Conflict**: PyG and DGL both require PyTorch. Consider:
+- Use only one GNN library
+- Pin PyTorch version
+- Test compatibility before upgrading
+
+**Pydantic v1 vs v2**: LangChain moved to Pydantic v2, some libraries still on v1:
+- Check compatibility before mixing
+- Use pydantic v2 if possible (faster, better typing)
+
+### Installation Size Analysis
+
+| Library | Wheel Size | Installed Size | Models/Data | Total |
+|---------|-----------|----------------|-------------|-------|
+| networkx | 1.6 MB | 4 MB | 0 | 4 MB |
+| rdflib | 500 KB | 3 MB | 0 | 3 MB |
+| faiss-cpu | 10 MB | 30 MB | 0 | 30 MB |
+| owlready2 | 100 KB | 500 KB | 0 | 500 KB |
+| spacy | 7 MB | 20 MB | 12 MB (small) | 32 MB |
+| docling | ~50 MB | ~150 MB | ~1 GB (first run) | ~1.2 GB |
+| torch | ~800 MB | ~2 GB | varies | 2+ GB |
+| transformers | ~4 MB | ~10 MB | 100 MB - 10 GB | varies |
+
+**Jerry Footprint:**
+
+| Configuration | Total Size | Notes |
+|---------------|-----------|-------|
+| **Minimal** (NetworkX + RDFLib) | ~10 MB | Graph + semantic only |
+| **Standard** (+ FAISS + spaCy small) | ~80 MB | + vector search + NLP |
+| **Full Infrastructure** (+ Docling) | ~1.3 GB | + document processing |
+| **With ML** (+ PyTorch + transformers) | ~3+ GB | Interface layer features |
+
+**Recommendation**: Ship Jerry with **Standard** configuration. Make **Full Infrastructure** and **With ML** optional.
+
+### Dependency Isolation Strategy
+
+**Use Virtual Environments:**
+
+```bash
+# Base environment (infrastructure)
+python -m venv venv-base
+source venv-base/bin/activate
+pip install networkx rdflib faiss-cpu spacy docling
+
+# ML environment (interface)
+python -m venv venv-ml
+source venv-ml/bin/activate
+pip install -r requirements/interface.txt
+```
+
+**Use Docker Layers:**
+
+```dockerfile
+# Base image with infrastructure deps
+FROM python:3.11-slim AS base
+COPY requirements/infrastructure.txt .
+RUN pip install --no-cache-dir -r infrastructure.txt
+
+# ML image extends base
+FROM base AS ml
+COPY requirements/interface.txt .
+RUN pip install --no-cache-dir -r interface.txt
+```
+
+**Use Optional Extras:**
+
+```python
+# setup.py or pyproject.toml
+[project.optional-dependencies]
+infrastructure = [
+    "networkx>=3.0",
+    "rdflib>=7.0",
+    "faiss-cpu>=1.7",
+]
+nlp = [
+    "spacy>=3.0",
+    "en-core-web-sm @ https://...",
+]
+documents = [
+    "docling>=0.1",
+]
+ml = [
+    "torch>=2.0",
+    "transformers>=4.30",
+    "langchain>=0.1",
+]
+all = [
+    "jerry[infrastructure,nlp,documents,ml]",
+]
+```
+
+**Install:**
+
+```bash
+# Minimal
+pip install jerry
+
+# With infrastructure
+pip install jerry[infrastructure]
+
+# Full stack
+pip install jerry[all]
+```
+
+---
+
+## Recommendations Summary
+
+### Tier 1: Use Now (Infrastructure Layer)
+
+1. **NetworkX** - Primary graph library
+   - Pure Python, minimal deps
+   - Easy to swap later
+   - Good for <10K nodes
+
+2. **RDFLib** - Semantic knowledge graphs
+   - Standards-compliant (RDF, OWL, SPARQL)
+   - Pure Python
+   - Industry standard
+
+3. **FAISS** - Vector similarity search
+   - Lightweight (no framework dependency)
+   - High performance (C++ core)
+   - Scalable to billions of vectors
+
+4. **spaCy** - NLP for entity/relation extraction
+   - Use small model (en_core_web_sm)
+   - Modular pipelines
+   - Good quality/performance balance
+
+5. **Docling** - Document processing
+   - Multi-format support
+   - Good quality output
+   - Well-packaged
+
+### Tier 2: Consider Later (Scaling)
+
+1. **igraph** - When graph performance becomes bottleneck
+2. **Owlready2** - If need formal OWL reasoning
+3. **ChromaDB** - For RAG prototyping (interface layer)
+4. **Marker-PDF** - If PDF quality is critical
+
+### Tier 3: Interface Layer Only
+
+1. **PyTorch Geometric / DGL** - Graph neural networks
+2. **Transformers** - State-of-the-art NLP models
+3. **LangChain / LlamaIndex** - RAG frameworks (thin adapters)
+4. **Qdrant / Weaviate** - Vector databases (if service-based)
+
+### Avoid / Not Recommended
+
+1. **Pinecone** - Cloud-only, vendor lock-in
+2. **Heavy GNN libraries in core** - Keep in interface layer
+3. **Multiple GNN frameworks** - Pick one (PyG recommended)
+4. **LangChain deep integration** - Rapid API changes, use adapters
+
+---
+
+## Citations & References
+
+### Graph Libraries
+- [NetworkX GitHub Repository](https://github.com/networkx/networkx)
+- [NetworkX PyPI Package](https://pypi.org/project/networkx/)
+- [igraph Python Package](https://pypi.org/project/python-igraph/)
+- [graph-tool Performance Benchmarks](https://graph-tool.skewed.de/performance.html)
+- [PyTorch Geometric GitHub](https://github.com/pyg-team/pytorch_geometric)
+- [PyG vs DGL Comparison](https://www.exxactcorp.com/blog/Deep-Learning/pytorch-geometric-vs-deep-graph-library)
+- [DGL GitHub Repository](https://github.com/dmlc/dgl)
+- [Graph Library Benchmark](https://www.timlrx.com/blog/benchmark-of-popular-graph-network-packages)
+- [Graphs with Python Overview](https://towardsdatascience.com/graphs-with-python-overview-and-best-libraries-a92aa485c2f8/)
+
+### RDF/Semantic Web Libraries
+- [RDFLib GitHub Repository](https://github.com/RDFLib/rdflib)
+- [RDFLib PyPI Package](https://pypi.org/project/rdflib/)
+- [RDFLib Documentation](https://rdflib.readthedocs.io/)
+- [Owlready2 PyPI Package](https://pypi.org/project/owlready2/)
+- [Owlready2 Documentation](https://owlready2.readthedocs.io/)
+- [kglab GitHub Repository](https://github.com/DerwenAI/kglab)
+- [Semantic Python Overview](https://github.com/pysemtec/semantic-python-overview)
+
+### Knowledge Graph Construction
+- [spaCy GitHub Repository](https://github.com/explosion/spacy)
+- [spaCy Knowledge Graph Tutorial](https://www.analyticsvidhya.com/blog/2019/10/how-to-build-knowledge-graph-text-using-spacy/)
+- [Building KG with spaCy and LLMs](https://medium.com/mantisnlp/constructing-a-knowledge-base-with-spacy-and-spacy-llm-f65b50ea534d)
+- [Hugging Face Transformers GitHub](https://github.com/huggingface/transformers)
+- [REBEL for Knowledge Graph Construction](https://medium.com/@sauravjoshi23/building-knowledge-graphs-rebel-llamaindex-and-rebel-llamaindex-8769cf800115)
+- [LangChain Documentation](https://python.langchain.com/)
+- [LangChain GitHub Repository](https://github.com/langchain-ai/langchain)
+- [LlamaIndex Documentation](https://developers.llamaindex.ai/)
+- [LlamaIndex Knowledge Graph Examples](https://developers.llamaindex.ai/python/examples/index_structs/knowledge_graph/knowledge_graph2/)
+
+### Vector Databases
+- [FAISS GitHub Repository](https://github.com/facebookresearch/faiss)
+- [FAISS Documentation](https://faiss.ai/)
+- [FAISS Tutorial](https://www.pinecone.io/learn/series/faiss/faiss-tutorial/)
+- [ChromaDB GitHub Repository](https://github.com/chroma-core/chroma)
+- [ChromaDB Documentation](https://docs.trychroma.com/)
+- [Qdrant GitHub Repository](https://github.com/qdrant/qdrant)
+- [Qdrant Documentation](https://qdrant.tech/documentation/)
+- [Vector Database Comparison 2025](https://liquidmetal.ai/casesAndBlogs/vector-comparison/)
+- [Best Vector Databases 2026](https://www.datacamp.com/blog/the-top-5-vector-databases)
+- [Vector Database Comparison Guide](https://www.firecrawl.dev/blog/best-vector-databases-2025)
+
+### Ontology/Taxonomy Libraries
+- [Pronto GitHub Repository](https://github.com/althonos/pronto)
+- [EMMOntoPy GitHub Repository](https://github.com/emmo-repo/EMMOntoPy)
+- [Comparing Python Ontology Libraries](https://incenp.org/notes/2025/comparing-python-ontology-libraries.html)
+
+### Document Processing Libraries
+- [Docling GitHub Repository](https://github.com/docling-project/docling)
+- [Docling Tutorial](https://www.codecademy.com/article/docling-ai-a-complete-guide-to-parsing)
+- [Marker-PDF PyPI Package](https://pypi.org/project/marker-pdf/)
+- [Unstructured GitHub Repository](https://github.com/Unstructured-IO/unstructured)
+- [I Tested 7 Python PDF Extractors](https://dev.to/onlyoneaman/i-tested-7-python-pdf-extractors-so-you-dont-have-to-2025-edition-akm)
+- [Best Python PDF to Text Parser Libraries 2026](https://unstract.com/blog/evaluating-python-pdf-to-text-libraries/)
+
+---
+
+## Appendix: Quick Start Examples
+
+### Example 1: Build Simple Knowledge Graph with NetworkX + RDFLib
+
+```python
+# Build knowledge graph from Jerry documentation
+import networkx as nx
+from rdflib import Graph, Namespace, Literal
+from rdflib.namespace import RDF, RDFS
+
+# NetworkX graph (property graph)
+pg = nx.DiGraph()
+pg.add_node("jerry", type="framework", lang="python")
+pg.add_node("networkx", type="library", purpose="graphs")
+pg.add_node("rdflib", type="library", purpose="semantic")
+pg.add_edge("jerry", "networkx", relationship="uses")
+pg.add_edge("jerry", "rdflib", relationship="uses")
+
+# RDF graph (semantic)
+kg = Graph()
+JERRY = Namespace("http://jerry.ai/")
+kg.add((JERRY.Jerry, RDF.type, JERRY.Framework))
+kg.add((JERRY.Jerry, JERRY.uses, JERRY.NetworkX))
+kg.add((JERRY.Jerry, JERRY.uses, JERRY.RDFLib))
+
+print(kg.serialize(format='turtle'))
+```
+
+### Example 2: Vector Search with FAISS
+
+```python
+import numpy as np
+import faiss
+
+# Create embeddings (use sentence-transformers in production)
+vectors = np.random.random((1000, 384)).astype('float32')
+faiss.normalize_L2(vectors)
+
+# Build index
+index = faiss.IndexHNSWFlat(384, 32)
+index.add(vectors)
+
+# Search
+query = np.random.random((1, 384)).astype('float32')
+faiss.normalize_L2(query)
+distances, indices = index.search(query, 5)
+
+print(f"Nearest neighbors: {indices[0]}")
+```
+
+### Example 3: Extract Entities with spaCy
+
+```python
+import spacy
+
+nlp = spacy.load("en_core_web_sm")
+doc = nlp("Jerry uses NetworkX for graph operations.")
+
+for ent in doc.ents:
+    print(f"Entity: {ent.text}, Type: {ent.label_}")
+
+# Build graph from entities
+from rdflib import Graph, Namespace
+g = Graph()
+JERRY = Namespace("http://jerry.ai/")
+
+for ent in doc.ents:
+    g.add((JERRY[ent.text], JERRY.type, JERRY[ent.label_]))
+
+print(g.serialize(format='turtle'))
+```
+
+### Example 4: Process Document with Docling
+
+```python
+from docling.document_converter import DocumentConverter
+
+converter = DocumentConverter()
+result = converter.convert("document.pdf")
+
+# Export to Markdown
+markdown = result.document.export_to_markdown()
+with open("output.md", "w") as f:
+    f.write(markdown)
+
+# Extract structured data
+for element in result.document.elements:
+    if element.type == "heading":
+        print(f"Heading: {element.text}")
+```
+
+---
+
+**END OF RESEARCH DOCUMENT**

--- a/docs/archive/projects-archive/research/work-032-e-005-km-frameworks.md
+++ b/docs/archive/projects-archive/research/work-032-e-005-km-frameworks.md
@@ -1,0 +1,1935 @@
+# Knowledge Management and Problem-Solving Frameworks
+
+**Research ID:** WORK-032-E-005
+**Topic:** Knowledge Solving Frameworks and Methodologies
+**Date:** 2026-01-08
+**Status:** Complete
+
+---
+
+## L0: Executive Summary
+
+This research catalogues 16 knowledge management and problem-solving frameworks spanning 80+ years of organizational learning theory, from classic knowledge management (1960s-1990s) through modern AI-augmented approaches (2020s). The analysis reveals four distinct framework categories serving complementary purposes in the knowledge work lifecycle.
+
+**Key Findings:**
+
+1. **Classic KM frameworks** (SECI, Wiig, Boisot, Cynefin) excel at understanding knowledge types, flows, and contexts but lack operational specificity
+2. **Problem-solving frameworks** (TRIZ, Design Thinking, Systems Thinking, RCA) provide structured approaches to different problem types but require context awareness
+3. **Decision frameworks** (OODA, Kepner-Tregoe, PDCA, A3) offer systematic decision-making processes with varying speed/rigor trade-offs
+4. **AI-era frameworks** (RAG, GraphRAG, Chain-of-Thought, ReAct) enhance LLM capabilities but introduce new challenges around grounding and verification
+
+**Strategic Recommendation for Jerry:**
+
+Jerry should implement a **layered framework stack** that combines:
+- **Cynefin** for problem classification (complexity assessment)
+- **SECI Model** for knowledge creation and flow (tacit ↔ explicit conversion)
+- **ReAct + GraphRAG** for AI-augmented problem-solving (reasoning + knowledge retrieval)
+- **A3 Thinking** for documentation and continuous learning
+
+This combination leverages Jerry's filesystem-as-memory architecture while maintaining human oversight and systematic learning capture.
+
+---
+
+## L1: Framework Catalog with Decision Guide
+
+### Category 1: Classic Knowledge Management Frameworks
+
+These frameworks explain how knowledge is created, organized, stored, and transferred within organizations.
+
+#### 1.1 SECI Model (Nonaka & Takeuchi, 1995)
+
+**Origin:** Ikujiro Nonaka and Hirotaka Takeuchi, "The Knowledge-Creating Company" (1995)
+
+**Core Principles:**
+- Knowledge creation through continuous dialogue between tacit and explicit knowledge
+- Four modes of knowledge conversion: Socialization, Externalization, Combination, Internalization
+- Knowledge spirals across ontological levels (individual → group → organization → inter-organizational)
+- Concept of "Ba" (shared context/space) where knowledge is created and utilized
+
+**Knowledge Conversion Modes:**
+1. **Socialization** (Tacit → Tacit): Sharing experiences through observation, imitation, practice
+2. **Externalization** (Tacit → Explicit): Articulating tacit knowledge into documents, models, metaphors
+3. **Combination** (Explicit → Explicit): Systematizing concepts into knowledge systems
+4. **Internalization** (Explicit → Tacit): Learning by doing, embodying knowledge into practice
+
+**When to Use:**
+- Understanding organizational knowledge flows
+- Designing knowledge-sharing systems
+- Bridging tacit knowledge across teams
+- Building communities of practice
+
+**Strengths:**
+- Dynamic, process-oriented view of knowledge creation
+- Acknowledges both tacit and explicit knowledge dimensions
+- Widely validated across industries and cultures
+- Provides actionable framework for knowledge management initiatives
+
+**Limitations:**
+- Can be difficult to operationalize without supporting tools
+- Requires cultural support for knowledge sharing
+- Does not prescribe specific technologies or methods
+- Assumes organizational commitment to learning
+
+**Integration with KM:**
+SECI is foundational to modern KM. Most KM systems attempt to support at least one conversion mode. The model informs:
+- Knowledge repository design (Combination)
+- Mentoring programs (Socialization)
+- Documentation practices (Externalization)
+- Training and onboarding (Internalization)
+
+**Citations:**
+- [Managing Knowledge in Organizations: A Nonaka's SECI Model Operationalization - PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC6914727/)
+- [SECI model of knowledge dimensions - Wikipedia](https://en.wikipedia.org/wiki/SECI_model_of_knowledge_dimensions)
+- [SECI Model of Knowledge Dimensions - ToolsHero](https://www.toolshero.com/quality-management/seci-model-nonaka-takeuchi/)
+
+---
+
+#### 1.2 Wiig Knowledge Management Model (Wiig, 1993)
+
+**Origin:** Karl Wiig, "Knowledge Management Foundations" (1993). Wiig is considered a founder of the knowledge management movement, using the term "Knowledge Management" as early as 1986.
+
+**Core Principles:**
+- Knowledge must be organized to be useful
+- Knowledge organization depends on intended use
+- Three-stage process: Building → Holding → Leveraging
+- Four types of knowledge: Factual, Conceptual, Expectational, Methodological
+- Three forms: Public, Shared, Personal
+
+**The Three Major Components:**
+1. **Knowledge Building**: Creation and acquisition through learning, experience, research, and validation
+2. **Knowledge Holding**: Storage, documentation, and organization in retrievable forms
+3. **Knowledge Leveraging**: Application, dissemination, and use for decision-making and innovation
+
+**Levels of Internalization:**
+- Novice: Unaware of available knowledge
+- Beginner: Knows knowledge exists and where to find it
+- Competent: Can use and reason with external help
+- Expert: Holds knowledge in memory, reasons independently
+- Master: Full internalization with deep understanding and value integration
+
+**Quality Dimensions:**
+- **Completeness**: Whether knowledge covers the full domain
+- **Connectedness**: Relationships between knowledge parcels
+- **Congruency**: Alignment with organizational objectives
+
+**When to Use:**
+- Assessing organizational knowledge maturity
+- Designing knowledge repositories
+- Training and skill development programs
+- Knowledge audit and gap analysis
+
+**Strengths:**
+- Clear progression from knowledge acquisition to application
+- Recognizes different knowledge types and forms
+- Provides maturity model for individual and organizational learning
+- Practical for assessing knowledge management needs
+
+**Limitations:**
+- Less focus on tacit knowledge than SECI
+- Assumes knowledge can be effectively codified
+- Limited guidance on social/collaborative aspects
+- Can be bureaucratic if over-formalized
+
+**Integration with KM:**
+Wiig's model informs knowledge audits, competency frameworks, and learning management systems. Particularly useful for:
+- Training curriculum design
+- Knowledge retention during turnover
+- Expert identification and mapping
+- Knowledge base categorization
+
+**Citations:**
+- [The Wiig Model for Building and Using Knowledge - Theoretical Models](https://www.tlu.ee/~sirvir/IKM/Theoretical_models_of_Information_and_Knowledge_Management/the_wiig_model_for_building_and_using_knowledge.html)
+- [4 Knowledge Management Models - HelpieWP](https://helpiewp.com/knowledge-management-models/)
+- [Karl Wiig: Profiles in Knowledge - Medium](https://stangarfield.medium.com/karl-wiig-profiles-in-knowledge-cb09e2c9088e)
+
+---
+
+#### 1.3 Boisot I-Space Framework (Boisot, 1995)
+
+**Origin:** Max Henri Boisot, "Information Space: A Framework for Learning in Organizations, Institutions and Culture" (1995)
+
+**Core Principles:**
+- Knowledge flows within a three-dimensional information space
+- Information goods differ fundamentally from physical assets
+- Social Learning Cycle (SLC) models dynamic knowledge flow
+- Context determines knowledge value and shareability
+
+**The Three Dimensions:**
+1. **Codification**: Uncodified (tacit) ↔ Codified (explicit)
+2. **Abstraction**: Concrete (context-specific) ↔ Abstract (generalizable)
+3. **Diffusion**: Undiffused (private) ↔ Diffused (shared)
+
+**Four Knowledge Types in I-Space:**
+- **Public Knowledge**: Codified + Diffused (e.g., textbooks, newspapers)
+- **Proprietary Knowledge**: Codified + Undiffused (e.g., patents, trade secrets)
+- **Personal Knowledge**: Uncodified + Undiffused (e.g., individual expertise, biographical knowledge)
+- **Common Sense**: Uncodified + Diffused (e.g., cultural knowledge, "what everybody knows")
+
+**Social Learning Cycle (SLC) - Six Phases:**
+1. **Scanning**: Gaining insights from generally available data
+2. **Problem-Solving**: Structuring insights (codification)
+3. **Abstraction**: Generalizing to broader contexts
+4. **Diffusion**: Sharing with target population
+5. **Absorption**: Applying to situations, producing new learning (becomes tacit again)
+6. **Impacting**: Embedding in artifacts, rules, behaviors
+
+**When to Use:**
+- Analyzing knowledge flows across organizational boundaries
+- Intellectual property strategy
+- Innovation diffusion planning
+- Understanding knowledge evolution over time
+
+**Strengths:**
+- Three-dimensional model captures nuanced knowledge states
+- Social Learning Cycle shows knowledge as dynamic, not static
+- Explains how knowledge moves between public and proprietary states
+- Useful for competitive strategy and IP management
+
+**Limitations:**
+- Abstract and conceptual, requires interpretation
+- Less prescriptive than other frameworks
+- Complex to operationalize without significant training
+- May oversimplify social dynamics of knowledge sharing
+
+**Integration with KM:**
+I-Space helps organizations understand:
+- When to codify vs. keep knowledge tacit
+- Patent vs. trade secret strategies
+- Open innovation vs. proprietary approaches
+- Knowledge transfer across cultures and contexts
+
+**Citations:**
+- [The Boisot I-Space KM Model - Theoretical Models](https://www.tlu.ee/~sirvir/IKM/Theoretical_models_of_Information_and_Knowledge_Management/the_boisot_ispace_km_model.html)
+- [Max Boisot: Profiles in Knowledge - Medium](https://stangarfield.medium.com/max-boisot-profiles-in-knowledge-fdfd3352c1e5)
+- [Navigating Information Flow: A Deep Dive into Max Boisot's I-Space](https://conikeec.substack.com/p/navigating-the-information-space)
+
+---
+
+#### 1.4 Cynefin Framework (Snowden, 1999)
+
+**Origin:** Dave Snowden, developed at IBM Global Services (1999). Published in Harvard Business Review "A Leader's Framework for Decision Making" (2007) with Mary E. Boone.
+
+**Core Principles:**
+- Different contexts require different decision-making approaches
+- Cause-and-effect relationships vary by domain complexity
+- No one-size-fits-all management approach
+- Sense-making before decision-making
+
+**The Five Domains:**
+
+1. **Clear/Obvious** (formerly "Simple")
+   - Relationship: Cause and effect are obvious to all
+   - Approach: **Sense → Categorize → Respond**
+   - Method: Apply best practices
+   - Examples: Standard operating procedures, known fixes
+
+2. **Complicated**
+   - Relationship: Cause and effect require analysis or expertise
+   - Approach: **Sense → Analyze → Respond**
+   - Method: Apply good practices (multiple right answers exist)
+   - Examples: Engineering problems, expert diagnosis
+
+3. **Complex**
+   - Relationship: Cause and effect only deduced in retrospect
+   - Approach: **Probe → Sense → Respond**
+   - Method: Run safe-to-fail experiments, emergent practice
+   - Examples: Market dynamics, cultural change, innovation
+
+4. **Chaotic**
+   - Relationship: No cause-and-effect relationship discernible
+   - Approach: **Act → Sense → Respond**
+   - Method: Novel practice, stabilize then move to complex
+   - Examples: Crisis management, disasters
+
+5. **Disorder/Confusion**
+   - State: Unclear which domain applies
+   - Approach: Break down into components and assign to other domains
+   - Method: Gather more information, seek diverse perspectives
+
+**When to Use:**
+- Assessing problem complexity before choosing solution approach
+- Avoiding "best practice" where it doesn't apply
+- Strategy development in uncertain environments
+- Team alignment on problem-solving approach
+
+**Strengths:**
+- Simple to understand and communicate
+- Prevents misapplication of frameworks (e.g., PDCA in chaos)
+- Widely adopted across industries and sectors
+- Supports adaptive leadership in VUCA environments
+- Won Academy of Management "Outstanding Practitioner-Oriented Publication" award
+
+**Limitations:**
+- Can be oversimplified in application
+- Boundaries between domains can be fuzzy
+- Doesn't prescribe specific methods within domains
+- Risk of incorrect domain classification
+
+**Integration with KM:**
+Cynefin helps KM practitioners:
+- Choose appropriate knowledge capture methods by domain
+- Design different sharing mechanisms for different knowledge types
+- Understand when to standardize (clear) vs. experiment (complex)
+- Manage transition of problems across domains as understanding grows
+
+**Citations:**
+- [Cynefin framework - Wikipedia](https://en.wikipedia.org/wiki/Cynefin_framework)
+- [A Leader's Framework for Decision Making - Harvard Business Review](https://hbr.org/2007/11/a-leaders-framework-for-decision-making)
+- [About Cynefin Framework - The Cynefin Co](https://thecynefin.co/about-us/about-cynefin-framework/)
+- [The Cynefin Framework - MindTools](https://www.mindtools.com/atddimk/the-cynefin-framework/)
+
+---
+
+### Category 2: Problem-Solving Frameworks
+
+These frameworks provide structured approaches to identifying and resolving specific types of problems.
+
+#### 2.1 TRIZ - Theory of Inventive Problem Solving (Altshuller, 1946)
+
+**Origin:** Genrich Altshuller and colleagues, Soviet Union, beginning in 1946. Based on analysis of 200,000+ patents.
+
+**Core Principles:**
+- Innovation follows patterns that can be systematized
+- Most problems have been solved before in other domains
+- 95% of patents use only 40 inventive principles
+- Evolution of technical systems follows objective laws
+- Resolve contradictions without compromise (no trade-offs)
+
+**Key Concepts:**
+
+1. **40 Inventive Principles**: Universal problem-solving strategies (e.g., Segmentation, Asymmetry, Local Quality, Dynamicity, Periodic Action, Feedback)
+
+2. **Contradiction Matrix**: 39×39 matrix mapping improving vs. worsening parameters to suggest applicable inventive principles
+
+3. **Ideal Final Result (IFR)**: Envisioning the ideal solution helps identify path forward
+
+4. **Technical Contradictions**: Improving one parameter negatively affects another
+
+5. **Physical Contradictions**: A parameter must have opposite properties simultaneously
+
+**When to Use:**
+- Complex technical or engineering problems
+- Product innovation and design
+- Overcoming design constraints and trade-offs
+- Systematic innovation rather than trial-and-error
+- Cross-industry solution transfer
+
+**Strengths:**
+- Systematic, repeatable approach to innovation
+- Leverages patterns from millions of inventions
+- Reduces time to breakthrough solutions
+- Applicable across industries and domains
+- Proven at major corporations (Samsung, Boeing, NASA, Ford, Intel)
+
+**Limitations:**
+- Steep learning curve, requires training
+- Originally designed for technical/engineering problems
+- Can be complex to apply without expertise
+- May not suit all problem types (especially non-technical)
+- Tools and methods require significant investment
+
+**Integration with KM:**
+TRIZ enhances KM by:
+- Creating knowledge repositories of solution patterns
+- Enabling cross-domain knowledge transfer
+- Formalizing innovation knowledge
+- Capturing engineering expertise systematically
+
+**Industry Adoption:**
+Samsung, BAE Systems, GE, Mars (chocolate packaging patent), Rolls-Royce, Ford, Daimler-Chrysler, Boeing, NASA, HP, Motorola, IBM, Intel.
+
+**Citations:**
+- [TRIZ - Wikipedia](https://en.wikipedia.org/wiki/TRIZ)
+- [TRIZ: The Backbone of Innovation - Quality Magazine](https://www.qualitymag.com/articles/98566-triz-the-backbone-of-innovation-and-problem-solving)
+- [What is TRIZ? - TRIZ.co.uk](https://www.triz.co.uk/what-is-triz)
+- [NASA: Can TRIZ Help You? - APPEL Knowledge Services](https://appel.nasa.gov/2010/02/23/aa_1-10_f_inventive-html/)
+
+---
+
+#### 2.2 Design Thinking (IDEO / Stanford d.school, 1990s-2000s)
+
+**Origin:** Term coined at Stanford (1957), popularized by IDEO (1990s) and Stanford d.school (2005+). Key figures: David Kelley, Tim Brown.
+
+**Core Principles:**
+- Human-centered problem solving
+- Empathy as foundation for innovation
+- Iterative, non-linear process
+- Bias toward action (prototyping over planning)
+- Interdisciplinary collaboration
+- Embrace ambiguity and failure as learning
+
+**Stanford d.school Five Stages:**
+
+1. **Empathize**: Understand users through observation, engagement, immersion
+2. **Define**: Synthesize findings into actionable problem statement
+3. **Ideate**: Generate wide range of creative solutions (divergent thinking)
+4. **Prototype**: Build quick, low-fidelity representations
+5. **Test**: Gather feedback, refine, iterate
+
+**IDEO's Three-Stage Model:**
+- **Inspiration**: Understanding the challenge, user needs, market landscape
+- **Ideation**: Generating, developing, and testing ideas
+- **Implementation**: Bringing solution to market
+
+**Three Foundational Pillars:**
+1. Empathy (understanding users deeply)
+2. Experimentation (rapid prototyping and testing)
+3. Iteration (continuous refinement based on feedback)
+
+**When to Use:**
+- User experience design problems
+- Product/service innovation
+- "Wicked problems" with unclear requirements
+- Situations requiring creative breakthrough
+- Cross-functional team collaboration
+- Customer-centric strategy development
+
+**Strengths:**
+- Centers users and their actual needs
+- Encourages creative, out-of-the-box thinking
+- Reduces risk through rapid prototyping
+- Accessible to non-designers
+- Proven across industries (healthcare, education, technology, business)
+- Fosters collaboration and diverse perspectives
+
+**Limitations:**
+- Can be time-intensive, especially empathy phase
+- Requires cultural acceptance of iteration and "failure"
+- May lack rigor for highly technical problems
+- Can lead to over-emphasis on ideation vs. implementation
+- Not all stakeholders understand the non-linear process
+
+**Integration with KM:**
+Design Thinking enhances KM through:
+- User research creating knowledge about customer needs
+- Prototyping as knowledge externalization
+- Iteration embedding learning into artifacts
+- Cross-functional collaboration spreading tacit knowledge
+
+**Citations:**
+- [What is Design Thinking? Stanford d.school Model](https://juanfernandopacheco.com/2025/01/what-is-design-thinking-stanford-d-school-model/)
+- [Design Thinking by Stanford d.school and IDEO - Wind4Change](https://wind4change.com/design-thinking-d-school-stanford-ideo-approach-methodology/)
+- [What is Design Thinking? - Interaction Design Foundation](https://www.interaction-design.org/literature/topics/design-thinking)
+
+---
+
+#### 2.3 Systems Thinking (Von Bertalanffy, Senge, Meadows, 1940s-1990s)
+
+**Origin:** Ludwig von Bertalanffy (General Systems Theory, 1940s), popularized by Peter Senge ("The Fifth Discipline", 1990) and Donella Meadows ("Thinking in Systems", 2008).
+
+**Core Principles:**
+- Focus on relationships and interconnections, not just parts
+- Systems produce their own patterns of behavior over time
+- Structure drives behavior (mental models → systemic structures → patterns → events)
+- Circular causality (feedback loops) vs. linear thinking
+- Delays between cause and effect
+- Non-obvious leverage points exist in systems
+
+**Key Concepts:**
+
+1. **Stocks and Flows**: Elements that accumulate (stocks) and rates of change (flows)
+2. **Feedback Loops**:
+   - Reinforcing loops (amplify change, exponential growth/decline)
+   - Balancing loops (stabilize, goal-seeking)
+3. **System Archetypes**: Common patterns (e.g., "Limits to Growth", "Shifting the Burden", "Tragedy of the Commons")
+4. **Leverage Points**: Places to intervene in a system (Meadows' 12 leverage points, from parameters to paradigms)
+
+**Senge's Fifth Discipline:**
+Systems Thinking integrates with Personal Mastery, Mental Models, Shared Vision, and Team Learning to create "learning organizations."
+
+**Meadows' Definition:**
+"A system is a set of elements or parts interconnected in such a way that they produce their own pattern of behavior over time."
+
+**When to Use:**
+- Complex, multi-stakeholder problems
+- Unintended consequences from past solutions
+- Persistent problems that resist fixes
+- Organizational change initiatives
+- Policy design and analysis
+- Long-term strategic planning
+
+**Strengths:**
+- Reveals hidden dynamics and feedback loops
+- Prevents "fixes that backfire"
+- Supports long-term thinking
+- Applicable to social, technical, ecological systems
+- Provides shared language for complexity
+
+**Limitations:**
+- Requires significant mental shift from linear thinking
+- Can be overwhelmed by complexity
+- Difficult to model all variables accurately
+- May lead to analysis paralysis
+- Requires time and patience, resists quick fixes
+
+**Integration with KM:**
+Systems Thinking in KM helps:
+- Map knowledge flows as systems
+- Identify feedback loops in learning processes
+- Understand organizational learning dynamics
+- Design interventions at leverage points
+- Model knowledge ecosystems
+
+**Citations:**
+- [Systems Thinking - Von Bertalanffy, Senge, Meadows - Springer](https://link.springer.com/chapter/10.1007/978-3-030-43620-9_28)
+- [Thinking in Systems: A Primer - Donella Meadows (PDF)](https://research.fit.edu/media/site-specific/researchfitedu/coast-climate-adaptation-library/climate-communications/psychology-amp-behavior/Meadows-2008.-Thinking-in-Systems.pdf)
+- [Demystifying Systems Thinking - CISL Cambridge](https://www.cisl.cam.ac.uk/files/cisl_primer_demystifying_systems_thinking.pdf)
+
+---
+
+#### 2.4 Root Cause Analysis: 5 Whys & Ishikawa Diagram (1920s-1960s)
+
+**Origin:**
+- **Ishikawa (Fishbone) Diagram**: Kaoru Ishikawa, 1960s, Kawasaki shipyards. Basic concept from 1920s. One of the seven basic tools of quality control.
+- **5 Whys**: Toyota Production System, Taiichi Ohno (though concept is older)
+
+**Core Principles:**
+- Problems have root causes, not just symptoms
+- Asking "why" repeatedly reveals deeper causes
+- Visual mapping helps identify all contributing factors
+- Categorization organizes potential causes
+- Best used together for comprehensive analysis
+
+**Ishikawa (Fishbone) Diagram:**
+
+**Structure:**
+- Problem/defect as "fish head" (right side)
+- Major cause categories as "bones"
+- Sub-causes branch from major causes
+
+**Common Categories (6 Ms):**
+- **Methods**: Processes, procedures
+- **Materials**: Inputs, raw materials
+- **Machines**: Equipment, tools, technology
+- **Measurements**: Inspection, data collection
+- **Mother Nature**: Environment, conditions
+- **Manpower**: People, skills, training
+
+**5 Whys Technique:**
+- Ask "Why did this happen?" 5 times (or until root cause reached)
+- Each answer becomes the basis for the next question
+- Simple, no special tools required
+- Example:
+  1. Why? → Car won't start
+  2. Why? → Battery is dead
+  3. Why? → Alternator not charging
+  4. Why? → Alternator belt broken
+  5. Why? → Belt exceeded lifespan, wasn't replaced per schedule
+  - **Root cause**: Lack of preventive maintenance schedule
+
+**Using Both Together:**
+1. Create Fishbone diagram to identify all potential causes
+2. For each major cause branch, apply 5 Whys
+3. Expand Fishbone as deeper root causes discovered
+4. Prioritize root causes for corrective action
+
+**When to Use:**
+- Quality problems and defects
+- Process failures and errors
+- Incident investigation
+- Manufacturing issues
+- Service delivery problems
+- Any problem requiring root cause identification
+
+**Strengths:**
+- Simple, intuitive, widely accessible
+- Visual (Fishbone) aids communication
+- Encourages looking beyond symptoms
+- Involves cross-functional teams
+- Low cost, quick to implement
+- Proven across industries (Microsoft for buggy software, Amazon for UI issues)
+
+**Limitations:**
+- 5 Whys: May oversimplify complex, multi-causal problems
+- Fishbone: Can become convoluted with complex issues
+- Both rely on team knowledge (garbage in, garbage out)
+- May not identify truly novel causes
+- Stopping too early misses root causes
+- Multiple root causes can complicate analysis
+
+**Integration with KM:**
+RCA contributes to KM by:
+- Capturing lessons learned from failures
+- Building organizational problem-solving capability
+- Creating knowledge repositories of common failure modes
+- Supporting continuous improvement cultures
+
+**Citations:**
+- [Root Cause Analysis: 5 Whys vs. Fishbone - EasyRCA](https://easyrca.com/blog/root-cause-and-effect-analysis-5-whys-vs-fishbone/)
+- [Ishikawa diagram - Wikipedia](https://en.wikipedia.org/wiki/Ishikawa_diagram)
+- [Root Cause Analysis: Integrating Ishikawa Diagrams and 5 Whys - iSixSigma](https://www.isixsigma.com/cause-effect/root-cause-analysis-ishikawa-diagrams-and-the-5-whys/)
+- [Cause and Effect Analysis - Visual Paradigm](https://www.visual-paradigm.com/project-management/fishbone-diagram-and-5-whys/)
+
+---
+
+### Category 3: Decision Frameworks
+
+These frameworks provide systematic approaches to making decisions under various conditions.
+
+#### 3.1 OODA Loop (Boyd, 1970s)
+
+**Origin:** Colonel John Boyd, U.S. Air Force, early 1970s. Developed from fighter pilot tactics and thermodynamics (Energy-Manoeuvrability Theory).
+
+**Core Principles:**
+- Speed of decision cycle matters more than raw speed
+- "Get inside" opponent's decision loop
+- Agility beats speed
+- Continuous observation and adaptation
+- Decision-making is iterative, not linear
+
+**The Four Stages:**
+
+1. **Observe**: Gather information from environment
+   - Raw data collection from multiple sources
+   - Awareness of changing conditions
+
+2. **Orient**: Analyze and synthesize information
+   - Most critical and complex stage
+   - Influenced by cultural traditions, genetic heritage, previous experiences, mental models
+   - Synthesize data into understanding
+
+3. **Decide**: Select course of action
+   - Hypothesis formation
+   - Choose among alternatives
+
+4. **Act**: Execute decision
+   - Implementation
+   - Creates new observations (feedback)
+
+**Key Insight:**
+"Orientation" is the critical phase where mental models, culture, and experience shape interpretation. Getting inside opponent's OODA loop means:
+- Observing faster
+- Orienting more accurately
+- Deciding more wisely
+- Acting more swiftly
+- Thereby creating confusion and disorientation in adversary
+
+**When to Use:**
+- Competitive, rapidly changing environments
+- Military and security operations
+- Business strategy in dynamic markets
+- Crisis response and emergency management
+- Sports coaching and tactics
+- Cybersecurity and threat response
+
+**Strengths:**
+- Emphasizes adaptability and speed
+- Applicable across domains (military, business, sports)
+- Simple four-stage model
+- Recognizes importance of mental models (orientation)
+- Proven in military doctrine (AirLand Battle, NATO, mission command)
+- Supports agile, iterative approaches
+
+**Limitations:**
+- Can be oversimplified to "move fast"
+- Vague enough to see what you want to see in it
+- Doesn't prescribe specific methods within stages
+- May encourage reactive vs. strategic thinking
+- Limited guidance on collaborative decision-making
+
+**Boyd's Background:**
+- Nickname: "Forty-Second Boyd" (could win dogfight in <40 seconds)
+- Developed Energy-Manoeuvrability Theory (transformed aircraft design)
+- Influenced AirLand Battle doctrine and mission command concept
+
+**Integration with KM:**
+OODA Loop in KM:
+- Observation = Knowledge acquisition
+- Orientation = Sense-making and contextualization
+- Decide = Knowledge application
+- Act = Knowledge creation through action
+- Loop = Continuous learning cycle
+
+**Citations:**
+- [OODA loop - Wikipedia](https://en.wikipedia.org/wiki/OODA_loop)
+- [The OODA Loop - The Decision Lab](https://thedecisionlab.com/reference-guide/computer-science/the-ooda-loop)
+- [The OODA Loop Explained - OODAloop.com](https://oodaloop.com/the-ooda-loop-explained-the-real-story-about-the-ultimate-model-for-decision-making-in-competitive-environments/)
+- [How Fighter Pilots Make Fast and Accurate Decisions - Farnam Street](https://fs.blog/ooda-loop/)
+
+---
+
+#### 3.2 Kepner-Tregoe Method (Kepner & Tregoe, 1965)
+
+**Origin:** Charles Kepner and Benjamin Tregoe, "The Rational Manager: A Systematic Approach to Problem Solving and Decision Making" (1965)
+
+**Core Principles:**
+- Disconnect "problem" from "decision"
+- Systematic, structured thinking reduces oversight and error
+- Goal is "best possible" choice, not perfect choice
+- Separate problem analysis from decision analysis
+- Proactive approach to potential problems/opportunities
+
+**The Four Key Processes:**
+
+1. **Situation Appraisal**
+   - Define scope and priority
+   - Questions: What's happening? How urgent/important? Who's involved?
+   - Break complex situations into manageable concerns
+
+2. **Problem Analysis**
+   - Identify root cause
+   - "IS / IS NOT" analysis (What, Where, When, How Big)
+   - Specify problem precisely
+   - Test possible causes
+   - Verify the true cause
+
+3. **Decision Analysis**
+   - Evaluate alternatives against objectives
+   - Separate "musts" from "wants"
+   - Weight objectives by importance
+   - Assess risks of each alternative
+   - Make informed selection
+
+4. **Potential Problem/Opportunity Analysis**
+   - Forecast future issues
+   - Identify preventive actions
+   - Prepare contingency plans
+   - Capitalize on opportunities
+   - Proactive risk management
+
+**When to Use:**
+- Complex, high-stakes decisions
+- Problems requiring systematic investigation
+- Situations with multiple alternatives
+- Risk assessment and mitigation
+- IT incident management (ITIL)
+- Corrective/preventive action (CAPA)
+- Integration with Lean, Six Sigma, 8D
+
+**Strengths:**
+- Rigorous, logical framework
+- Reduces likelihood of oversight
+- Common language for teams (builds consensus)
+- Develops critical thinking skills
+- Well-respected, adopted by top organizations (NASA, General Motors)
+- Timeless framework for complex systems
+- Transferable skills across domains
+
+**Limitations:**
+- Can be time-intensive for simple problems
+- Requires training and practice
+- May feel bureaucratic if over-applied
+- Cultural acceptance needed (some prefer intuitive decisions)
+- Not suited to chaotic or highly creative contexts
+
+**Integration with KM:**
+Kepner-Tregoe enhances KM by:
+- Structuring problem-solving knowledge
+- Creating decision audit trails
+- Building organizational decision-making competency
+- Standardizing root cause analysis
+- Capturing rationale for decisions
+
+**Citations:**
+- [The Kepner-Tregoe Matrix - MindTools](https://www.mindtools.com/atznth6/the-kepner-tregoe-matrix/)
+- [Kepner Tregoe Method - ToolsHero](https://www.toolshero.com/problem-solving/kepner-tregoe-method/)
+- [Kepner-Tregoe: Structured Problem Solving - Microsoft Community](https://techcommunity.microsoft.com/blog/azuredbsupport/kepner%E2%80%91tregoe-a-structured-and-rational-approach-to-problem-solving-and-decision/4482643)
+
+---
+
+#### 3.3 PDCA Cycle (Shewhart/Deming, 1920s-1950s)
+
+**Origin:** Walter A. Shewhart (1920s-1930s), popularized by W. Edwards Deming (1950s+). Also called Shewhart Cycle or Deming Cycle.
+
+**Core Principles:**
+- Continuous improvement through iterative cycles
+- Scientific method applied to business
+- Prediction → experimentation → learning
+- No end to improvement (spiral, not circle)
+- Quality control through systematic process
+
+**The Four Steps:**
+
+1. **Plan**
+   - Define quality goals
+   - Understand customer requirements
+   - Develop strategic plan
+   - Identify potential problems
+   - Predict outcomes based on data
+   - Establish success metrics
+
+2. **Do**
+   - Implement solution/change
+   - Execute on small scale initially (pilot)
+   - Collect data during implementation
+   - Document process
+
+3. **Check** (or **Study**)
+   - Confirm results through before/after comparison
+   - Analyze collected data
+   - Compare actual vs. predicted results
+   - Determine if solution addresses problem
+   - **Note**: Deming preferred "Study" over "Check" (PDSA vs. PDCA)
+
+4. **Act** (or **Adjust**)
+   - If successful: Standardize and implement broadly
+   - If unsuccessful: Learn and start new cycle
+   - Document results and recommendations
+   - Inform others about process changes
+   - Make recommendations for next PDCA cycle
+
+**PDCA vs. PDSA:**
+- Deming emphasized **PDSA** (Plan-Do-Study-Act)
+- "Study" focuses on predicting results, comparing to actuals, revising theory
+- "Check" more binary (success/failure of implementation)
+- Study encourages deeper learning
+
+**Iterative Nature:**
+- "Just as a circle has no end, the PDCA cycle should be repeated again and again"
+- Each cycle should increase knowledge
+- Spirals converge toward ultimate goal
+
+**When to Use:**
+- Continuous improvement initiatives
+- Quality management (TQM, ISO 9001)
+- Manufacturing optimization
+- Healthcare process improvement
+- Service delivery enhancement
+- Any process requiring iterative refinement
+
+**Strengths:**
+- Simple, intuitive four-step model
+- Proven across industries and decades
+- Supports data-driven decision making
+- Embeds learning into operations
+- Scalable (individuals to organizations)
+- Foundation for Lean and Six Sigma
+
+**Limitations:**
+- Requires cultural commitment to continuous improvement
+- Can be slow for urgent problems
+- Assumes problems are measurable
+- May resist radical innovation (favors incremental)
+- Needs discipline to complete cycles
+
+**Integration with KM:**
+PDCA embeds learning into operations:
+- Plan = Knowledge gathering and prediction
+- Do = Knowledge application and testing
+- Study = Reflection and sense-making
+- Act = Knowledge capture and standardization
+
+**Citations:**
+- [PDCA Cycle - ASQ](https://asq.org/quality-resources/pdca-cycle)
+- [PDCA - Wikipedia](https://en.wikipedia.org/wiki/PDCA)
+- [PDSA Cycle - The W. Edwards Deming Institute](https://deming.org/explore/pdsa/)
+- [The Deming Cycle (PDCA) Explained - Brightly Software](https://www.brightlysoftware.com/learning-center/the-deming-cycle-pdca-explained-a-comprehensive-guide-to-continuous-improvement)
+
+---
+
+#### 3.4 A3 Problem Solving (Toyota, 1960s+)
+
+**Origin:** Toyota Production System, attributed to Taiichi Ohno. Rumor: Ohno refused to read past first page of reports, so teams created one-page summaries on A3 paper.
+
+**Core Principles:**
+- Problem-solving on a single sheet of A3-size paper
+- Based on PDCA cycle
+- Solve problems at the source, permanently
+- Address root causes, not symptoms
+- Structured thinking + visual communication
+- Learning through mentorship (not giving answers)
+
+**The Seven Steps (A3 Template Boxes):**
+
+1. **Background/Business Context**
+   - Why this problem matters
+   - Establish importance and urgency
+
+2. **Current Condition**
+   - Describe the current state objectively
+   - Use data and observations, not opinions
+
+3. **Desired Outcome/Goal**
+   - Define target state
+   - What success looks like
+
+4. **Root Cause Analysis**
+   - Analyze situation to establish causality
+   - Use tools like 5 Whys, Fishbone
+
+5. **Countermeasures**
+   - Propose solutions to address root causes
+   - Evaluate alternatives
+
+6. **Action Plan**
+   - Who does what, when
+   - Prescribe implementation steps
+   - Assign responsibilities
+
+7. **Follow-Up**
+   - How will success be measured?
+   - Monitoring and evaluation plan
+   - Lessons learned
+
+**Three Key Roles:**
+
+1. **Owner**: Manages A3 process, maintains the report
+2. **Mentor/Coach**: Guides owner without giving direct solutions, encourages learning
+3. **Responders/Stakeholders**: Provide input, impacted by problem/solution
+
+**A3 Thinking (More Than Template):**
+- The template is less important than the thinking process
+- Flexible, adaptable to different situations
+- Emphasizes understanding before solving
+- "Gemba walk" principle: see problems first-hand
+- Encourages dialogue and collaboration
+
+**When to Use:**
+- Problem-solving (find and fix root causes)
+- Proposal development (new initiatives)
+- Status reporting (project updates)
+- Strategic planning
+- Any situation requiring structured thinking + communication
+
+**Strengths:**
+- Concise, forces clarity and prioritization
+- Visual, one-page format aids communication
+- Combines problem-solving with documentation
+- Fosters learning through coaching
+- Aligns interests across organization
+- Basis for collaboration and dialogue
+- Part of proven Toyota Production System
+
+**Limitations:**
+- Requires cultural support (Lean mindset)
+- One page can feel constraining for complex issues
+- Coaching/mentorship role requires skill
+- May be seen as bureaucratic if forced
+- Takes time to understand problem thoroughly
+
+**Integration with KM:**
+A3 thinking enhances KM by:
+- Creating knowledge artifacts (completed A3s)
+- Mentoring as tacit knowledge transfer (SECI socialization)
+- Documenting reasoning, not just conclusions
+- Building problem-solving capability organization-wide
+- Capturing lessons learned systematically
+
+**Best Practices:**
+- Go to Gemba (go and see actual conditions)
+- Focus on understanding, not rushing to solutions
+- Use A3 as conversation tool, not just report
+- Iterate based on feedback
+- Archive A3s as organizational learning resources
+
+**Citations:**
+- [A3 problem solving - Wikipedia](https://en.wikipedia.org/wiki/A3_problem_solving)
+- [Toyota's Secret: The A3 Report - MIT Sloan Management Review](https://sloanreview.mit.edu/article/toyotas-secret-the-a3-report/)
+- [What is A3 Problem Solving? - Kanban Tool](https://kanbantool.com/kanban-guide/a3-problem-solving)
+- [How to use Toyota's legendary A3 problem solving technique - Nulab](https://nulab.com/learn/project-management/use-toyotas-legendary-a3-problem-solving-technique/)
+
+---
+
+### Category 4: AI-Era Frameworks
+
+These frameworks leverage LLMs and AI to enhance knowledge retrieval, reasoning, and problem-solving.
+
+#### 4.1 RAG - Retrieval Augmented Generation (2020+)
+
+**Origin:** Emerging from LLM research (2020+), formalized in various papers. Widely adopted by 2023-2024 as LLMs scaled.
+
+**Core Principles:**
+- LLMs have limited/outdated knowledge from training data
+- External knowledge retrieval improves accuracy and relevance
+- Combine parametric knowledge (in weights) with non-parametric knowledge (retrieved)
+- Reduce hallucination through grounding
+- Enable continuous knowledge updates without retraining
+
+**How It Works:**
+
+1. **Indexing Phase** (offline):
+   - Convert documents to embeddings (vector representations)
+   - Store in vector database
+
+2. **Retrieval Phase** (query-time):
+   - Convert user query to embedding
+   - Search vector database for most relevant documents
+   - Retrieve top-k most similar documents
+
+3. **Augmentation Phase**:
+   - Inject retrieved documents into prompt context
+   - Augment query with relevant information
+
+4. **Generation Phase**:
+   - LLM generates response using both its training and retrieved context
+   - Grounded in provided documents
+
+**RAG Paradigms (Evolution):**
+
+1. **Naive RAG**: Simple retrieval → augmentation → generation
+2. **Advanced RAG**: Pre-retrieval and post-retrieval improvements (query rewriting, re-ranking)
+3. **Modular RAG**: Composable components, multi-source retrieval, agentic retrieval (2025+)
+
+**Agentic Retrieval (2025 State-of-Art):**
+- LLM-assisted query planning
+- Break complex queries into focused subqueries
+- Parallel execution
+- Structured responses optimized for chat models
+- Example: Azure AI Search agentic retrieval (preview)
+
+**Recent Research:**
+- **"Sufficient Context"** (ICLR 2025, Google): Understanding when LLM has enough information to answer correctly
+- Emphasis on retrieval quality over quantity
+
+**When to Use:**
+- Domain-specific Q&A systems
+- Enterprise knowledge bases
+- Customer support chatbots
+- Document search and analysis
+- Any LLM application requiring up-to-date or specialized knowledge
+
+**Strengths:**
+- Improves LLM accuracy and relevance
+- Reduces hallucinations through grounding
+- Enables knowledge updates without retraining
+- Cost-effective vs. fine-tuning
+- Provides source attribution/provenance
+- Applicable to any domain with text data
+
+**Limitations:**
+- Retrieval quality critical (garbage in, garbage out)
+- Context window limits how much can be injected
+- Latency from retrieval step
+- Vector embeddings may miss nuanced relationships
+- Requires vector database infrastructure
+- May struggle with multi-hop reasoning across documents
+
+**Integration with KM:**
+RAG transforms KM by:
+- Making organizational knowledge LLM-accessible
+- Enabling semantic search over documents
+- Reducing knowledge silos
+- Providing conversational interface to KM systems
+
+**Technical Components:**
+- **Embeddings**: Text → vector space (e.g., OpenAI, Cohere, local models)
+- **Vector Databases**: Pinecone, Weaviate, ChromaDB, FAISS
+- **Chunking Strategies**: How to split documents
+- **Hybrid Search**: Combining semantic (vector) + keyword (BM25)
+
+**Citations:**
+- [Retrieval Augmented Generation (RAG) - Prompt Engineering Guide](https://www.promptingguide.ai/research/rag)
+- [What is RAG? - AWS](https://aws.amazon.com/what-is/retrieval-augmented-generation/)
+- [Retrieval-augmented generation - Wikipedia](https://en.wikipedia.org/wiki/Retrieval-augmented_generation)
+- [RAG in 2025: Bridging Knowledge and Generative AI - Squirro](https://squirro.com/squirro-blog/state-of-rag-genai)
+- [All You Need To Know About RAG in 2025 - Towards AI](https://pub.towardsai.net/all-you-need-to-know-about-retrieval-augmented-generation-rag-in-2025-04c386284c18)
+
+---
+
+#### 4.2 GraphRAG (Microsoft, 2024)
+
+**Origin:** Microsoft Research, publicly released on GitHub in 2024. Now available in Microsoft Discovery (agentic platform for scientific research).
+
+**Core Principles:**
+- Knowledge graphs provide structured representation of relationships
+- Hierarchical community structure improves retrieval
+- Pre-summarization of semantic clusters
+- Better for "unknown unknowns" and multi-hop reasoning
+- Graph-based indexing vs. flat vector search
+
+**How It Works:**
+
+1. **Extraction Phase**:
+   - Slice corpus into TextUnits
+   - LLM extracts entities, relationships, and key claims
+   - Build knowledge graph from extracted information
+
+2. **Community Detection**:
+   - Bottom-up clustering organizes graph hierarchically
+   - Identifies semantic communities/themes
+   - Creates multi-level hierarchy (local → global)
+
+3. **Summarization**:
+   - Pre-generate summaries for each community
+   - Hierarchical summaries (detailed → abstract)
+
+4. **Query Phase**:
+   - Use graph structure to retrieve relevant communities
+   - Leverage pre-computed summaries
+   - Provide both answers and provenance
+
+**Key Differences from Standard RAG:**
+
+| Aspect | Standard RAG | GraphRAG |
+|--------|-------------|----------|
+| Structure | Flat documents + embeddings | Knowledge graph + communities |
+| Retrieval | Vector similarity | Graph traversal + community |
+| Summarization | None (raw chunks) | Pre-computed community summaries |
+| Reasoning | Single-hop | Multi-hop via graph |
+| Strength | Known questions | Unknown unknowns, exploration |
+
+**When to Use:**
+- Complex, interconnected knowledge domains
+- Multi-hop reasoning requirements
+- Exploratory questions ("What are the themes in this corpus?")
+- Scientific research and discovery
+- When relationships matter as much as entities
+- Private/proprietary datasets requiring deep understanding
+
+**Strengths:**
+- Vastly improved retrieval relevance
+- Handles multi-hop questions
+- Provides comprehensive thematic answers
+- Source grounding and provenance tracking
+- Excellent for "connecting the dots" across documents
+- Hierarchical structure supports different query types
+- Ideal for previously unseen datasets
+
+**Limitations:**
+- **Expensive**: LLM-powered indexing can cost significant money and time
+- Requires careful prompt tuning for domain
+- More complex infrastructure (graph database or structures)
+- Overkill for simple retrieval tasks
+- Indexing time longer than standard RAG
+- Start small and test before scaling
+
+**Integration with KM:**
+GraphRAG enhances KM by:
+- Revealing hidden connections in knowledge base
+- Supporting discovery vs. just search
+- Capturing conceptual relationships, not just keywords
+- Enabling strategic knowledge exploration
+
+**Best Practices:**
+- Read all documentation before starting (cost awareness)
+- Fine-tune prompts for your domain
+- Start with small dataset
+- Use for complex knowledge work, not simple FAQ
+
+**Availability:**
+- Open source on GitHub: [microsoft/graphrag](https://github.com/microsoft/graphrag)
+- Integrated in Microsoft Discovery platform (Azure)
+
+**Citations:**
+- [Welcome - GraphRAG Official Docs](https://microsoft.github.io/graphrag/)
+- [GitHub - microsoft/graphrag](https://github.com/microsoft/graphrag)
+- [Project GraphRAG - Microsoft Research](https://www.microsoft.com/en-us/research/project/graphrag/)
+- [GraphRAG: Unlocking LLM discovery on narrative private data - Microsoft Research](https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/)
+- [GraphRAG Explained: Enhancing RAG with Knowledge Graphs - Zilliz/Medium](https://medium.com/@zilliz_learn/graphrag-explained-enhancing-rag-with-knowledge-graphs-3312065f99e1)
+
+---
+
+#### 4.3 Chain-of-Thought (CoT) Prompting (Wei et al., 2022)
+
+**Origin:** "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models" by Wei et al., 2022 ([arXiv:2201.11903](https://arxiv.org/abs/2201.11903))
+
+**Core Principles:**
+- LLMs can perform better reasoning with intermediate steps
+- Simulates human-like step-by-step thinking
+- Emergent ability in large models (~100B+ parameters)
+- Breaks complex problems into manageable steps
+- Makes reasoning transparent and auditable
+
+**How It Works:**
+
+**Few-Shot CoT:**
+- Provide examples (exemplars) showing reasoning process
+- Each example includes: Question → Reasoning Steps → Answer
+- LLM learns to mimic reasoning pattern
+- Example:
+  ```
+  Q: Roger has 5 tennis balls. He buys 2 more cans of tennis balls. Each can has 3 balls. How many tennis balls does he have now?
+  A: Roger started with 5 balls. 2 cans of 3 balls each is 6 balls. 5 + 6 = 11. The answer is 11.
+
+  Q: [Your actual question]
+  ```
+
+**Zero-Shot CoT:**
+- Simply add "Let's think step by step" to prompt
+- No examples needed
+- Example: MultiArith benchmark accuracy jumped from 17.7% → 78.7% (InstructGPT)
+
+**Auto-CoT:**
+- Automatically generate reasoning chains
+- Sample questions with diversity
+- Construct demonstrations automatically
+
+**Types of Reasoning Enhanced:**
+- Arithmetic reasoning
+- Commonsense reasoning
+- Symbolic reasoning
+- Multi-step logical inference
+
+**When to Use:**
+- Complex, multi-step problems
+- Math and logic tasks
+- Situations requiring explanation of reasoning
+- When transparency matters (auditing LLM decisions)
+- Tasks where breaking down helps accuracy
+
+**Strengths:**
+- Significantly improves accuracy on reasoning tasks
+- Provides interpretable reasoning traces
+- Reduces logical errors and hallucinations
+- Helps identify where LLM goes wrong
+- Simple to implement (just add examples or prompt phrase)
+- Works across different LLM architectures
+
+**Limitations:**
+- **Only effective with large models (~100B+ parameters)**
+- Smaller models produce illogical chains → worse accuracy
+- Adds tokens to context (cost and latency)
+- May over-complicate simple tasks
+- Quality depends on example selection (Few-Shot) or model capability (Zero-Shot)
+- Can still produce confident but incorrect reasoning
+
+**Integration with KM:**
+CoT enhances KM by:
+- Externalizing reasoning as knowledge artifact
+- Teaching problem-solving patterns
+- Creating audit trails for decisions
+- Supporting learning through worked examples
+
+**Variations:**
+- **Self-Consistency CoT**: Generate multiple reasoning paths, use majority vote
+- **Least-to-Most Prompting**: Break problem into subproblems
+- **Tree-of-Thoughts**: Explore multiple reasoning branches
+
+**Citations:**
+- [Chain-of-Thought Prompting Elicits Reasoning - arXiv](https://arxiv.org/abs/2201.11903)
+- [Chain-of-Thought Prompting - Learn Prompting](https://learnprompting.org/docs/intermediate/chain_of_thought)
+- [What is Chain of Thought Prompting? - IBM](https://www.ibm.com/think/topics/chain-of-thoughts)
+- [Chain-of-Thought Prompting - Prompt Engineering Guide](https://www.promptingguide.ai/techniques/cot)
+
+---
+
+#### 4.4 ReAct - Reasoning + Acting (Yao et al., 2023)
+
+**Origin:** "ReAct: Synergizing Reasoning and Acting in Language Models" by Yao et al., 2023 ([arXiv:2210.03629](https://arxiv.org/abs/2210.03629)). Google Research / Princeton.
+
+**Core Principles:**
+- Combine reasoning (internal thought) with acting (external tool use)
+- Synergy: Reasoning guides actions, actions inform reasoning
+- Interleaved thought-action-observation loop
+- Dynamic planning and error correction
+- Grounding in external environments reduces hallucination
+
+**How It Works:**
+
+**The ReAct Loop:**
+```
+Thought → Action → Observation → Thought → Action → Observation → ... → Answer
+```
+
+1. **Thought**: LLM reasons about what to do next
+2. **Action**: LLM calls external tool (search, calculator, API, etc.)
+3. **Observation**: Environment returns result to LLM
+4. **Repeat**: Until sufficient information gathered or answer determined
+
+**Example Scenario (Question Answering):**
+```
+Question: What is the elevation of the mountain where the 2020 Summer Olympics torch relay started?
+
+Thought: I need to find where the torch relay started.
+Action: Search[2020 Summer Olympics torch relay]
+Observation: The relay started at Mount Olympus in Greece.
+
+Thought: Now I need to find the elevation of Mount Olympus.
+Action: Search[Mount Olympus elevation]
+Observation: Mount Olympus has an elevation of 2,917 meters.
+
+Thought: I have the answer.
+Answer: 2,917 meters
+```
+
+**Key Components:**
+
+1. **LLM (Reasoning Engine)**: Generates thoughts and decides actions
+2. **Tools/Actions**: APIs, search engines, calculators, databases, code execution
+3. **Environment**: External knowledge sources that provide observations
+4. **Prompt Template**: Defines Thought/Action/Observation format
+
+**Comparison to Alternatives:**
+
+| Approach | Reasoning | Acting | Result |
+|----------|-----------|--------|--------|
+| Reason-Only (CoT) | ✓ | ✗ | Hallucination, outdated info |
+| Act-Only | ✗ | ✓ | Can't synthesize, lacks planning |
+| ReAct | ✓ | ✓ | Grounded, adaptive, accurate |
+
+**When to Use:**
+- Questions requiring external information
+- Multi-step research tasks
+- Problems needing both reasoning and data lookup
+- Agentic workflows (autonomous task completion)
+- Situations where LLM knowledge is insufficient
+- When actions have consequences in external systems
+
+**Strengths:**
+- Overcomes hallucination by grounding in real data
+- Handles "unknown unknowns" through exploration
+- Adaptive planning (can change course based on observations)
+- Interpretable (can audit thought process)
+- More accurate than CoT alone on fact-based tasks (HotpotQA, Fever)
+- Generates human-like problem-solving trajectories
+
+**Limitations:**
+- Requires access to external tools/APIs
+- More complex to implement than simple prompting
+- Latency from multiple LLM calls + tool invocations
+- Tool reliability becomes critical
+- Can be expensive (multiple LLM calls per task)
+- Agent may get stuck in loops or take inefficient paths
+
+**Integration with KM:**
+ReAct enhances KM by:
+- Making knowledge bases actionable (not just searchable)
+- Combining explicit knowledge (documents) with procedural knowledge (how to search)
+- Creating trace logs of knowledge discovery process
+- Enabling autonomous knowledge work
+
+**Modern Implementations:**
+- **LangChain / LlamaIndex**: ReAct agent frameworks
+- **AutoGPT / BabyAGI**: Autonomous agent systems
+- **Function Calling APIs**: OpenAI, Anthropic, Google (Claude, GPT-4, Gemini)
+
+**ReAct vs. Standard RAG:**
+- RAG: Single retrieval step
+- ReAct: Iterative, multi-turn retrieval with reasoning
+- ReAct can decide WHEN and WHAT to retrieve based on reasoning
+
+**Citations:**
+- [ReAct: Synergizing Reasoning and Acting - arXiv](https://arxiv.org/abs/2210.03629)
+- [ReAct: Synergizing Reasoning and Acting - Google Research Blog](https://research.google/blog/react-synergizing-reasoning-and-acting-in-language-models/)
+- [What is a ReAct Agent? - IBM](https://www.ibm.com/think/topics/react-agent)
+- [ReAct Prompting - Prompt Engineering Guide](https://www.promptingguide.ai/techniques/react)
+- [ReAct Official Site](https://react-lm.github.io/)
+
+---
+
+## L2: Strategic Framework Selection for Jerry
+
+This section provides strategic guidance for selecting and integrating frameworks within the Jerry architecture.
+
+### Jerry's Unique Context
+
+Jerry operates with specific architectural constraints and capabilities:
+
+**Strengths:**
+- Filesystem-as-memory (persistent, infinite context)
+- Structured knowledge hierarchy (`docs/` organization)
+- Skills-based agent interfaces
+- CQRS pattern for commands/queries
+- Constitutional governance (Jerry Constitution v1.0)
+
+**Challenges:**
+- Context rot as conversation lengthens
+- Agent nesting limitations (max 1 level: orchestrator → worker)
+- Need for systematic knowledge capture
+- Balancing autonomy with human oversight
+
+### Recommended Framework Stack for Jerry
+
+#### Layer 1: Problem Classification (Entry Point)
+
+**Primary Framework: Cynefin**
+
+**Purpose:** Classify problems before applying frameworks
+
+**Integration:**
+- Create skill: `problem-classifier` that applies Cynefin domains
+- Maps domains to appropriate frameworks:
+  - **Clear** → A3, PDCA (standard processes)
+  - **Complicated** → Kepner-Tregoe, TRIZ (expert analysis)
+  - **Complex** → Systems Thinking, Design Thinking (experimentation)
+  - **Chaotic** → OODA Loop (rapid action)
+
+**Implementation:**
+```
+User request → problem-classifier skill → Cynefin domain assessment → framework recommendation
+```
+
+**Why Cynefin for Jerry:**
+- Prevents misapplication of frameworks (e.g., PDCA in chaos)
+- Aligns with Jerry's need for context-aware responses
+- Simple enough to apply quickly
+- Prevents "one-size-fits-all" approach
+
+---
+
+#### Layer 2: Knowledge Flow Management
+
+**Primary Framework: SECI Model**
+
+**Purpose:** Manage tacit ↔ explicit knowledge conversion
+
+**Integration with Jerry's Architecture:**
+
+1. **Socialization (Tacit → Tacit)**
+   - Agent-to-agent collaboration (orchestrator ↔ specialist)
+   - Pair programming / review sessions documented in `docs/experience/`
+   - User-agent dialogue captured in session logs
+
+2. **Externalization (Tacit → Explicit)**
+   - Skills externalize tacit knowledge into markdown interfaces
+   - `docs/wisdom/` captures heuristics and principles
+   - ADRs (Architecture Decision Records) document reasoning
+
+3. **Combination (Explicit → Explicit)**
+   - Knowledge synthesis in `docs/research/`
+   - Cross-referencing between documents
+   - Aggregation of learnings into higher-level patterns
+
+4. **Internalization (Explicit → Tacit)**
+   - Agent training on accumulated knowledge
+   - User reading and absorbing documentation
+   - Applying documented patterns in new contexts
+
+**Why SECI for Jerry:**
+- Aligns with filesystem-as-memory (explicit knowledge storage)
+- Supports multi-agent knowledge sharing
+- Provides structure for `docs/` hierarchy
+- Addresses Jerry's core mission: accruing knowledge, wisdom, experience
+
+**Implementation:**
+- Update `worktracker` skill to tag work by SECI mode
+- Create `knowledge-flow` skill that maps Jerry's artifacts to SECI
+- Ensure each significant output goes through externalization
+
+---
+
+#### Layer 3: AI-Augmented Problem Solving
+
+**Primary Frameworks: ReAct + GraphRAG**
+
+**Purpose:** Leverage LLM capabilities with grounding and reasoning
+
+**ReAct Integration:**
+- `problem-solving` skill already uses ReAct pattern implicitly
+- Make explicit: Thought (reasoning trace) → Action (tool call) → Observation → repeat
+- Tools: File operations, Bash commands, Grep, Glob, WebSearch
+- Capture reasoning traces in PLAN files or work logs
+
+**GraphRAG Integration:**
+- Build knowledge graph from `docs/` hierarchy
+- Entities: Frameworks, principles, agents, skills
+- Relationships: Uses, extends, conflicts-with, supports
+- Communities: Group related concepts (e.g., "Quality Management", "AI Frameworks")
+- Query interface for complex questions: "What frameworks address tacit knowledge transfer?"
+
+**Why ReAct + GraphRAG for Jerry:**
+- ReAct aligns with agent architecture (reasoning + acting)
+- GraphRAG addresses Jerry's growing knowledge base
+- Combination supports both exploration and exploitation
+- Reduces context rot by retrieving only relevant knowledge
+
+**Phased Implementation:**
+1. **Phase 1** (Current): ReAct via existing agent patterns
+2. **Phase 2**: Standard RAG over `docs/` with vector embeddings
+3. **Phase 3**: GraphRAG with full knowledge graph extraction
+
+---
+
+#### Layer 4: Continuous Learning and Documentation
+
+**Primary Framework: A3 Problem Solving**
+
+**Purpose:** Capture learnings systematically, one-page format
+
+**Integration:**
+- Create `a3-template.md` in `.claude/templates/`
+- Use for significant problem-solving sessions
+- Completed A3s stored in `docs/a3/` by date or WORK-ID
+- Seven sections map to Jerry's workflow:
+  1. **Background** → WORK-ID context
+  2. **Current Condition** → Initial state assessment
+  3. **Desired Outcome** → Success criteria
+  4. **Root Cause Analysis** → Investigation results
+  5. **Countermeasures** → Solutions applied
+  6. **Action Plan** → Implementation steps
+  7. **Follow-Up** → Lessons learned
+
+**Why A3 for Jerry:**
+- Concise format combats context rot
+- Structured thinking improves output quality
+- One-page constraint forces prioritization
+- Creates knowledge artifacts (completed A3s)
+- Aligns with Jerry's principle P-002 (File Persistence)
+
+**Implementation:**
+```markdown
+## A3 Template Structure
+WORK-ID: [ID]
+Date: [YYYY-MM-DD]
+Owner: [Agent/User]
+
+### 1. Background
+Why this matters...
+
+### 2. Current Condition
+Observed state...
+
+### 3. Goal
+Target state...
+
+### 4. Root Cause Analysis
+Why it's happening...
+
+### 5. Countermeasures
+How we'll address it...
+
+### 6. Action Plan
+Who | What | When
+
+### 7. Follow-Up
+Metrics | Learnings
+```
+
+---
+
+#### Supporting Frameworks (Tactical Use)
+
+**5 Whys / Ishikawa (Root Cause Analysis):**
+- Use within A3 section 4
+- Apply during incident post-mortems
+- Document in `docs/experience/failures/`
+
+**PDCA (Continuous Improvement):**
+- Apply to incremental improvements
+- Integrate with Work Tracker (Plan → In Progress → Check → Act/Close)
+- Useful for clear/obvious domain problems (Cynefin)
+
+**Systems Thinking:**
+- Apply to architectural decisions
+- Map feedback loops in Jerry's operation
+- Use for understanding agent interaction dynamics
+- Document in ADRs when architectural changes needed
+
+**Design Thinking:**
+- Apply to user-facing features (skills, interfaces)
+- Empathize with user needs
+- Prototype solutions before full implementation
+
+**TRIZ:**
+- Reserve for technical contradictions
+- Not primary framework (Jerry is software, not hardware)
+- Could apply to agent design trade-offs
+
+---
+
+### Framework Selection Decision Matrix
+
+| Problem Type | Cynefin Domain | Recommended Framework | Jerry Artifact |
+|--------------|----------------|----------------------|----------------|
+| Classify problem | Any | Cynefin | PLAN file (domain noted) |
+| Knowledge capture | Clear/Complicated | A3 + SECI Externalization | `docs/a3/`, `docs/wisdom/` |
+| Root cause investigation | Clear/Complicated | 5 Whys / Ishikawa | A3 Section 4 |
+| Incremental improvement | Clear | PDCA | Work Tracker |
+| Complex knowledge synthesis | Complex | ReAct + GraphRAG | `docs/research/`, `docs/knowledge/` |
+| Architectural decision | Complicated/Complex | Systems Thinking + ADR | `docs/design/ADR-XXX.md` |
+| User-facing feature | Complex | Design Thinking | Prototypes, feedback loops |
+| Technical contradiction | Complicated | TRIZ | Engineering docs |
+| Rapid decision under uncertainty | Chaotic/Complex | OODA Loop | Incident logs |
+| High-stakes decision | Complicated | Kepner-Tregoe | Decision logs |
+
+---
+
+### Integration with Jerry Constitution
+
+**Mapping Frameworks to Constitutional Principles:**
+
+| Framework | Constitutional Principles Supported |
+|-----------|-------------------------------------|
+| A3 | P-002 (File Persistence), P-004 (Reasoning Documentation) |
+| SECI | P-002 (File Persistence), P-010 (Task Tracking Integrity) |
+| ReAct | P-001 (Truth/Accuracy), P-004 (Reasoning Documentation) |
+| GraphRAG | P-001 (Truth/Accuracy via grounding) |
+| Cynefin | P-001 (Truth/Accuracy in problem classification) |
+| 5 Whys | P-004 (Reasoning Documentation) |
+| PDCA | P-010 (Task Tracking Integrity via cycles) |
+
+**Avoiding Constitutional Violations:**
+
+- **P-003 (No Recursive Subagents)**: ReAct actions must be tools, not recursive agent calls
+- **P-020 (User Authority)**: Cynefin/Framework selection recommendations, not mandates
+- **P-022 (No Deception)**: CoT/ReAct reasoning traces must be honest, expose uncertainty
+
+---
+
+### Recommended Implementation Roadmap
+
+**Phase 1: Foundation (Immediate)**
+1. Create `problem-classifier` skill using Cynefin
+2. Implement A3 template in `.claude/templates/`
+3. Document SECI mapping in `docs/knowledge/seci-mapping.md`
+
+**Phase 2: AI Augmentation (Next)**
+4. Formalize ReAct pattern in `problem-solving` skill
+5. Implement standard RAG over `docs/` with vector database
+6. Create `knowledge-query` skill for semantic search
+
+**Phase 3: Advanced (Future)**
+7. Build GraphRAG knowledge graph from Jerry's docs
+8. Develop `framework-selector` agent that recommends frameworks
+9. Create framework effectiveness metrics (which frameworks led to best outcomes?)
+
+**Phase 4: Optimization (Ongoing)**
+10. Continuous refinement based on usage patterns
+11. Archive completed A3s and extract patterns
+12. Update Jerry Constitution based on framework learnings
+
+---
+
+## Framework Comparison Matrix
+
+### Overview Matrix: All 16 Frameworks
+
+| Framework | Category | Origin Year | Complexity | Time to Apply | Best For | Primary Output |
+|-----------|----------|-------------|------------|---------------|----------|----------------|
+| **SECI** | KM | 1995 | Medium | Ongoing | Knowledge flow | Knowledge artifacts |
+| **Wiig** | KM | 1993 | Medium | Days-Weeks | Knowledge audit | Competency model |
+| **Boisot I-Space** | KM | 1995 | High | Weeks | IP strategy | Knowledge map |
+| **Cynefin** | KM | 1999 | Low | Minutes | Problem classification | Domain assignment |
+| **TRIZ** | Problem-Solving | 1946 | Very High | Days-Weeks | Technical innovation | Inventive solution |
+| **Design Thinking** | Problem-Solving | 1990s | Medium | Days-Weeks | User-centric innovation | Prototype |
+| **Systems Thinking** | Problem-Solving | 1940s-1990s | High | Weeks-Months | Complex systems | System map |
+| **5 Whys / Ishikawa** | Problem-Solving | 1920s-1960s | Low | Hours | Root cause analysis | Cause diagram |
+| **OODA Loop** | Decision | 1970s | Low | Seconds-Minutes | Rapid decisions | Action |
+| **Kepner-Tregoe** | Decision | 1965 | High | Days | High-stakes decisions | Decision record |
+| **PDCA** | Decision | 1920s-1950s | Low | Weeks (per cycle) | Continuous improvement | Standardized process |
+| **A3** | Decision | 1960s | Medium | Hours-Days | Structured problem-solving | One-page report |
+| **RAG** | AI-Era | 2020+ | Medium | Setup: Days, Query: Seconds | Domain-specific Q&A | Grounded answer |
+| **GraphRAG** | AI-Era | 2024 | High | Setup: Weeks, Query: Seconds | Complex knowledge exploration | Graph-based answer |
+| **Chain-of-Thought** | AI-Era | 2022 | Low | Seconds | Reasoning transparency | Reasoning trace |
+| **ReAct** | AI-Era | 2023 | Medium | Seconds-Minutes | Agentic tasks | Action sequence |
+
+---
+
+### Detailed Comparison by Dimension
+
+#### 1. Problem Type Suitability
+
+| Framework | Technical | Organizational | Strategic | Operational | Creative | Analytical |
+|-----------|-----------|----------------|-----------|-------------|----------|------------|
+| SECI | ● | ●●● | ●● | ●● | ● | ● |
+| Wiig | ● | ●●● | ●● | ●● | ○ | ●● |
+| Boisot I-Space | ● | ●● | ●●● | ○ | ● | ●● |
+| Cynefin | ●● | ●●● | ●●● | ●● | ●● | ●● |
+| TRIZ | ●●● | ○ | ● | ● | ●●● | ●● |
+| Design Thinking | ●● | ●● | ●● | ● | ●●● | ● |
+| Systems Thinking | ●● | ●●● | ●●● | ●● | ●● | ●●● |
+| 5 Whys / Ishikawa | ●●● | ●● | ○ | ●●● | ○ | ●●● |
+| OODA Loop | ●● | ●● | ●●● | ●●● | ● | ●● |
+| Kepner-Tregoe | ●●● | ●● | ●● | ●● | ○ | ●●● |
+| PDCA | ●● | ●● | ○ | ●●● | ○ | ●● |
+| A3 | ●●● | ●● | ● | ●●● | ○ | ●●● |
+| RAG | ●● | ●● | ○ | ●● | ○ | ●● |
+| GraphRAG | ●● | ●● | ●●● | ● | ● | ●●● |
+| Chain-of-Thought | ●●● | ● | ○ | ●● | ● | ●●● |
+| ReAct | ●●● | ●● | ● | ●●● | ● | ●●● |
+
+**Legend:** ●●● Excellent fit | ●● Good fit | ● Some fit | ○ Limited fit
+
+---
+
+#### 2. Knowledge Type Addressed
+
+| Framework | Tacit | Explicit | Procedural | Declarative | Contextual |
+|-----------|-------|----------|------------|-------------|------------|
+| SECI | ●●● | ●●● | ●● | ●● | ●●● |
+| Wiig | ●● | ●●● | ●● | ●●● | ● |
+| Boisot I-Space | ●●● | ●●● | ● | ●● | ●●● |
+| Cynefin | ● | ●● | ●● | ●● | ●●● |
+| TRIZ | ● | ●●● | ●●● | ●● | ● |
+| Design Thinking | ●●● | ●● | ●●● | ● | ●●● |
+| Systems Thinking | ●● | ●● | ●● | ●● | ●●● |
+| 5 Whys / Ishikawa | ● | ●● | ●● | ●●● | ●● |
+| OODA Loop | ●● | ●● | ●●● | ●● | ●●● |
+| Kepner-Tregoe | ● | ●●● | ●●● | ●●● | ●● |
+| PDCA | ● | ●●● | ●●● | ●● | ● |
+| A3 | ●● | ●●● | ●●● | ●●● | ●● |
+| RAG | ○ | ●●● | ● | ●●● | ●● |
+| GraphRAG | ○ | ●●● | ● | ●●● | ●●● |
+| Chain-of-Thought | ○ | ●●● | ●●● | ●● | ● |
+| ReAct | ○ | ●●● | ●●● | ●● | ●● |
+
+---
+
+#### 3. Implementation Requirements
+
+| Framework | Training Needed | Tool Support | Cultural Change | Cost | Scalability |
+|-----------|----------------|--------------|-----------------|------|-------------|
+| SECI | Medium | Low | High | Low | High |
+| Wiig | Medium | Low | Medium | Low | High |
+| Boisot I-Space | High | Low | Medium | Low | Medium |
+| Cynefin | Low | Low | Medium | Low | High |
+| TRIZ | Very High | Medium | Medium | Medium | Medium |
+| Design Thinking | Medium | Low | High | Low | High |
+| Systems Thinking | High | Medium | High | Low | Medium |
+| 5 Whys / Ishikawa | Low | Low | Low | Low | High |
+| OODA Loop | Low | Low | Medium | Low | High |
+| Kepner-Tregoe | High | Low | Medium | Medium | Medium |
+| PDCA | Low | Low | Medium | Low | High |
+| A3 | Medium | Low | High | Low | High |
+| RAG | Medium | High | Low | Medium-High | High |
+| GraphRAG | High | Very High | Low | High-Very High | Medium |
+| Chain-of-Thought | Low | Medium | Low | Medium | High |
+| ReAct | Medium | High | Low | Medium-High | High |
+
+---
+
+#### 4. Strengths & Weaknesses Summary
+
+| Framework | Key Strength | Key Weakness | Best Alternative |
+|-----------|--------------|--------------|------------------|
+| SECI | Captures tacit knowledge flow | Requires knowledge-sharing culture | Wiig (more structured) |
+| Wiig | Clear knowledge maturity levels | Less focus on tacit knowledge | SECI (tacit emphasis) |
+| Boisot I-Space | 3D knowledge mapping | Abstract, hard to operationalize | SECI (more actionable) |
+| Cynefin | Fast problem classification | Domain boundaries can be fuzzy | None (unique purpose) |
+| TRIZ | Systematic innovation from patterns | Steep learning curve | Design Thinking (more accessible) |
+| Design Thinking | Human-centered creativity | Time-intensive | TRIZ (faster if trained) |
+| Systems Thinking | Reveals hidden dynamics | Can lead to analysis paralysis | Cynefin (faster sense-making) |
+| 5 Whys / Ishikawa | Simple, fast root cause analysis | May oversimplify complex issues | Kepner-Tregoe (rigorous) |
+| OODA Loop | Speed and adaptability | Can be oversimplified | Kepner-Tregoe (high-stakes) |
+| Kepner-Tregoe | Rigorous, logical decision-making | Time-intensive | OODA (speed) or A3 (balance) |
+| PDCA | Continuous improvement mindset | Slow for urgent problems | OODA (rapid action) |
+| A3 | Concise, combines solving + docs | One page can feel constraining | Kepner-Tregoe (more detail) |
+| RAG | Grounds LLM in current knowledge | Retrieval quality critical | GraphRAG (complex queries) |
+| GraphRAG | Multi-hop reasoning, exploration | Expensive, complex setup | RAG (simpler/cheaper) |
+| Chain-of-Thought | Transparent reasoning | Only works with large LLMs | ReAct (adds grounding) |
+| ReAct | Grounds reasoning in actions/data | Multiple LLM calls (latency, cost) | RAG (single retrieval) |
+
+---
+
+#### 5. Integration Compatibility Matrix
+
+Which frameworks work well together?
+
+| Framework Pair | Synergy Level | How They Complement |
+|----------------|---------------|---------------------|
+| Cynefin + Any | ●●● | Cynefin classifies, then apply domain-appropriate framework |
+| SECI + A3 | ●●● | A3 externalizes (SECI step), completed A3s are combination |
+| SECI + ReAct | ●●● | ReAct reasoning traces externalize tacit knowledge |
+| ReAct + RAG | ●●● | ReAct decides when to retrieve (RAG provides retrieval) |
+| RAG + GraphRAG | ●● | Start with RAG, upgrade to GraphRAG for complex needs |
+| Chain-of-Thought + ReAct | ●●● | CoT provides reasoning, ReAct adds grounding via actions |
+| A3 + PDCA | ●●● | A3 documents each PDCA cycle |
+| A3 + 5 Whys | ●●● | 5 Whys in A3 section 4 (root cause analysis) |
+| Systems Thinking + Cynefin | ●●● | Cynefin for classification, Systems for complex domain |
+| TRIZ + Design Thinking | ●● | TRIZ for technical solutions, Design Thinking for user validation |
+| OODA + Cynefin | ●●● | Cynefin for domain, OODA for chaotic domain response |
+| Kepner-Tregoe + A3 | ●● | K-T for analysis rigor, A3 for documentation brevity |
+| Wiig + SECI | ●● | Wiig for auditing, SECI for flow management |
+| Boisot + GraphRAG | ●● | Both model knowledge as networks/spaces |
+
+**Legend:** ●●● Highly synergistic | ●● Complementary | ● Compatible with effort
+
+---
+
+## Full Citations & References
+
+### Classic Knowledge Management Frameworks
+
+**SECI Model:**
+1. Managing Knowledge in Organizations: A Nonaka's SECI Model Operationalization - PMC. (2019). https://pmc.ncbi.nlm.nih.gov/articles/PMC6914727/
+2. SECI model of knowledge dimensions. Wikipedia. https://en.wikipedia.org/wiki/SECI_model_of_knowledge_dimensions
+3. SECI Model of Knowledge Dimensions (Nonaka & Takeuchi). ToolsHero. https://www.toolshero.com/quality-management/seci-model-nonaka-takeuchi/
+4. Nonaka, I., & Takeuchi, H. (1995). *The Knowledge-Creating Company: How Japanese Companies Create the Dynamics of Innovation*. Oxford University Press.
+
+**Wiig Model:**
+1. The Wiig Model for Building and Using Knowledge. Theoretical Models of Information and Knowledge Management. https://www.tlu.ee/~sirvir/IKM/Theoretical_models_of_Information_and_Knowledge_Management/the_wiig_model_for_building_and_using_knowledge.html
+2. 4 Knowledge Management Models That Can Supercharge Your Organisation. HelpieWP. https://helpiewp.com/knowledge-management-models/
+3. Garfield, S. (2020). Karl Wiig: Profiles in Knowledge. Medium. https://stangarfield.medium.com/karl-wiig-profiles-in-knowledge-cb09e2c9088e
+4. Wiig, K. M. (1993). *Knowledge Management Foundations: Thinking about Thinking - How People and Organizations Create, Represent and Use Knowledge*. Schema Press.
+
+**Boisot I-Space:**
+1. The Boisot I-Space KM Model. Theoretical Models of Information and Knowledge Management. https://www.tlu.ee/~sirvir/IKM/Theoretical_models_of_Information_and_Knowledge_Management/the_boisot_ispace_km_model.html
+2. Garfield, S. (2020). Max Boisot: Profiles in Knowledge. Medium. https://stangarfield.medium.com/max-boisot-profiles-in-knowledge-fdfd3352c1e5
+3. Navigating Information Flow: A Deep Dive into Max Boisot's I-Space. (2024). https://conikeec.substack.com/p/navigating-the-information-space
+4. Boisot, M. H. (1995). *Information Space: A Framework for Learning in Organizations, Institutions and Culture*. Routledge.
+
+**Cynefin Framework:**
+1. Cynefin framework. Wikipedia. https://en.wikipedia.org/wiki/Cynefin_framework
+2. Snowden, D. J., & Boone, M. E. (2007). A Leader's Framework for Decision Making. *Harvard Business Review*, 85(11), 68-76. https://hbr.org/2007/11/a-leaders-framework-for-decision-making
+3. About Cynefin Framework. The Cynefin Co. https://thecynefin.co/about-us/about-cynefin-framework/
+4. The Cynefin Framework. MindTools. https://www.mindtools.com/atddimk/the-cynefin-framework/
+
+### Problem-Solving Frameworks
+
+**TRIZ:**
+1. TRIZ. Wikipedia. https://en.wikipedia.org/wiki/TRIZ
+2. TRIZ: The Backbone of Innovation and Problem-Solving. *Quality Magazine*. (2024). https://www.qualitymag.com/articles/98566-triz-the-backbone-of-innovation-and-problem-solving
+3. What is TRIZ? TRIZ.co.uk. https://www.triz.co.uk/what-is-triz
+4. Can the Theory of Inventive Problem Solving Help You? NASA APPEL Knowledge Services. (2010). https://appel.nasa.gov/2010/02/23/aa_1-10_f_inventive-html/
+5. Altshuller, G. S. (1999). *The Innovation Algorithm: TRIZ, Systematic Innovation and Technical Creativity*. Technical Innovation Center.
+
+**Design Thinking:**
+1. Pacheco, J. F. (2025). What is Design Thinking? Stanford d.school Model. https://juanfernandopacheco.com/2025/01/what-is-design-thinking-stanford-d-school-model/
+2. Design Thinking by Stanford d.school and IDEO. Wind4Change. https://wind4change.com/design-thinking-d-school-stanford-ideo-approach-methodology/
+3. What is Design Thinking? Interaction Design Foundation. https://www.interaction-design.org/literature/topics/design-thinking
+4. Brown, T. (2008). Design Thinking. *Harvard Business Review*, 86(6), 84-92.
+
+**Systems Thinking:**
+1. Zhang, L., & Ahmed, A. A. (2020). Systems Thinking—Ludwig Von Bertalanffy, Peter Senge, and Donella Meadows. In *Springer Handbook of Engineering Systems*. Springer. https://link.springer.com/chapter/10.1007/978-3-030-43620-9_28
+2. Meadows, D. H. (2008). *Thinking in Systems: A Primer*. Chelsea Green Publishing. https://research.fit.edu/media/site-specific/researchfitedu/coast-climate-adaptation-library/climate-communications/psychology-amp-behavior/Meadows-2008.-Thinking-in-Systems.pdf
+3. Demystifying Systems Thinking. Cambridge Institute for Sustainability Leadership. https://www.cisl.cam.ac.uk/files/cisl_primer_demystifying_systems_thinking.pdf
+4. Senge, P. M. (1990). *The Fifth Discipline: The Art and Practice of the Learning Organization*. Doubleday.
+
+**Root Cause Analysis (5 Whys / Ishikawa):**
+1. Root Cause and Effect Analysis: 5 Whys vs. Fishbone. EasyRCA. https://easyrca.com/blog/root-cause-and-effect-analysis-5-whys-vs-fishbone/
+2. Ishikawa diagram. Wikipedia. https://en.wikipedia.org/wiki/Ishikawa_diagram
+3. Root Cause Analysis: Integrating Ishikawa Diagrams and the 5 Whys. iSixSigma. https://www.isixsigma.com/cause-effect/root-cause-analysis-ishikawa-diagrams-and-the-5-whys/
+4. Cause and Effect Analysis: Using Fishbone Diagram and 5 Whys. Visual Paradigm. https://www.visual-paradigm.com/project-management/fishbone-diagram-and-5-whys/
+
+### Decision Frameworks
+
+**OODA Loop:**
+1. OODA loop. Wikipedia. https://en.wikipedia.org/wiki/OODA_loop
+2. The OODA Loop. The Decision Lab. https://thedecisionlab.com/reference-guide/computer-science/the-ooda-loop
+3. The OODA Loop Explained: The real story about the ultimate model for decision-making in competitive environments. OODAloop.com. https://oodaloop.com/the-ooda-loop-explained-the-real-story-about-the-ultimate-model-for-decision-making-in-competitive-environments/
+4. The OODA Loop: How Fighter Pilots Make Fast and Accurate Decisions. Farnam Street. https://fs.blog/ooda-loop/
+5. Boyd, J. R. (1976). *Destruction and Creation*. U.S. Army Command and General Staff College.
+
+**Kepner-Tregoe:**
+1. The Kepner-Tregoe Matrix. MindTools. https://www.mindtools.com/atznth6/the-kepner-tregoe-matrix/
+2. Kepner Tregoe Method of Problem Solving. ToolsHero. https://www.toolshero.com/problem-solving/kepner-tregoe-method/
+3. Kepner‑Tregoe: A Structured and Rational Approach to Problem Solving and Decision‑Making. Microsoft Community Hub. (2024). https://techcommunity.microsoft.com/blog/azuredbsupport/kepner%E2%80%91tregoe-a-structured-and-rational-approach-to-problem-solving-and-decision/4482643
+4. Kepner, C. H., & Tregoe, B. B. (1965). *The Rational Manager: A Systematic Approach to Problem Solving and Decision Making*. McGraw-Hill.
+
+**PDCA Cycle:**
+1. PDCA Cycle - What is the Plan-Do-Check-Act Cycle? ASQ. https://asq.org/quality-resources/pdca-cycle
+2. PDCA. Wikipedia. https://en.wikipedia.org/wiki/PDCA
+3. PDSA Cycle. The W. Edwards Deming Institute. https://deming.org/explore/pdsa/
+4. The Deming Cycle (PDCA) Explained: A Comprehensive Guide to Continuous Improvement. Brightly Software. https://www.brightlysoftware.com/learning-center/the-deming-cycle-pdca-explained-a-comprehensive-guide-to-continuous-improvement
+5. Deming, W. E. (1986). *Out of the Crisis*. MIT Press.
+
+**A3 Problem Solving:**
+1. A3 problem solving. Wikipedia. https://en.wikipedia.org/wiki/A3_problem_solving
+2. Sobek, D. K., & Smalley, A. (2008). Toyota's Secret: The A3 Report. *MIT Sloan Management Review*, 49(4). https://sloanreview.mit.edu/article/toyotas-secret-the-a3-report/
+3. What is A3 Problem Solving? Kanban Tool. https://kanbantool.com/kanban-guide/a3-problem-solving
+4. How to use Toyota's legendary A3 problem solving technique. Nulab. https://nulab.com/learn/project-management/use-toyotas-legendary-a3-problem-solving-technique/
+
+### AI-Era Frameworks
+
+**RAG (Retrieval Augmented Generation):**
+1. Retrieval Augmented Generation (RAG) for LLMs. Prompt Engineering Guide. https://www.promptingguide.ai/research/rag
+2. What is RAG? - Retrieval-Augmented Generation AI Explained. AWS. https://aws.amazon.com/what-is/retrieval-augmented-generation/
+3. Retrieval-augmented generation. Wikipedia. https://en.wikipedia.org/wiki/Retrieval-augmented_generation
+4. RAG in 2025: Bridging Knowledge and Generative AI. Squirro. https://squirro.com/squirro-blog/state-of-rag-genai
+5. Boulahia, H. (2025). All You Need To Know About Retrieval-Augmented Generation (RAG) in 2025. *Towards AI*. https://pub.towardsai.net/all-you-need-to-know-about-retrieval-augmented-generation-rag-in-2025-04c386284c18
+6. Gao, Y., et al. (2023). Retrieval-Augmented Generation for Large Language Models: A Survey. *arXiv preprint* arXiv:2312.10997. https://arxiv.org/abs/2312.10997
+
+**GraphRAG:**
+1. Welcome - GraphRAG. Microsoft GraphRAG Documentation. https://microsoft.github.io/graphrag/
+2. microsoft/graphrag. GitHub. https://github.com/microsoft/graphrag
+3. Project GraphRAG. Microsoft Research. https://www.microsoft.com/en-us/research/project/graphrag/
+4. GraphRAG: Unlocking LLM discovery on narrative private data. Microsoft Research Blog. https://www.microsoft.com/en-us/research/blog/graphrag-unlocking-llm-discovery-on-narrative-private-data/
+5. GraphRAG Explained: Enhancing RAG with Knowledge Graphs. Zilliz/Medium. (2024). https://medium.com/@zilliz_learn/graphrag-explained-enhancing-rag-with-knowledge-graphs-3312065f99e1
+
+**Chain-of-Thought (CoT) Prompting:**
+1. Wei, J., et al. (2022). Chain-of-Thought Prompting Elicits Reasoning in Large Language Models. *arXiv preprint* arXiv:2201.11903. https://arxiv.org/abs/2201.11903
+2. Chain-of-Thought Prompting. Learn Prompting. https://learnprompting.org/docs/intermediate/chain_of_thought
+3. What is chain of thought (CoT) prompting? IBM. https://www.ibm.com/think/topics/chain-of-thoughts
+4. Chain-of-Thought Prompting. Prompt Engineering Guide. https://www.promptingguide.ai/techniques/cot
+
+**ReAct (Reasoning + Acting):**
+1. Yao, S., et al. (2023). ReAct: Synergizing Reasoning and Acting in Language Models. *arXiv preprint* arXiv:2210.03629. https://arxiv.org/abs/2210.03629
+2. ReAct: Synergizing Reasoning and Acting in Language Models. Google Research Blog. https://research.google/blog/react-synergizing-reasoning-and-acting-in-language-models/
+3. What is a ReAct Agent? IBM. https://www.ibm.com/think/topics/react-agent
+4. ReAct Prompting. Prompt Engineering Guide. https://www.promptingguide.ai/techniques/react
+5. ReAct: Synergizing Reasoning and Acting in Language Models. Official Site. https://react-lm.github.io/
+
+---
+
+## Appendix: Quick Reference Cards
+
+### For Agent Use: Framework Selection Flowchart
+
+```
+START: User presents problem/request
+    ↓
+┌─────────────────────────────────────┐
+│ STEP 1: Classify with Cynefin       │
+│ - Clear? → Best practices apply     │
+│ - Complicated? → Expert analysis    │
+│ - Complex? → Experiment & probe     │
+│ - Chaotic? → Act to stabilize       │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ STEP 2: Select Framework            │
+│                                      │
+│ Clear Domain:                        │
+│   → A3, PDCA, 5 Whys                │
+│                                      │
+│ Complicated Domain:                  │
+│   → Kepner-Tregoe, TRIZ, Ishikawa   │
+│                                      │
+│ Complex Domain:                      │
+│   → Systems Thinking, Design Thinking│
+│   → ReAct + GraphRAG                 │
+│                                      │
+│ Chaotic Domain:                      │
+│   → OODA Loop                        │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ STEP 3: Apply SECI for Knowledge    │
+│ - Externalize: Document reasoning    │
+│ - Combine: Cross-reference docs      │
+│ - Share: Update relevant docs/       │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ STEP 4: Create A3 if Significant    │
+│ - Capture problem-solving process    │
+│ - Store in docs/a3/                  │
+└─────────────────────────────────────┘
+    ↓
+END: Problem solved + Knowledge captured
+```
+
+---
+
+### Jerry-Specific Quick Decisions
+
+**Use This Framework When:**
+
+- **Cynefin**: First thing, every time (classify before solving)
+- **A3**: Problem took >2 hours or likely to recur
+- **ReAct**: Need to search/retrieve external knowledge
+- **5 Whys**: Bug or failure requiring root cause
+- **PDCA**: Iterative improvement of known process
+- **SECI**: Deciding where/how to document knowledge
+- **GraphRAG**: Complex query across multiple docs (future)
+
+**Don't Use (Outside Jerry's Scope):**
+
+- **TRIZ**: Unless hardware/physical system involved
+- **Design Thinking**: Unless user research phase explicitly requested
+- **Wiig**: Too organizational, Jerry is individual/team scale
+- **Boisot**: Too abstract for operational use
+
+---
+
+### Constitutional Compliance Checklist
+
+Before finalizing framework application:
+
+- [ ] **P-001**: Information accurate and sourced? (especially with RAG/GraphRAG)
+- [ ] **P-002**: Significant outputs persisted to filesystem?
+- [ ] **P-003**: No recursive agent calls (only tools in ReAct)?
+- [ ] **P-004**: Reasoning documented (CoT traces, A3, etc.)?
+- [ ] **P-010**: Work Tracker updated with progress?
+- [ ] **P-020**: User authority respected (recommendations, not mandates)?
+- [ ] **P-022**: Transparent about limitations and confidence?
+
+---
+
+## Conclusion
+
+This research provides a comprehensive catalog of 16 knowledge management and problem-solving frameworks spanning from 1946 (TRIZ) to 2024 (GraphRAG). The analysis reveals that effective knowledge work requires a **layered framework stack** rather than a single approach:
+
+1. **Classification layer** (Cynefin) to match context with appropriate methods
+2. **Knowledge flow layer** (SECI) to manage tacit ↔ explicit conversion
+3. **AI augmentation layer** (ReAct + GraphRAG) to leverage LLM capabilities with grounding
+4. **Documentation layer** (A3) to capture learnings systematically
+
+For Jerry, this stack aligns with architectural strengths (filesystem-as-memory, agent patterns) while addressing core challenges (context rot, knowledge retention). The recommended implementation roadmap provides a phased approach from immediate foundational work to future advanced capabilities.
+
+The framework comparison matrix enables evidence-based selection based on problem type, knowledge type, implementation requirements, and integration compatibility. By embedding these frameworks into Jerry's skills and workflows, the system can systematically improve its problem-solving effectiveness while accruing reusable knowledge, wisdom, and experience.
+
+**File:** `/home/user/jerry/docs/research/work-032-e-005-km-frameworks.md`
+**Status:** Complete
+**Word Count:** ~13,500 words
+**Framework Coverage:** 16/16 (100%)

--- a/docs/archive/projects-archive/research/work-033-e-001-integration-analysis.md
+++ b/docs/archive/projects-archive/research/work-033-e-001-integration-analysis.md
@@ -1,0 +1,1464 @@
+# Integration Analysis: WORK-031 + WORK-032
+# Knowledge Architecture & KM Integration Unified Design
+
+**PS ID:** work-033
+**Entry ID:** e-001
+**Topic:** Integration Analysis - Knowledge Architecture + KM Implementation
+**Date:** 2026-01-09
+**Agent:** ps-researcher v2.0.0
+
+---
+
+## L0: Executive Summary (Plain Language)
+
+### What This Analysis Does
+
+This document analyzes how two major architectural decisions—WORK-031 (Knowledge Architecture with semantic web) and WORK-032 (Knowledge Management integration)—fit together to create a unified design for Jerry's knowledge system.
+
+### The Good News: Strong Alignment
+
+The two decisions are **highly compatible**. Both independently arrived at similar conclusions:
+- Hybrid architecture (property graph + RDF)
+- Four-phase implementation roadmap
+- Lightweight, embedded-first approach
+- GraphRAG for LLM grounding
+- Hexagonal architecture with ports/adapters
+
+### The Integration Points
+
+These decisions aren't competing—they're **complementary layers**:
+
+- **WORK-031** = **Technical Foundation** (what to build)
+  - Semantic web standards (RDF, JSON-LD, SPARQL)
+  - Graph architecture patterns
+  - Performance and validation layers
+
+- **WORK-032** = **Practical Implementation** (how to build it)
+  - Specific Python libraries (NetworkX, RDFLib, FAISS)
+  - Knowledge management protocols (AAR, A3)
+  - Social/behavioral processes
+
+Think of WORK-031 as the architectural blueprint and WORK-032 as the construction plan with specific materials and techniques.
+
+### The Key Finding: Natural Layering
+
+The integration reveals a **three-layer architecture**:
+
+```
+Layer 3: Semantic Web (WORK-031 focus)
+├─ JSON-LD contexts, SPARQL endpoints
+├─ OWL ontologies, reasoning
+└─ Content negotiation, 5-star Linked Data
+
+Layer 2: Knowledge Graph (Both decisions)
+├─ Property graph (NetworkX for operations)
+├─ RDF serialization (RDFLib/pyoxigraph for export)
+└─ Vector search (FAISS for semantic queries)
+
+Layer 1: Filesystem (WORK-032 foundation)
+├─ Markdown files (source of truth)
+├─ Git versioning
+└─ Direct agent access
+```
+
+### What Needs Reconciliation
+
+**Minor gaps** that need design decisions (not conflicts):
+
+1. **RDF Library Choice**: RDFLib vs. pyoxigraph (or use both?)
+2. **Phase 2 Scope**: How much to include in Q1 2026?
+3. **Validation Priority**: SHACL vs. protocols (AAR/A3) first?
+4. **Vector Storage Format**: TOON vs. FAISS index files?
+
+### Recommendation: Unified 4-Phase Roadmap
+
+Merge both roadmaps into a **single implementation plan** that:
+- Phase 1 (✅ Complete): Property graph foundation
+- Phase 2 (Q1 2026): RDF serialization + AAR/A3 protocols + basic RAG
+- Phase 3 (Q2-Q3 2026): SPARQL + GraphRAG + grounding verification
+- Phase 4 (Q4 2026+): Scale as needed, ISO 30401 alignment
+
+The two decisions **strengthen each other** and should be implemented together, not sequentially.
+
+---
+
+## L1: Technical Integration Analysis
+
+### 1. Alignment Analysis: Where They Agree
+
+#### 1.1 Architectural Pattern Convergence
+
+**Finding**: Both decisions independently recommend **identical architectural patterns**.
+
+| Pattern | WORK-031 | WORK-032 | Strength |
+|---------|----------|----------|----------|
+| **Hybrid Property Graph + RDF** | PAT-001, unanimous (5/5 docs) | PAT-003 (Graph Dominance) | ✅✅✅ UNANIMOUS |
+| **Four-Phase Maturity Model** | PAT-002, explicit roadmap | Phased implementation (Q1-Q4) | ✅✅✅ UNANIMOUS |
+| **Netflix UDA "Model Once, Represent Everywhere"** | PAT-003, cited 4/5 docs | Not explicitly named but followed | ✅✅ STRONG |
+| **Embedded-First, Scale-Later** | PAT-007, Phase 4 triggers | Tier 3 (long-term/optional) | ✅✅ STRONG |
+| **HybridRAG (Vector + Graph)** | PAT-006, Phase 3 feature | Phase 3 AI layer | ✅✅ STRONG |
+| **Local-First with Optional Cloud** | Embedded through Phase 3 | PAT-006 (Local-First Hybrid) | ✅✅ STRONG |
+
+**Evidence of Convergence:**
+- Both cite Netflix UDA as architectural ideal
+- Both recommend property graph for operations, RDF for interoperability
+- Both emphasize incremental phases over big-bang
+- Both target Q1 2026 for semantic layer implementation
+
+**Implication**: The architectural vision is **unified**. No competing paradigms.
+
+---
+
+#### 1.2 Technology Stack Compatibility
+
+**Finding**: The technology choices are **complementary, not contradictory**.
+
+| Component | WORK-031 Technology | WORK-032 Technology | Integration Strategy |
+|-----------|---------------------|---------------------|---------------------|
+| **Property Graph** | Implicit (TinkerPop/Gremlin mentioned) | NetworkX (explicit) | ✅ Use NetworkX as adapter for property graph operations |
+| **RDF Storage** | pyoxigraph (Rust/Python) | RDFLib (pure Python) | ✅ Use BOTH: RDFLib for lightweight, pyoxigraph for scale |
+| **Vector Search** | text-embedding-3-small + storage in TOON | FAISS + ChromaDB | ✅ Use FAISS as primary, TOON for metadata/provenance |
+| **JSON-LD** | Phase 2 priority, contexts defined | Not explicitly mentioned | ✅ WORK-031 provides specification, implement in Phase 2 |
+| **SPARQL** | Phase 3 endpoint (Flask + pyoxigraph) | Not explicitly mentioned | ✅ WORK-031 provides roadmap, optional in Phase 3 |
+| **Document Processing** | Not specified | Docling (IBM, multi-format) | ✅ WORK-032 fills gap, use Docling |
+| **NLP** | Not specified | spaCy with small models | ✅ WORK-032 fills gap, use spaCy for entity extraction |
+
+**Key Insight**: WORK-031 provides **semantic web layer**, WORK-032 provides **implementation libraries**. They operate at different abstraction levels.
+
+**Dependency Graph**:
+```
+WORK-031 (Semantic Layer)
+    ├─ JSON-LD contexts → RDFLib for creation
+    ├─ RDF export → pyoxigraph for storage, RDFLib for serialization
+    ├─ SPARQL endpoint → pyoxigraph query engine
+    └─ SHACL validation → RDFLib/pyoxigraph
+         ↓
+WORK-032 (Implementation Layer)
+    ├─ Property graph operations → NetworkX
+    ├─ RDF manipulation → RDFLib
+    ├─ Vector search → FAISS
+    ├─ Document processing → Docling
+    └─ Entity extraction → spaCy
+```
+
+**Implication**: Libraries from WORK-032 **implement** capabilities from WORK-031. No redundancy.
+
+---
+
+#### 1.3 Constitutional Alignment
+
+**Finding**: Both decisions align with Jerry Constitution, with WORK-031 proposing extensions.
+
+| Principle | WORK-031 | WORK-032 | Status |
+|-----------|----------|----------|--------|
+| **P-001: Truth and Accuracy** | Grounding verification (MiniCheck) | Source attribution always | ✅ Reinforced |
+| **P-002: File Persistence** | Filesystem remains source of truth | Filesystem as Tier 1 foundation | ✅ Reinforced |
+| **P-003: No Recursive Subagents** | Not addressed | ReAct uses tools, not agents | ✅ Reinforced |
+| **P-020: User Authority** | Phase gates require user approval | Recommendations, not mandates | ✅ Reinforced |
+| **P-022: No Deception** | Jerry URI citations | Always cite sources | ✅ Reinforced |
+| **P-030: Schema Evolution** | ✨ NEW: Proposed by WORK-031 | Not addressed | 🔄 Extend constitution |
+| **P-031: Supernode Prevention** | ✨ NEW: Proposed by WORK-031 | Not addressed | 🔄 Extend constitution |
+| **P-032: Phase Gate Compliance** | ✨ NEW: Proposed by WORK-031 | Implicit in phased rollout | 🔄 Extend constitution |
+
+**Implication**: WORK-031 proposes **three new constitutional principles** that WORK-032 doesn't contradict but doesn't explicitly address. These should be adopted.
+
+---
+
+#### 1.4 Shared Strategic Goals
+
+**Finding**: Both decisions target the **same high-level outcomes**.
+
+| Goal | WORK-031 Evidence | WORK-032 Evidence | Alignment |
+|------|-------------------|-------------------|-----------|
+| **LLM Grounding** | 90% hallucination reduction (FalkorDB) | RAG/GraphRAG as AI layer | ✅ Primary driver |
+| **Standards Compliance** | 5-star Linked Open Data, W3C RDF | ISO 30401 progressive alignment | ✅ Different standards, same philosophy |
+| **Knowledge Accumulation** | Multi-representation architecture | SECI spiral, knowledge flow cycles | ✅ Core mission |
+| **Reduced Context Rot** | Filesystem as infinite memory | Filesystem-based source of truth | ✅ Foundational principle |
+| **Interoperability** | JSON-LD, SPARQL, Schema.org | RDF export, semantic web | ✅ Standards-based |
+
+**Implication**: Both decisions are **working toward the same vision** from different angles.
+
+---
+
+### 2. Gap Analysis: Where Integration is Needed
+
+#### 2.1 RDF Library Strategy: RDFLib vs. pyoxigraph
+
+**Gap Description**: Both decisions mention RDF libraries, but with different emphases.
+
+| Aspect | RDFLib (WORK-032) | pyoxigraph (WORK-031) |
+|--------|-------------------|----------------------|
+| **Language** | Pure Python | Rust core with Python bindings |
+| **Performance** | Slower (Python-based parsing) | Faster (Rust-optimized) |
+| **Maturity** | 14M downloads/week, mature | Newer but W3C-compliant |
+| **Capabilities** | RDF 1.1, SPARQL 1.1, parsing/serialization | RDF 1.2 (RDF*), SPARQL 1.2, embedded store |
+| **Dependencies** | Minimal Python deps | Zero external deps (embedded) |
+| **Use Case** | Lightweight RDF manipulation | Production RDF storage and queries |
+
+**Integration Strategy**: Use **BOTH** with clear separation of concerns.
+
+```python
+# Port definitions
+class RDFSerializerPort(ABC):
+    """Converts entities to RDF formats"""
+    @abstractmethod
+    def to_turtle(self, entity: EntityBase) -> str: ...
+
+    @abstractmethod
+    def to_jsonld(self, entity: EntityBase) -> dict: ...
+
+class RDFStorePort(ABC):
+    """Stores and queries RDF triples"""
+    @abstractmethod
+    def add_triple(self, subject: str, predicate: str, object: str) -> None: ...
+
+    @abstractmethod
+    def query_sparql(self, query: str) -> QueryResult: ...
+
+# Adapters
+class RDFLibSerializerAdapter(RDFSerializerPort):
+    """Use RDFLib for lightweight serialization (Phase 2)"""
+    # Implementation with rdflib
+
+class PyoxigraphStoreAdapter(RDFStorePort):
+    """Use pyoxigraph for embedded RDF storage (Phase 3)"""
+    # Implementation with pyoxigraph
+```
+
+**Phased Adoption**:
+- **Phase 2**: RDFLib for serialization (Turtle, JSON-LD export)
+- **Phase 3**: pyoxigraph for embedded triple store (SPARQL endpoint)
+- **Rationale**: Start simple (RDFLib), scale when needed (pyoxigraph)
+
+**Resolved**: Both libraries serve different purposes. No conflict.
+
+---
+
+#### 2.2 Property Graph Implementation: NetworkX vs. TinkerPop
+
+**Gap Description**: WORK-031 mentions Gremlin/TinkerPop (Apache standard), WORK-032 explicitly recommends NetworkX.
+
+**Analysis**:
+
+| Aspect | NetworkX (WORK-032) | TinkerPop/Gremlin (WORK-031) |
+|--------|---------------------|------------------------------|
+| **Language** | Pure Python | Java-based (Gremlin Server) |
+| **Deployment** | Embedded | Server-based |
+| **Query Language** | Python API | Gremlin (traversal DSL) |
+| **Maturity** | 14.9M downloads/week | Apache Foundation standard |
+| **Jerry Fit** | ✅ Excellent (embedded, Python) | ❌ Poor (requires Java server) |
+| **Phase Suitability** | Phase 1-3 (embedded) | Phase 4 (if scale demands) |
+
+**Integration Strategy**: NetworkX is the **correct choice** for Jerry Phase 1-3.
+
+**Clarification**: WORK-031's mention of Gremlin is **conceptual** (traversal patterns), not a library requirement. NetworkX provides similar graph operations with Python API.
+
+**Example Mapping**:
+```python
+# Gremlin traversal (conceptual)
+# g.V(task_id).out('BLOCKS').toList()
+
+# NetworkX equivalent
+def get_blocking_tasks(graph: nx.MultiDiGraph, task_id: str) -> List[str]:
+    """Get tasks blocked by task_id"""
+    return [target for source, target, data in graph.out_edges(task_id, data=True)
+            if data.get('label') == 'BLOCKS']
+```
+
+**Resolved**: Use NetworkX. Gremlin mentioned in WORK-031 is illustrative, not prescriptive.
+
+---
+
+#### 2.3 Vector Storage Format: TOON vs. FAISS Index
+
+**Gap Description**: WORK-031 suggests storing embeddings in TOON format alongside documents. WORK-032 recommends FAISS index files.
+
+**Analysis**:
+
+| Aspect | TOON Format (WORK-031) | FAISS Index (WORK-032) |
+|--------|------------------------|------------------------|
+| **Purpose** | Human-readable metadata + embeddings | Optimized vector index for search |
+| **Storage** | Text file with embedding array | Binary index file |
+| **Performance** | Slower (parse TOON, no index) | Faster (native vector operations) |
+| **Portability** | ✅ Human-readable, git-friendly | ❌ Binary, tool-specific |
+| **Metadata** | ✅ Rich context alongside embeddings | ❌ External metadata needed |
+
+**Integration Strategy**: Use **BOTH** for different purposes.
+
+```
+Document: docs/experience/LES-001-hybrid-prevents-lockin.md
+    ├─ Source: Markdown file (source of truth)
+    ├─ Metadata: .toon sidecar (human-readable provenance)
+    │   {
+    │     file: "LES-001-hybrid-prevents-lockin.md"
+    │     embedding_model: "text-embedding-3-small"
+    │     embedding_dimensions: 1536
+    │     indexed_at: 2026-01-09T10:30:00Z
+    │     chunk_count: 3
+    │   }
+    └─ Vector Index: FAISS index (fast search)
+        └─ Stored in: .jerry/indexes/embeddings.faiss
+```
+
+**Benefits**:
+- FAISS provides fast vector search
+- TOON provides human-readable provenance and metadata
+- Separation of concerns: operational (FAISS) vs. documentation (TOON)
+
+**Resolved**: Not a conflict—complementary storage layers.
+
+---
+
+#### 2.4 Phase 2 Scope Definition
+
+**Gap Description**: Both plans target Q1 2026 for Phase 2, but with different feature emphases.
+
+| Feature | WORK-031 Phase 2 | WORK-032 Phase 2 |
+|---------|------------------|------------------|
+| **RDF Serialization** | ✅ Primary focus | ✅ Infrastructure adapters |
+| **JSON-LD Contexts** | ✅ Week 1-2 deliverable | ❌ Not explicitly mentioned |
+| **SHACL Validation** | ✅ Week 3-4 deliverable | ❌ Not mentioned |
+| **Supernode Detection** | ✅ Week 1-2 deliverable | ❌ Not mentioned |
+| **Vector RAG** | ✅ Week 5-6 deliverable | ✅ Phase 2 Integration |
+| **AAR/A3 Protocols** | ❌ Not mentioned | ✅ Q1 2026 immediate |
+| **Graph Adapters** | ❌ Implicit | ✅ Explicit (NetworkX, RDFLib) |
+| **Knowledge Audit** | ❌ Not mentioned | ✅ Q1 2026 foundation |
+
+**Integration Strategy**: Merge into **unified Phase 2 scope**.
+
+**Unified Phase 2 (Q1 2026, 8 weeks)**:
+
+```
+Week 1-2: Foundation + Protocols
+├─ JSON-LD context creation (WORK-031)
+├─ Supernode validator (WORK-031)
+├─ AAR/A3 templates (WORK-032)
+└─ Knowledge Audit baseline (WORK-032)
+
+Week 3-4: RDF Serialization
+├─ RDFLib adapter (WORK-032 library, WORK-031 spec)
+├─ Turtle serialization (WORK-031)
+├─ JSON-LD serialization (WORK-031)
+└─ SHACL validation shapes (WORK-031)
+
+Week 5-6: Graph Layer
+├─ NetworkX adapter (WORK-032)
+├─ Entity extraction from docs/ (WORK-032)
+├─ Relationship detection (WORK-032)
+└─ Graph query interface (both)
+
+Week 7-8: Vector RAG
+├─ FAISS adapter (WORK-032)
+├─ Document embedding (both)
+├─ Semantic search (both)
+└─ Integration testing (both)
+```
+
+**Effort Estimate**: 70-100 hours total (WORK-032's estimate), 8-week timeline (WORK-031's plan).
+
+**Resolved**: Merged scope balances both decisions. No features dropped.
+
+---
+
+#### 2.5 Validation Priorities: SHACL vs. Protocols
+
+**Gap Description**: WORK-031 emphasizes technical validation (SHACL, supernode detection). WORK-032 emphasizes social protocols (AAR, A3).
+
+**Analysis**: This is **not a conflict**—it reflects different validation layers.
+
+| Layer | WORK-031 Contribution | WORK-032 Contribution |
+|-------|----------------------|----------------------|
+| **Layer 1: Data Schema** | SHACL shapes, schema versioning | Not addressed |
+| **Layer 2: Graph Structure** | Supernode detection, edge count | Not addressed |
+| **Layer 3: Semantic Integrity** | Content negotiation, URI dereferencing | RDF standards (RDFLib) |
+| **Layer 4: Process Compliance** | Phase gates (P-032) | AAR, A3, Knowledge Audit |
+| **Layer 5: LLM Grounding** | MiniCheck verification | Source attribution |
+
+**Integration Strategy**: Implement **all validation layers** as defense-in-depth.
+
+```python
+# Unified validation pipeline
+class JerryValidationPipeline:
+    def validate_entity(self, entity: EntityBase) -> ValidationResult:
+        results = []
+
+        # Layer 1: Schema validation (WORK-031)
+        results.append(self.schema_validator.validate(entity))
+
+        # Layer 2: Graph structure (WORK-031)
+        if isinstance(entity, Vertex):
+            results.append(self.supernode_validator.validate(entity))
+
+        # Layer 3: Semantic integrity (WORK-031 + WORK-032)
+        if hasattr(entity, 'to_rdf'):
+            results.append(self.shacl_validator.validate(entity.to_rdf()))
+
+        # Layer 4: Process compliance (WORK-032)
+        if entity.metadata.get('work_item'):
+            results.append(self.aar_validator.check_completed(entity))
+
+        # Layer 5: Grounding verification (WORK-031)
+        if entity.metadata.get('llm_generated'):
+            results.append(self.grounding_validator.verify(entity))
+
+        return ValidationResult.combine(results)
+```
+
+**Resolved**: Both validation approaches are needed. Complementary, not competing.
+
+---
+
+### 3. Integration Points: Key Connection Areas
+
+#### 3.1 Hexagonal Architecture as Integration Foundation
+
+**Finding**: Both decisions respect hexagonal architecture, enabling seamless integration.
+
+**Port Definitions** (from analysis):
+
+```python
+# Domain layer - no dependencies
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+import networkx as nx  # Type hint only, no import at runtime
+
+# Graph operations port (WORK-032 primary)
+class GraphPort(ABC):
+    @abstractmethod
+    def add_vertex(self, vertex_id: str, properties: Dict[str, Any]) -> None: ...
+
+    @abstractmethod
+    def add_edge(self, source: str, target: str, label: str, properties: Dict[str, Any]) -> None: ...
+
+    @abstractmethod
+    def traverse(self, start: str, direction: str, edge_label: str) -> List[str]: ...
+
+# RDF serialization port (WORK-031 primary)
+class RDFSerializerPort(ABC):
+    @abstractmethod
+    def to_turtle(self, entity: EntityBase) -> str: ...
+
+    @abstractmethod
+    def to_jsonld(self, entity: EntityBase, context_url: str) -> dict: ...
+
+# RDF storage port (WORK-031 Phase 3)
+class RDFStorePort(ABC):
+    @abstractmethod
+    def add_triples(self, triples: List[Tuple[str, str, str]]) -> None: ...
+
+    @abstractmethod
+    def query_sparql(self, query: str) -> QueryResult: ...
+
+# Vector search port (WORK-032 primary)
+class VectorStorePort(ABC):
+    @abstractmethod
+    def add_vectors(self, ids: List[str], vectors: np.ndarray, metadata: List[dict]) -> None: ...
+
+    @abstractmethod
+    def search(self, query_vector: np.ndarray, k: int, filter: dict = None) -> List[SearchResult]: ...
+
+# Knowledge port (WORK-032 semantic operations)
+class KnowledgePort(ABC):
+    @abstractmethod
+    def extract_entities(self, document: str) -> List[Entity]: ...
+
+    @abstractmethod
+    def detect_relationships(self, entities: List[Entity]) -> List[Relationship]: ...
+```
+
+**Adapter Implementations** (infrastructure layer):
+
+```python
+# From WORK-032
+from networkx_adapter import NetworkXAdapter  # implements GraphPort
+from rdflib_adapter import RDFLibAdapter      # implements RDFSerializerPort
+from faiss_adapter import FAISSAdapter         # implements VectorStorePort
+
+# From WORK-031 (Phase 3)
+from pyoxigraph_adapter import PyoxigraphAdapter  # implements RDFStorePort
+```
+
+**Integration Benefit**: Can implement WORK-032's adapters (Phase 2), then add WORK-031's pyoxigraph adapter (Phase 3) **without changing domain or application layers**.
+
+---
+
+#### 3.2 Jerry URI Scheme as Unified Identifier
+
+**Finding**: Both decisions rely on Jerry URI scheme (SPEC-001) as common identifier format.
+
+**Current Jerry URIs** (from SPEC-001):
+```
+jer:jer:work-tracker:task:TASK-042
+jer:jer:work-tracker:phase:PHASE-001
+jer:jer:work-tracker:plan:PLAN-2024-01
+```
+
+**Integration**: Jerry URIs serve as:
+
+| Usage | WORK-031 | WORK-032 |
+|-------|----------|----------|
+| **RDF Subject URIs** | ✅ JSON-LD @id field | ✅ RDFLib subject nodes |
+| **Graph Vertex IDs** | ✅ Property graph vertex IDs | ✅ NetworkX node identifiers |
+| **Vector Metadata Keys** | ✅ TOON file field | ✅ FAISS metadata IDs |
+| **Content Negotiation** | ✅ HTTP endpoint paths | ❌ Not addressed |
+| **Citation Format** | ✅ LLM response sourcing | ✅ Source attribution |
+
+**Unified Implementation**:
+```python
+@dataclass
+class Task(EntityBase):
+    """
+    Unified representation - works for all layers:
+    - Property graph vertex (NetworkX)
+    - RDF resource (RDFLib/pyoxigraph)
+    - Vector metadata (FAISS)
+    - HTTP resource (Flask endpoint)
+    """
+    id: VertexId  # Jerry URI: jer:jer:work-tracker:task:TASK-042
+    title: str
+    status: str
+
+    # Netflix UDA: Multiple representations from single source
+    def to_json(self) -> dict: ...
+    def to_toon(self) -> str: ...
+    def to_jsonld(self, context: str) -> dict: ...   # WORK-031
+    def to_turtle(self) -> str: ...                  # WORK-031
+    def to_networkx_node(self) -> Tuple[str, dict]: ... # WORK-032
+    def to_vector_metadata(self) -> dict: ...        # WORK-032
+```
+
+**Implication**: Jerry URI scheme is the **integration keystone**. Already RDF-compatible (WORK-031), already used in Work Tracker (Phase 1).
+
+---
+
+#### 3.3 HybridRAG as Combined Architecture
+
+**Finding**: Both decisions converge on HybridRAG (vector + graph retrieval).
+
+**WORK-031 Description** (from PAT-006):
+```
+User Query: "What tasks block TASK-042?"
+    │
+    ├─ Vector RAG: Embed query → retrieve semantically similar chunks
+    │  └─ Top-5 chunks from docs/ (broad coverage)
+    │
+    ├─ Graph RAG: Parse entities → traverse BLOCKS edges
+    │  └─ Direct relationships from Work Tracker (structured reasoning)
+    │
+    └─ Context Merger: Deduplicate, rank, inject into LLM prompt
+```
+
+**WORK-032 Description** (Three-Tier Architecture):
+```
+Tier 3: AI Layer (Q3 2026)
+├─ RAG: FAISS embeddings over docs/
+├─ GraphRAG: Multi-hop reasoning
+├─ ReAct: Grounded agent workflows
+└─ Source attribution always
+```
+
+**Integration**: Identical architecture, different terminology.
+
+**Unified Implementation Plan**:
+```python
+# Phase 2 (Q1 2026): Vector RAG
+class VectorRAG:
+    def __init__(self, vector_store: VectorStorePort):
+        self.vector_store = vector_store  # FAISS adapter (WORK-032)
+
+    def retrieve(self, query: str, k: int = 5) -> List[Document]:
+        query_vector = embed(query)  # text-embedding-3-small (WORK-031)
+        results = self.vector_store.search(query_vector, k)
+        return [self._load_document(r.id) for r in results]
+
+# Phase 3 (Q2-Q3 2026): Graph RAG
+class GraphRAG:
+    def __init__(self, graph: GraphPort):
+        self.graph = graph  # NetworkX adapter (WORK-032)
+
+    def retrieve(self, entity_id: str, hops: int = 2) -> List[Entity]:
+        # Traverse BLOCKS, DEPENDS_ON, PART_OF edges
+        return self.graph.traverse(entity_id, depth=hops)
+
+# Phase 3 (Q3 2026): Hybrid RAG (combines both)
+class HybridRAG:
+    def __init__(self, vector_rag: VectorRAG, graph_rag: GraphRAG):
+        self.vector_rag = vector_rag
+        self.graph_rag = graph_rag
+
+    def retrieve(self, query: str, context_entities: List[str] = None) -> GroundingContext:
+        # Parallel retrieval (WORK-031 pattern)
+        vector_results = self.vector_rag.retrieve(query, k=5)
+
+        graph_results = []
+        if context_entities:
+            for entity_id in context_entities:
+                graph_results.extend(self.graph_rag.retrieve(entity_id, hops=2))
+
+        # Context merger (WORK-031 Week 5-6 deliverable)
+        merged = self._deduplicate_and_rank(vector_results, graph_results)
+
+        # Jerry URI citations (both decisions)
+        citations = [result.uri for result in merged]
+
+        return GroundingContext(sources=merged, citations=citations)
+```
+
+**Implication**: HybridRAG is the **primary integration point** for AI capabilities. Both decisions align perfectly.
+
+---
+
+#### 3.4 Netflix UDA Pattern as Integration Philosophy
+
+**Finding**: WORK-031 explicitly names Netflix UDA. WORK-032 follows the pattern without naming it.
+
+**Netflix UDA "Model Once, Represent Everywhere"** (PAT-003):
+- Single canonical domain model
+- Multiple serializations via adapters
+- Consistent semantics across representations
+
+**Application to Integration**:
+
+```
+Canonical Domain Model (domain layer)
+    ├─ Task, Phase, Plan entities
+    ├─ BLOCKS, DEPENDS_ON, PART_OF relationships
+    └─ Zero external dependencies
+         ↓
+Multiple Representations (infrastructure layer)
+    ├─ JSON (existing)
+    ├─ TOON (existing)
+    ├─ JSON-LD (WORK-031 Phase 2)
+    ├─ Turtle (WORK-031 Phase 2)
+    ├─ NetworkX Graph (WORK-032 Phase 2)
+    ├─ FAISS Vectors (WORK-032 Phase 2)
+    ├─ RDF Triples (WORK-031 Phase 3)
+    └─ GraphSON (WORK-031 Phase 4)
+```
+
+**Implication**: Integration strategy is already defined by Netflix UDA pattern. No architectural conflict.
+
+---
+
+### 4. Dependency Mapping
+
+#### 4.1 Library Dependency Graph
+
+```
+┌─────────────────────────────────────────────────┐
+│ Domain Layer (ZERO dependencies)                │
+│ ├─ Entities: Task, Phase, Plan                  │
+│ ├─ Ports: GraphPort, RDFSerializerPort, etc.   │
+│ └─ Pure business logic                          │
+└─────────────────────────────────────────────────┘
+                     ↓ depends on
+┌─────────────────────────────────────────────────┐
+│ Infrastructure Layer (Adapter implementations)  │
+│                                                  │
+│ WORK-032 Libraries (Phase 2):                   │
+│ ├─ NetworkX (graph operations)                  │
+│ ├─ RDFLib (RDF serialization)                   │
+│ ├─ FAISS (vector search)                        │
+│ ├─ Docling (document processing)                │
+│ └─ spaCy (entity extraction, optional)          │
+│                                                  │
+│ WORK-031 Libraries (Phase 3):                   │
+│ ├─ pyoxigraph (RDF triple store)                │
+│ └─ MiniCheck (grounding verification, optional) │
+└─────────────────────────────────────────────────┘
+                     ↓ used by
+┌─────────────────────────────────────────────────┐
+│ Application Layer (Use cases - CQRS)            │
+│ ├─ Commands: CreateTask, BuildKnowledgeGraph    │
+│ └─ Queries: FindRelatedDocs, SemanticSearch     │
+└─────────────────────────────────────────────────┘
+                     ↓ invoked by
+┌─────────────────────────────────────────────────┐
+│ Interface Layer (Agents, skills, CLI)           │
+│ ├─ Agents: ps-*, qa-*, security-auditor         │
+│ ├─ Skills: worktracker, problem-solving         │
+│ └─ CLI: jerry knowledge graph/search            │
+└─────────────────────────────────────────────────┘
+```
+
+**Dependencies Installation** (merged from both):
+```bash
+# Phase 2 (Q1 2026)
+pip install networkx==3.2.1     # WORK-032
+pip install rdflib==7.0.0        # WORK-032
+pip install faiss-cpu==1.7.4     # WORK-032
+
+# Phase 3 (Q2-Q3 2026)
+pip install pyoxigraph           # WORK-031
+pip install docling              # WORK-032
+
+# Optional
+pip install spacy                # WORK-032
+python -m spacy download en_core_web_sm
+```
+
+**Implication**: No dependency conflicts. Libraries serve different ports.
+
+---
+
+#### 4.2 Implementation Sequence
+
+**Dependency Order** (what must be built first):
+
+```
+1. Port Definitions (Week 1)
+   ├─ GraphPort
+   ├─ RDFSerializerPort
+   ├─ VectorStorePort
+   └─ KnowledgePort
+        ↓ enables
+2. Basic Adapters (Week 2-3)
+   ├─ NetworkXAdapter → GraphPort
+   ├─ RDFLibAdapter → RDFSerializerPort
+   └─ Documentation: SERIALIZATION_GUIDE.md
+        ↓ enables
+3. Entity Serialization (Week 3-4)
+   ├─ Task.to_jsonld()
+   ├─ Task.to_turtle()
+   ├─ Task.to_networkx_node()
+   └─ SHACL validation shapes
+        ↓ enables
+4. Knowledge Extraction (Week 5-6)
+   ├─ Extract entities from docs/
+   ├─ Build knowledge graph (NetworkX)
+   ├─ Export as RDF (RDFLib)
+   └─ Visualization (Graphviz)
+        ↓ enables
+5. Vector RAG (Week 7-8)
+   ├─ FAISSAdapter → VectorStorePort
+   ├─ Embed documents
+   ├─ Semantic search
+   └─ Integration with agents
+        ↓ enables
+6. GraphRAG (Phase 3)
+   ├─ Graph traversal retrieval
+   ├─ HybridRAG context merger
+   └─ Grounding verification
+```
+
+**Critical Path**: Ports → Adapters → Serialization → Extraction → RAG
+
+**Parallel Work Possible**:
+- JSON-LD context creation (WORK-031) || AAR/A3 templates (WORK-032)
+- SHACL shapes (WORK-031) || Knowledge Audit (WORK-032)
+- NetworkX adapter (WORK-032) || RDFLib adapter (both)
+
+---
+
+#### 4.3 Data Flow Architecture
+
+**Unified data flow** integrating both decisions:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Input Sources                                         │
+│ ├─ docs/ (markdown files) - WORK-032 focus          │
+│ ├─ Work Tracker (tasks, phases) - WORK-031 focus     │
+│ └─ Agent interactions - both                         │
+└──────────────────────────────────────────────────────┘
+                     ↓
+┌──────────────────────────────────────────────────────┐
+│ Extraction Layer (WORK-032)                          │
+│ ├─ Docling: PDF/DOCX → Markdown                     │
+│ ├─ spaCy: Entity extraction                          │
+│ └─ Heuristics: Relationship detection                │
+└──────────────────────────────────────────────────────┘
+                     ↓
+┌──────────────────────────────────────────────────────┐
+│ Storage Layer (Multi-format, Netflix UDA)            │
+│ ├─ Filesystem: Markdown (source of truth)           │
+│ ├─ Property Graph: NetworkX (operations)            │
+│ ├─ RDF: RDFLib/pyoxigraph (semantic export)         │
+│ └─ Vectors: FAISS (semantic search)                 │
+└──────────────────────────────────────────────────────┘
+                     ↓
+┌──────────────────────────────────────────────────────┐
+│ Query Layer                                           │
+│ ├─ Graph Traversal: NetworkX API (WORK-032)         │
+│ ├─ Vector Search: FAISS similarity (WORK-032)       │
+│ ├─ SPARQL Queries: pyoxigraph (WORK-031 Phase 3)    │
+│ └─ HybridRAG: Merged retrieval (both)                │
+└──────────────────────────────────────────────────────┘
+                     ↓
+┌──────────────────────────────────────────────────────┐
+│ Output/Integration                                    │
+│ ├─ Agent grounding: Jerry URI citations             │
+│ ├─ Export: JSON-LD, Turtle, GraphSON                │
+│ ├─ Visualization: Cytoscape.js, Graphviz            │
+│ └─ HTTP: Content negotiation (WORK-031)             │
+└──────────────────────────────────────────────────────┘
+```
+
+**Key Insight**: Data flows through **multiple representations** (Netflix UDA), each optimized for different use cases.
+
+---
+
+### 5. Implementation Sequencing: Unified Roadmap
+
+#### Phase 1: Foundation (✅ COMPLETE)
+
+**Status**: Already implemented.
+
+**Deliverables**:
+- ✅ Property graph abstractions (Vertex, Edge, VertexProperty)
+- ✅ File-based storage (JSON, TOON)
+- ✅ Jerry URI scheme (SPEC-001)
+- ✅ Work Tracker graph model
+- ✅ CloudEvents integration
+
+**From**: Both WORK-031 and WORK-032 recognize this as complete.
+
+---
+
+#### Phase 2: Semantic Layer + KM Foundation (Q1 2026, 8 weeks)
+
+**Unified scope** merging both decisions:
+
+##### Week 1-2: Foundation & Protocols
+
+**From WORK-031**:
+- [ ] Create JSON-LD context (`contexts/worktracker.jsonld`)
+- [ ] Implement supernode validator (100/1000 thresholds)
+- [ ] Document Netflix UDA pattern (`docs/design/MULTI_REPRESENTATION_PATTERN.md`)
+
+**From WORK-032**:
+- [ ] Create AAR template (`.claude/templates/aar-template.md`)
+- [ ] Create A3 template (`.claude/templates/a3-template.md`)
+- [ ] Implement problem-classifier skill (Cynefin-based)
+- [ ] Conduct baseline Knowledge Audit
+
+**Integration**:
+- [ ] Define all ports (`GraphPort`, `RDFSerializerPort`, `VectorStorePort`, `KnowledgePort`)
+- [ ] Install dependencies (`networkx`, `rdflib`, `faiss-cpu`)
+
+##### Week 3-4: RDF Serialization
+
+**From WORK-031**:
+- [ ] RDF serialization adapter (`src/infrastructure/persistence/rdf_adapter.py`)
+- [ ] Implement Turtle serialization
+- [ ] Implement JSON-LD serialization using contexts
+- [ ] SHACL validation shapes (`schemas/worktracker-shapes.ttl`)
+
+**From WORK-032**:
+- [ ] RDFLib adapter implementing `RDFSerializerPort`
+- [ ] Schema.org mapping documentation
+
+**Integration**:
+- [ ] Automated round-trip tests (JSON ↔ TOON ↔ JSON-LD ↔ Turtle)
+
+##### Week 5-6: Graph Layer & Vector Foundation
+
+**From WORK-031**:
+- [ ] Index `docs/` with text-embedding-3-small
+- [ ] Store embeddings in TOON format (metadata)
+
+**From WORK-032**:
+- [ ] NetworkX adapter implementing `GraphPort`
+- [ ] Entity extraction from markdown (`src/infrastructure/extraction/markdown_entities.py`)
+- [ ] Relationship detection (REFERENCES, PART_OF, USES)
+- [ ] CLI: `jerry knowledge graph --query "find related to X"`
+
+**Integration**:
+- [ ] Graph builder command (`src/application/commands/build_knowledge_graph.py`)
+
+##### Week 7-8: Vector RAG & Testing
+
+**From WORK-031**:
+- [ ] Performance benchmarks (property graph <10ms, RDF export <100ms)
+- [ ] Schema evolution integration tests
+- [ ] Contributor guide (`docs/contributing/SERIALIZATION_GUIDE.md`)
+
+**From WORK-032**:
+- [ ] FAISS adapter implementing `VectorStorePort`
+- [ ] Semantic search query (`src/application/queries/semantic_search.py`)
+- [ ] CLI: `jerry knowledge search "semantic query text"`
+
+**Integration**:
+- [ ] HybridRAG foundation (vector + graph retrieval prototyped)
+- [ ] Constitutional amendments (P-030, P-031, P-032)
+
+**Success Criteria** (merged):
+- ✅ All Jerry entities serializable to JSON-LD and Turtle
+- ✅ Property graph queries P95 < 50ms (WORK-031 target)
+- ✅ docs/ indexed into knowledge graph (WORK-032 target)
+- ✅ Semantic search functional (WORK-032 target)
+- ✅ 100% backward compatibility (WORK-031 criterion)
+- ✅ AAR/A3 templates in use (WORK-032 criterion)
+
+---
+
+#### Phase 3: Advanced Capabilities (Q2-Q3 2026, 12 weeks)
+
+**Conditional**: Proceed ONLY if Phase 2 success criteria met.
+
+##### Month 4-5: GraphRAG & Grounding
+
+**From WORK-031**:
+- [ ] Extend Work Tracker entities with embedding properties
+- [ ] HybridRAG context merger (vector + graph)
+- [ ] Jerry URI citations in LLM responses
+- [ ] MiniCheck grounding verification (optional)
+
+**From WORK-032**:
+- [ ] ReAct pattern formalization in problem-solving skill
+- [ ] Agent integration with knowledge retrieval
+- [ ] "Lessons Applied" tracking
+
+**Integration**:
+- [ ] Unified `HybridRAG` class combining both approaches
+- [ ] Knowledge reuse metrics (SECI internalization tracking)
+
+##### Month 5-6: SPARQL & Content Negotiation
+
+**From WORK-031**:
+- [ ] pyoxigraph integration for embedded RDF storage
+- [ ] SPARQL endpoint (Flask + pyoxigraph)
+- [ ] Content negotiation for Jerry URIs
+- [ ] OWL-DL ontology (`ontologies/jerry-ontology.ttl`)
+
+**From WORK-032**:
+- [ ] SECI mode tagging for entities
+- [ ] Knowledge flow pattern analysis
+
+**Integration**:
+- [ ] RDF export via both RDFLib (lightweight) and pyoxigraph (queries)
+- [ ] Map Jerry vocabulary to Schema.org
+
+##### Month 6-7: Visualization & Monitoring
+
+**From WORK-031**:
+- [ ] Cytoscape.js graph visualization
+- [ ] Knowledge architecture health dashboard
+- [ ] CloudEvents alerts for thresholds
+
+**From WORK-032**:
+- [ ] Obsidian integration guide (optional user layer)
+- [ ] Graph visualization export (DOT format)
+
+**Integration**:
+- [ ] Unified monitoring: graph size, query latency, supernode detection
+
+**Success Criteria** (merged):
+- ✅ SPARQL endpoint responds to queries (WORK-031)
+- ✅ GraphRAG demonstrates measurable improvement (both)
+- ✅ Agents retrieve from Jerry knowledge base (both)
+- ✅ Visualization deployed and useful (both)
+
+---
+
+#### Phase 4: Scale & Maturity (Q4 2026+, Optional)
+
+**Trigger Conditions** (from both):
+- Multi-tenant SaaS offering OR
+- > 10M entities OR
+- P95 query latency > 500ms OR
+- Clustering/HA required
+
+**Potential Upgrades**:
+
+**From WORK-031**:
+- [ ] Apache Jena Fuseki or AWS Neptune evaluation
+- [ ] Cloud migration (if triggered)
+- [ ] Advanced reasoning (OWL-DL)
+
+**From WORK-032**:
+- [ ] NetworkX → igraph (if graph >5K nodes)
+- [ ] FAISS CPU → FAISS GPU (if search >1 second)
+- [ ] Neo4j Community Edition (if ACID needed)
+- [ ] ISO 30401 gap analysis and alignment
+
+**Governance**: Quarterly review against trigger conditions.
+
+---
+
+## L2: Strategic Recommendations
+
+### 1. Unified Design Philosophy
+
+**Recommendation**: Treat WORK-031 and WORK-032 as **complementary layers**, not competing alternatives.
+
+```
+WORK-031 = "WHAT" (Architecture & Patterns)
+├─ Semantic web standards (RDF, JSON-LD, SPARQL)
+├─ Validation strategies (SHACL, supernode, grounding)
+├─ Quality attributes (5-star Linked Data, W3C compliance)
+└─ Strategic vision (GraphRAG ROI, interoperability)
+
+WORK-032 = "HOW" (Implementation & Practice)
+├─ Specific libraries (NetworkX, RDFLib, FAISS, Docling)
+├─ Social protocols (AAR, A3, Knowledge Audit)
+├─ Pragmatic architecture (hexagonal, ports/adapters)
+└─ Tactical execution (phased roadmap, effort estimates)
+```
+
+**Integration Principle**: WORK-032 libraries **implement** WORK-031 patterns.
+
+**Analogy**:
+- WORK-031 = Building codes and architectural drawings
+- WORK-032 = Construction materials and techniques
+
+Both are necessary. Neither is sufficient alone.
+
+---
+
+### 2. Merged Architectural Diagram
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 5: Semantic Web Standards (WORK-031 Primary)            │
+│ ├─ 5-Star Linked Open Data                                     │
+│ ├─ W3C RDF 1.2, SPARQL 1.2, JSON-LD 1.1                       │
+│ ├─ Schema.org vocabulary integration                           │
+│ ├─ OWL-DL ontology (jerry-ontology.ttl)                       │
+│ └─ Content negotiation (Accept: application/ld+json, etc.)    │
+└────────────────────────────────────────────────────────────────┘
+                         ↓ implemented via
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 4: Knowledge Management Protocols (WORK-032 Primary)    │
+│ ├─ After-Action Review (AAR)                                   │
+│ ├─ A3 Problem Solving                                          │
+│ ├─ Knowledge Audit (quarterly)                                 │
+│ ├─ SECI Model (knowledge flow tracking)                       │
+│ └─ Cynefin (problem classification)                            │
+└────────────────────────────────────────────────────────────────┘
+                         ↓ operates on
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 3: Hybrid Architecture (Both Decisions)                  │
+│                                                                 │
+│ ┌──────────────────────────────────────────────────────────┐  │
+│ │ Property Graph (WORK-032 NetworkX)                       │  │
+│ │ ├─ Operational queries (fast traversal)                  │  │
+│ │ ├─ Gremlin-style patterns in Python                      │  │
+│ │ └─ Supernode detection (WORK-031 validator)             │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│ ┌──────────────────────────────────────────────────────────┐  │
+│ │ RDF Layer (WORK-031 + WORK-032 RDFLib + pyoxigraph)     │  │
+│ │ ├─ JSON-LD serialization (WORK-031 contexts)            │  │
+│ │ ├─ Turtle export (RDFLib)                                │  │
+│ │ ├─ SPARQL queries (pyoxigraph, Phase 3)                 │  │
+│ │ └─ SHACL validation (WORK-031 shapes)                   │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│ ┌──────────────────────────────────────────────────────────┐  │
+│ │ Vector Search (WORK-032 FAISS)                           │  │
+│ │ ├─ Document embeddings (text-embedding-3-small)          │  │
+│ │ ├─ Semantic similarity search                            │  │
+│ │ ├─ Metadata in TOON (WORK-031 format)                   │  │
+│ │ └─ Index in FAISS (WORK-032 performance)                │  │
+│ └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│ ┌──────────────────────────────────────────────────────────┐  │
+│ │ HybridRAG (Both Decisions)                                │  │
+│ │ ├─ Vector retrieval (FAISS) + Graph traversal (NetworkX) │  │
+│ │ ├─ Context merger (WORK-031 pattern)                     │  │
+│ │ ├─ Jerry URI citations (both)                            │  │
+│ │ └─ Grounding verification (MiniCheck, Phase 3)           │  │
+│ └──────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────┘
+                         ↓ built on
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 2: Infrastructure Adapters (WORK-032 Libraries)         │
+│ ├─ NetworkX 3.2.1 (graph operations)                           │
+│ ├─ RDFLib 7.0.0 (RDF serialization)                            │
+│ ├─ FAISS 1.7.4 (vector search)                                 │
+│ ├─ Docling (document processing)                               │
+│ ├─ spaCy (entity extraction, optional)                         │
+│ └─ pyoxigraph (RDF storage, Phase 3)                           │
+└────────────────────────────────────────────────────────────────┘
+                         ↓ implements ports defined in
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 1: Domain Model (Zero Dependencies)                      │
+│ ├─ Entities: Task, Phase, Plan, Document                       │
+│ ├─ Ports: GraphPort, RDFSerializerPort, VectorStorePort       │
+│ ├─ Validation: Schema, Supernode, Grounding                   │
+│ └─ Jerry URI scheme (SPEC-001)                                 │
+└────────────────────────────────────────────────────────────────┘
+                         ↓ persisted to
+┌────────────────────────────────────────────────────────────────┐
+│ LAYER 0: Filesystem (Both Decisions)                           │
+│ ├─ docs/ (source of truth, markdown)                           │
+│ ├─ Git versioning                                              │
+│ ├─ TOON metadata (human-readable)                             │
+│ └─ Binary indexes (FAISS, pyoxigraph)                         │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Key Insight**: The architecture has **natural layers** where WORK-031 and WORK-032 contributions fit without overlap.
+
+---
+
+### 3. Dependency Matrix
+
+**Which decision provides which component**:
+
+| Component | Source | Phase | Notes |
+|-----------|--------|-------|-------|
+| **Property Graph** | WORK-032 (NetworkX) | 2 | Primary implementation |
+| **Graph Patterns** | WORK-031 (Gremlin examples) | 1-2 | Conceptual guidance |
+| **RDF Serialization** | Both (RDFLib) | 2 | WORK-032 library, WORK-031 spec |
+| **RDF Storage** | WORK-031 (pyoxigraph) | 3 | SPARQL queries |
+| **JSON-LD Contexts** | WORK-031 | 2 | Semantic web integration |
+| **Vector Search** | WORK-032 (FAISS) | 2 | Implementation |
+| **Vector Metadata** | WORK-031 (TOON format) | 2 | Provenance tracking |
+| **Supernode Detection** | WORK-031 | 2 | Validation layer |
+| **SHACL Validation** | WORK-031 | 2 | RDF constraints |
+| **AAR/A3 Protocols** | WORK-032 | 2 | Social processes |
+| **Knowledge Audit** | WORK-032 | 2 | Assessment framework |
+| **Document Processing** | WORK-032 (Docling) | 2 | PDF/DOCX extraction |
+| **Entity Extraction** | WORK-032 (spaCy) | 2-3 | NLP capabilities |
+| **GraphRAG** | WORK-031 | 3 | LLM grounding architecture |
+| **ReAct Pattern** | WORK-032 | 3 | Agent reasoning framework |
+| **SPARQL Endpoint** | WORK-031 | 3 | HTTP queries |
+| **Content Negotiation** | WORK-031 | 3 | Multi-format responses |
+| **ISO 30401 Alignment** | WORK-032 | 4 | KM maturity standard |
+| **5-Star Linked Data** | WORK-031 | 2-3 | Semantic web goal |
+
+**Observation**: Almost **zero redundancy**. Each decision contributes unique components.
+
+---
+
+### 4. Risk Integration
+
+**Combined risk assessment** from both decisions:
+
+| Risk | WORK-031 Assessment | WORK-032 Assessment | Unified Mitigation |
+|------|---------------------|---------------------|-------------------|
+| **Supernode (Actor vertex)** | 9/9 Critical, strong mitigations | Not addressed | ✅ Implement WORK-031 validator in Phase 2 Week 1-2 |
+| **Complexity overhead** | 4/9 Moderate, Netflix UDA mitigation | Inherent in hybrid architecture | ✅ Strict adherence to ports/adapters, round-trip tests |
+| **Premature Phase 4 migration** | 3/9 Low-Moderate, explicit triggers | Not addressed | ✅ Use WORK-031 triggers (>10M entities, multi-tenant) |
+| **Schema evolution breaking** | 6/9 Moderate-High, migration scripts | Not addressed | ✅ Implement P-030 (WORK-031), schema versioning |
+| **Grounding false positives** | 2/9 Low, soft warnings | Not addressed | ✅ Phase 3 optional, confidence tuning |
+| **Knowledge corpus growth** | Not addressed | 4.8/10 High (P=60%, I=8) | ✅ Both: NetworkX → igraph migration path defined |
+| **Dependency abandonment** | Dependency expansion concern | 1.4/10 Medium (P=20%, I=7) | ✅ Both: Hexagonal architecture isolates impact |
+| **Implementation delays** | Not quantified | 2.0/10 Medium (P=40%, I=5) | ✅ Phased approach, MVP in 1 month |
+| **User adoption (protocols)** | Not addressed | 2.0/10 Medium (P=50%, I=4) | ✅ WORK-032: Lightweight AAR (3 questions, <5 min) |
+| **Over-engineering** | Phase gates as mitigation | 1.8/10 Medium (P=30%, I=6) | ✅ Both: YAGNI discipline, quarterly ROI review |
+
+**Unified Risk Profile**: MODERATE (same as WORK-031 conclusion). Combined mitigations are stronger than either decision alone.
+
+---
+
+### 5. Success Metrics (Merged)
+
+**Phase 2 Go/No-Go Gates** (Week 8):
+
+| Metric | WORK-031 Target | WORK-032 Target | Unified Target |
+|--------|-----------------|-----------------|----------------|
+| **Backward Compatibility** | 100% tests passing | Not specified | 100% Phase 1 tests passing |
+| **Property Graph Query Latency P95** | < 50ms | Not specified | < 50ms (WORK-031) |
+| **RDF Export Latency P95** | < 100ms | Not specified | < 100ms (WORK-031) |
+| **Vector Search Latency** | Not specified | < 2 seconds | < 2s (WORK-032) |
+| **Round-Trip Serialization** | 100% success | Not specified | 100% (all formats) |
+| **Knowledge Graph Size** | Not specified | 500+ nodes by Q2 | 500+ nodes |
+| **docs/ Coverage** | Not specified | 80% by Q3 | 80% indexed |
+| **AAR/A3 Adoption** | Not specified | 50% work items by Q2 | 50% compliance |
+| **Contributor Onboarding** | < 4 hours | Not specified | < 4 hours (WORK-031) |
+
+**Phase 3 Success Criteria**:
+
+| Metric | WORK-031 | WORK-032 | Unified |
+|--------|----------|----------|---------|
+| **Hallucination Reduction** | Measurable via baseline comparison | Qualitative improvement | Baseline → RAG comparison with user evaluation |
+| **SPARQL Endpoint** | Responds to queries | Not applicable | Test query succeeds |
+| **GraphRAG Impact** | HybridRAG measurable | Concepts applied to new problems | Quantitative + qualitative |
+| **Knowledge Reuse** | Not specified | 15-25% reduced duplicate work | Track via "Lessons Applied" |
+| **Time Saved** | Not specified | 10-20% finding information | Time-tracking baseline |
+
+---
+
+### 6. Constitutional Amendments (WORK-031 Proposals)
+
+**Recommendation**: Adopt all three new principles proposed by WORK-031.
+
+#### P-030: Schema Evolution Governance (Hard Principle)
+
+**Text**:
+> All graph schema changes MUST:
+> 1. Be documented in schema changelog
+> 2. Include forward migration script
+> 3. Include rollback migration script
+> 4. Pass validation tests before deployment
+>
+> Rationale: Schema changes affect traversal semantics and query assumptions.
+
+**WORK-032 Compatibility**: ✅ No conflicts. WORK-032 doesn't address schema evolution.
+
+**Integration**: Create `docs/specifications/SCHEMA_CHANGELOG.md` in Phase 2.
+
+---
+
+#### P-031: Supernode Prevention (Medium Principle)
+
+**Text**:
+> Vertices SHOULD be validated for edge degree:
+> - Warning threshold: 100 edges of same label
+> - Error threshold: 1000 edges of same label
+> - HIGH-risk vertices (Actor) require mitigation strategy
+>
+> Rationale: Supernodes degrade performance catastrophically.
+
+**WORK-032 Compatibility**: ✅ No conflicts. Complements WORK-032's performance focus.
+
+**Integration**: Implement `SupernodeValidator` in Phase 2 Week 1-2.
+
+---
+
+#### P-032: Phase Gate Compliance (Medium Principle)
+
+**Text**:
+> Phase transitions MUST meet explicit go/no-go criteria. Proceed to Phase N+1 ONLY if:
+> 1. All Phase N success criteria met
+> 2. User validation confirms value delivered
+> 3. No unresolved critical risks
+>
+> Rationale: Prevents premature optimization and scope creep.
+
+**WORK-032 Compatibility**: ✅ Reinforces WORK-032's phased approach.
+
+**Integration**: Both decisions already follow this implicitly. Formalize in constitution.
+
+---
+
+### 7. Unified Timeline
+
+```
+2026 Q1 (Phase 2: 8 weeks)
+├─ Week 1-2: Ports + JSON-LD + AAR/A3 + Supernode Validator
+├─ Week 3-4: RDF Serialization (RDFLib) + SHACL
+├─ Week 5-6: Graph Layer (NetworkX) + Entity Extraction
+└─ Week 7-8: Vector RAG (FAISS) + Integration Testing
+    └─ Go/No-Go Gate: All Phase 2 success criteria
+
+2026 Q2-Q3 (Phase 3: 12 weeks)
+├─ Month 4-5: GraphRAG + HybridRAG + Jerry URI Citations
+├─ Month 5-6: SPARQL Endpoint (pyoxigraph) + OWL Ontology
+└─ Month 6-7: Visualization + Monitoring Dashboard
+    └─ Go/No-Go Gate: User validation, measurable impact
+
+2026 Q4+ (Phase 4: Triggered)
+└─ IF (multi-tenant OR >10M entities OR P95>500ms OR HA required)
+    THEN evaluate server-based (Fuseki/Neptune/Neo4j)
+    ELSE remain on embedded Phase 2-3 architecture
+```
+
+**Key Dates**:
+- **2026-01-09** (today): Integration analysis complete
+- **2026-02-28**: Phase 2 complete, go/no-go decision
+- **2026-06-30**: Phase 3 complete, Phase 4 evaluation
+
+---
+
+## Integration Diagram (ASCII)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                   JERRY UNIFIED KNOWLEDGE ARCHITECTURE                │
+│              Integration of WORK-031 + WORK-032                       │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ USER/AGENT INTERACTIONS                                              │
+│ ├─ Claude Code agents                                                │
+│ ├─ Skills (worktracker, problem-solving)                            │
+│ ├─ CLI (jerry knowledge graph/search)                               │
+│ └─ Optional: Obsidian UI, Wiki.js                                   │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓ queries
+┌─────────────────────────────────────────────────────────────────────┐
+│ HYBRID RETRIEVAL LAYER (HybridRAG)                                  │
+│                                                                       │
+│  ┌─────────────────────┐    ┌─────────────────────┐                │
+│  │ Vector RAG          │    │ Graph RAG           │                │
+│  │ (WORK-032 FAISS)    │◄──►│ (WORK-032 NetworkX) │                │
+│  │                     │    │                     │                │
+│  │ Semantic similarity │    │ Relational          │                │
+│  │ search over docs/   │    │ traversal (BLOCKS,  │                │
+│  │                     │    │ DEPENDS_ON)         │                │
+│  └─────────────────────┘    └─────────────────────┘                │
+│              │                        │                              │
+│              └────────┬───────────────┘                              │
+│                       ↓                                              │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │ Context Merger (WORK-031 pattern)                            │  │
+│  │ ├─ Deduplicate results                                        │  │
+│  │ ├─ Rank by relevance                                          │  │
+│  │ ├─ Add Jerry URI citations                                    │  │
+│  │ └─ [Phase 3] Grounding verification (MiniCheck)              │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓ retrieves from
+┌─────────────────────────────────────────────────────────────────────┐
+│ MULTI-REPRESENTATION STORAGE (Netflix UDA Pattern)                  │
+│                                                                       │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ FILESYSTEM (Source of Truth)                                 │   │
+│  │ docs/ ──> Markdown files                                     │   │
+│  │    └─ Git versioning, TOON metadata                          │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                                                                       │
+│  ┌─────────────────────┐  ┌─────────────────────┐  ┌────────────┐ │
+│  │ Property Graph      │  │ RDF Layer           │  │ Vector DB  │ │
+│  │ (NetworkX)          │  │ (RDFLib/pyoxigraph) │  │ (FAISS)    │ │
+│  │                     │  │                     │  │            │ │
+│  │ • Fast traversal    │  │ • JSON-LD export    │  │ • Semantic │ │
+│  │ • Gremlin patterns  │  │ • Turtle format     │  │   search   │ │
+│  │ • Supernode detect  │  │ • SPARQL (Phase 3)  │  │ • Top-K    │ │
+│  │   (WORK-031)        │  │   (WORK-031)        │  │   results  │ │
+│  │                     │  │ • SHACL validation  │  │            │ │
+│  │ WORK-032            │  │   (WORK-031)        │  │ WORK-032   │ │
+│  │ NetworkX adapter    │  │                     │  │ FAISS      │ │
+│  └─────────────────────┘  └─────────────────────┘  └────────────┘ │
+│           ↕                         ↕                       ↕       │
+│  ┌───────────────────────────────────────────────────────────────┐ │
+│  │ ENTITY SERIALIZERS (Netflix UDA)                             │ │
+│  │ Task.to_json() | .to_toon() | .to_jsonld() | .to_turtle()   │ │
+│  │      │               │              │              │          │ │
+│  │  WORK-031        WORK-031       WORK-031       WORK-031      │ │
+│  │  existing        existing       Phase 2        Phase 2       │ │
+│  └───────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓ implements
+┌─────────────────────────────────────────────────────────────────────┐
+│ PORTS & ADAPTERS (Hexagonal Architecture)                           │
+│                                                                       │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
+│  │ GraphPort        │  │ RDFSerializerPort│  │ VectorStorePort  │  │
+│  │ (Domain)         │  │ (Domain)         │  │ (Domain)         │  │
+│  │                  │  │                  │  │                  │  │
+│  │ Zero deps        │  │ Zero deps        │  │ Zero deps        │  │
+│  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘  │
+│           │                     │                      │             │
+│           ↓                     ↓                      ↓             │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
+│  │ NetworkXAdapter  │  │ RDFLibAdapter    │  │ FAISSAdapter     │  │
+│  │ (Infrastructure) │  │ (Infrastructure) │  │ (Infrastructure) │  │
+│  │                  │  │                  │  │                  │  │
+│  │ WORK-032         │  │ WORK-032         │  │ WORK-032         │  │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘  │
+│                                                                       │
+│  Additional adapters (Phase 3):                                     │
+│  └─ PyoxigraphAdapter (WORK-031) → RDFStorePort                     │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓ validated by
+┌─────────────────────────────────────────────────────────────────────┐
+│ VALIDATION LAYERS (Defense-in-Depth)                                │
+│                                                                       │
+│  Layer 1: Schema Validation (WORK-031)                              │
+│  Layer 2: Graph Structure (WORK-031 Supernode Detection)            │
+│  Layer 3: Semantic Integrity (WORK-031 SHACL + Content Negotiation) │
+│  Layer 4: Process Compliance (WORK-032 AAR/A3/Knowledge Audit)      │
+│  Layer 5: LLM Grounding (WORK-031 MiniCheck + WORK-032 Attribution) │
+└─────────────────────────────────────────────────────────────────────┘
+                              ↓ governed by
+┌─────────────────────────────────────────────────────────────────────┐
+│ JERRY CONSTITUTION (Extended)                                        │
+│                                                                       │
+│  Existing Principles:                                                │
+│  ├─ P-001: Truth and Accuracy (reinforced by grounding)             │
+│  ├─ P-002: File Persistence (filesystem remains source of truth)    │
+│  ├─ P-003: No Recursive Subagents (ReAct uses tools)                │
+│  ├─ P-020: User Authority (phase gates require approval)            │
+│  └─ P-022: No Deception (Jerry URI citations)                       │
+│                                                                       │
+│  New Principles (WORK-031):                                          │
+│  ├─ P-030: Schema Evolution Governance                              │
+│  ├─ P-031: Supernode Prevention                                     │
+│  └─ P-032: Phase Gate Compliance                                    │
+└─────────────────────────────────────────────────────────────────────┘
+
+LEGEND:
+├─ Solid lines: Data flow
+◄─►: Bidirectional integration
+└─: Component hierarchy
+WORK-031: Semantic web architecture decision
+WORK-032: Knowledge management implementation decision
+```
+
+---
+
+## Key Findings Summary
+
+### ✅ Strong Alignment (No Conflicts)
+
+1. **Architectural Pattern**: Both recommend hybrid property graph + RDF (unanimous)
+2. **Implementation Phases**: Both use 4-phase roadmap (Q1-Q4 2026)
+3. **Technology Philosophy**: Both prefer embedded-first, scale-later
+4. **LLM Strategy**: Both emphasize HybridRAG for grounding
+5. **Hexagonal Architecture**: Both respect ports/adapters pattern
+6. **Constitutional Alignment**: Both reinforce existing principles
+
+### 🔄 Integration Needed (Minor Gaps)
+
+1. **RDF Libraries**: Use BOTH (RDFLib Phase 2, pyoxigraph Phase 3)
+2. **Vector Storage**: Use BOTH (FAISS for indexing, TOON for metadata)
+3. **Phase 2 Scope**: Merge into unified 8-week plan
+4. **Validation Layers**: Combine technical (WORK-031) + social (WORK-032)
+5. **Constitutional Extensions**: Adopt P-030, P-031, P-032 from WORK-031
+
+### ⚠️ No Conflicts Found
+
+**Zero architectural contradictions**. The decisions are complementary layers:
+- WORK-031 = Semantic web "what to build"
+- WORK-032 = Practical implementation "how to build it"
+
+### 🎯 Recommended Actions
+
+1. **Immediate (This Week)**:
+   - Create unified Phase 2 implementation plan
+   - Define all ports (Graph, RDF, Vector, Knowledge)
+   - Adopt P-030, P-031, P-032 constitutional amendments
+
+2. **Phase 2 Start (Week 1-2)**:
+   - Implement adapters: NetworkX, RDFLib, FAISS
+   - Create JSON-LD contexts (WORK-031)
+   - Create AAR/A3 templates (WORK-032)
+   - Implement supernode validator (WORK-031)
+
+3. **Ongoing**:
+   - Treat decisions as unified architecture
+   - Reference both ADRs in implementation docs
+   - Use merged success criteria for Phase 2 go/no-go
+
+---
+
+## Conclusion
+
+**WORK-031 (Knowledge Architecture) and WORK-032 (KM Integration) are highly compatible and mutually reinforcing.** They represent different but complementary perspectives on Jerry's knowledge system:
+
+- **WORK-031** provides the semantic web vision, standards compliance, and quality attributes
+- **WORK-032** provides the implementation libraries, social protocols, and pragmatic execution plan
+
+**The integration is natural because**:
+1. Both independently converged on hybrid architecture (property graph + RDF + vectors)
+2. Technology choices are complementary, not redundant (NetworkX, RDFLib, FAISS from WORK-032 implement patterns from WORK-031)
+3. Hexagonal architecture enables clean separation (ports from both, adapters from WORK-032)
+4. Jerry URI scheme serves as unified identifier across all layers
+5. Netflix UDA pattern (shared by both) provides integration philosophy
+
+**Recommendation**: Implement both decisions **together as a unified roadmap**, not sequentially. The merged Phase 2 (Q1 2026, 8 weeks) combines the best of both: semantic web standards (WORK-031) with practical Python libraries (WORK-032), technical validation (WORK-031) with social protocols (WORK-032), and architectural vision (WORK-031) with tactical execution (WORK-032).
+
+**Risk Assessment**: MODERATE (unchanged from individual decisions). Combined mitigations are stronger.
+
+**Confidence**: 95% (HIGH). Strong convergent evidence, zero conflicts, clear integration path.
+
+---
+
+**File**: `/home/user/jerry/docs/research/work-033-e-001-integration-analysis.md`
+**Date**: 2026-01-09
+**Agent**: ps-researcher v2.0.0
+**Status**: COMPLETE
+**Word Count**: ~11,500 words
+**Integration Quality**: HIGH (zero conflicts, natural layering, merged roadmap)
+
+---
+
+*Analysis Method: Multi-document integration analysis with dependency mapping*
+*Decisions Analyzed: ADR-031 (Knowledge Architecture), ADR-032 (KM Integration)*
+*Supporting Documents: work-031-e-006-synthesis.md, work-032-e-006-km-synthesis.md*
+*Constitution Compliance: P-001 (all claims cited), P-002 (analysis persisted), P-004 (reasoning documented)*

--- a/docs/archive/projects-archive/research/work-034-e-001-domain-analysis.md
+++ b/docs/archive/projects-archive/research/work-034-e-001-domain-analysis.md
@@ -1,0 +1,2202 @@
+# WORK-034 Domain Analysis: Work Tracker + Knowledge Management
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **PS ID** | work-034 |
+| **Entry ID** | e-001 |
+| **Date** | 2026-01-09 |
+| **Author** | ps-researcher v2.0.0 |
+| **Input Size** | ~355KB (WORK-033 outputs + WORK_TRACKER_PLAN.md) |
+| **Output Target** | 60-80KB (high-fidelity analysis) |
+| **Status** | COMPLETE |
+
+---
+
+## Executive Summary
+
+This comprehensive domain analysis examines two bounded contexts within the Jerry Framework: **Work Tracker** (from WORK_TRACKER_PLAN.md) and **Knowledge Management** (from WORK-033 ADR-033 and related documents). The purpose is to identify synergies, integration points, and a unified domain model that enables Work Tracker to serve as a proving ground for Knowledge Management patterns.
+
+**Key Findings:**
+
+1. **Architectural Convergence**: Both domains independently adopted identical architectural patterns - Hexagonal Architecture (Ports & Adapters), CQRS, Event Sourcing, and CloudEvents 1.0 compliance. This convergence is not coincidental but reflects shared design philosophy: the filesystem as source of truth, pure domain layer with zero dependencies, and separation of concerns through ports.
+
+2. **Entity Relationship Potential**: Work Tracker entities (Task, Phase, Plan) naturally produce Knowledge Management entities (Lesson, Pattern, Assumption). A Task completion can generate a Lesson; Phase patterns emerge from task aggregation; Plans track Assumptions requiring validation. These relationships form bidirectional graph edges enabling knowledge discovery.
+
+3. **Shared Infrastructure Opportunity**: Both domains require the same infrastructure components: Event Store for domain events, Graph Store (NetworkX) for relationship traversal, Semantic Index (FAISS) for discovery, and RDF Serialization (RDFLib) for standards compliance. Implementing these once for Work Tracker validates them for KM at larger scale.
+
+4. **Work Tracker as Proving Ground**: With ~500 expected nodes vs. KM's 5,000+ target, Work Tracker provides a smaller blast radius for validating KM infrastructure. Faster feedback loops (days vs. weeks) enable iterative refinement before KM rollout.
+
+**Recommendation**: Implement unified domain model with Work Tracker as Phase 1 validation of KM infrastructure patterns. The shared hexagonal architecture enables clean integration without domain coupling.
+
+---
+
+## 1. Work Tracker Domain Analysis
+
+### 1.1 Domain Overview
+
+The Work Tracker bounded context is Jerry's core operational subdomain, providing a local Azure DevOps/JIRA alternative that persists task state across Claude Code agent sessions. It directly addresses the **Context Rot** challenge documented in Chroma Research: LLM performance degrades as context windows fill, even within technical token limits.
+
+**Bounded Context Definition:**
+
+| Attribute | Value |
+|-----------|-------|
+| **Context Name** | Work Tracker |
+| **Subdomain Type** | Core Subdomain |
+| **Primary Actor** | Claude Code Agent |
+| **Secondary Actors** | Human Developer, QA Agent, Security Agent |
+| **Ubiquitous Language** | Task, Phase, Plan, Sprint, WorkItem, Status, Priority |
+
+**Domain Problem Statement:**
+
+> Claude Code agents lose task context during session compaction. External memory via Work Tracker persists state outside the context window, enabling resumption of complex multi-session work.
+
+**Strategic Importance:**
+
+Work Tracker is classified as a **Core Subdomain** because:
+1. It directly enables Jerry's mission of solving problems across sessions
+2. It contains unique business logic (task hierarchies, state machines, priority ordering)
+3. It cannot be replaced by commodity solutions due to tight Claude Code integration
+
+### 1.2 Aggregate Roots
+
+Work Tracker defines three aggregate roots, each encapsulating a distinct cluster of entities and enforcing invariants.
+
+#### 1.2.1 WorkItem Aggregate (Primary)
+
+The WorkItem aggregate is the central element of Work Tracker, representing units of work tracked across sessions.
+
+```
+<<Aggregate Root>>
+WorkItem
+├── Identity: WorkItemId (WORK-001, WORK-002, ...)
+├── Lifecycle: Status state machine
+├── Relationships: Parent-child hierarchy
+├── Audit: Creation, modification, completion timestamps
+└── Events: WorkItemCreated, WorkItemStarted, WorkItemCompleted, etc.
+```
+
+**Aggregate Invariants:**
+
+| Invariant | Enforcement | Violation Response |
+|-----------|-------------|-------------------|
+| Title must be non-empty, max 200 characters | Constructor validation | ValidationError |
+| Status transitions follow state machine | `_validate_state_transition()` method | InvalidStateTransitionError |
+| Tasks can only have Features/Epics as parents | `_validate_hierarchy()` method | InvalidHierarchyError |
+| Completed items cannot be modified (except reopen) | Status check in command methods | InvalidStateError |
+| WorkItemId is globally unique | Repository generates next ID | N/A (system-enforced) |
+
+**State Machine:**
+
+```
+                          start()
+        PENDING ────────────────────────► IN_PROGRESS
+            ▲                                   │
+            │                                   │ block()
+            │                                   ▼
+            │       unblock()             BLOCKED
+            │◄────────────────────────────────│
+            │                                   │
+            │ reopen()                          │ complete()
+            │                                   ▼
+        COMPLETED ◄────────────────────────────┘
+```
+
+**Valid State Transitions:**
+
+| From State | To State | Trigger | Event Emitted |
+|------------|----------|---------|---------------|
+| PENDING | IN_PROGRESS | `start()` | WorkItemStarted |
+| IN_PROGRESS | BLOCKED | `block(reason)` | WorkItemBlocked |
+| IN_PROGRESS | COMPLETED | `complete(notes)` | WorkItemCompleted |
+| BLOCKED | IN_PROGRESS | `unblock()` | WorkItemUnblocked |
+| COMPLETED | PENDING | `reopen()` | WorkItemReopened |
+
+#### 1.2.2 Project Aggregate (Secondary)
+
+The Project aggregate groups related WorkItems and provides organizational context.
+
+```
+<<Aggregate Root>>
+Project
+├── Identity: ProjectId
+├── WorkItems: References to WorkItemIds (not embedded)
+├── Metadata: Name, description, owner
+└── Events: ProjectCreated, WorkItemAddedToProject
+```
+
+#### 1.2.3 Sprint Aggregate (Secondary)
+
+The Sprint aggregate represents time-boxed iterations containing WorkItems.
+
+```
+<<Aggregate Root>>
+Sprint
+├── Identity: SprintId
+├── TimeBox: Start date, end date
+├── WorkItems: References to WorkItemIds
+├── Velocity: Planned vs actual points
+└── Events: SprintCreated, SprintStarted, SprintCompleted
+```
+
+### 1.3 Entities and Value Objects
+
+#### 1.3.1 Entities
+
+| Entity | Attributes | Purpose |
+|--------|------------|---------|
+| **WorkItem** | id, title, description, type, status, priority, parent_id, created_at, updated_at, completed_at, notes, tags | Primary work tracking unit |
+| **Note** | content, created_at, author | Timestamped observations on work items |
+
+#### 1.3.2 Value Objects
+
+| Value Object | Attributes | Invariants |
+|--------------|------------|------------|
+| **WorkItemId** | value: str | Pattern: `^WORK-[0-9]+$`, immutable |
+| **Status** | Enum: PENDING, IN_PROGRESS, BLOCKED, COMPLETED | Valid transitions enforced |
+| **Priority** | Enum: CRITICAL=1, HIGH=2, MEDIUM=3, LOW=4 | Comparable for sorting |
+| **WorkItemType** | Enum: EPIC, FEATURE, TASK, BUG, SPIKE | Hierarchy rules: only epic/feature can have children |
+| **Tag** | name: str, color: str | Immutable, comparable |
+
+**Value Object Implementation Patterns:**
+
+```python
+# WorkItemId - Strongly typed ID with generation
+@dataclass(frozen=True)
+class WorkItemId:
+    value: str
+    prefix: ClassVar[str] = "WORK"
+
+    def __post_init__(self):
+        if not re.match(r"^WORK-[0-9]+$", self.value):
+            raise ValueError(f"Invalid WorkItemId format: {self.value}")
+
+    @classmethod
+    def generate(cls, sequence: int) -> "WorkItemId":
+        return cls(f"WORK-{sequence:03d}")
+
+# Status - Enum with transition validation
+class Status(Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+
+    def can_transition_to(self, target: "Status") -> bool:
+        transitions = {
+            Status.PENDING: {Status.IN_PROGRESS},
+            Status.IN_PROGRESS: {Status.BLOCKED, Status.COMPLETED},
+            Status.BLOCKED: {Status.IN_PROGRESS},
+            Status.COMPLETED: {Status.PENDING},
+        }
+        return target in transitions.get(self, set())
+```
+
+### 1.4 Domain Events
+
+Work Tracker emits domain events following CloudEvents 1.0 specification for loose coupling and audit trail.
+
+#### 1.4.1 Event Catalog
+
+| Event Type | Aggregate | Trigger | Payload Fields |
+|------------|-----------|---------|----------------|
+| `WorkItemCreated` | WorkItem | Factory method `create()` | title, type, priority |
+| `WorkItemStarted` | WorkItem | `start()` | (none additional) |
+| `WorkItemBlocked` | WorkItem | `block(reason)` | reason |
+| `WorkItemUnblocked` | WorkItem | `unblock()` | (none additional) |
+| `WorkItemCompleted` | WorkItem | `complete(notes)` | completed_at, notes |
+| `WorkItemReopened` | WorkItem | `reopen()` | (none additional) |
+| `WorkItemUpdated` | WorkItem | `update_*()` methods | field, old_value, new_value |
+| `NoteAdded` | WorkItem | `add_note(content)` | note_content |
+| `TagAdded` | WorkItem | `add_tag(tag)` | tag_name |
+| `TagRemoved` | WorkItem | `remove_tag(tag)` | tag_name |
+
+#### 1.4.2 Event Schema (CloudEvents 1.0)
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/domain-event.json",
+  "title": "DomainEvent",
+  "type": "object",
+  "required": ["event_id", "event_type", "aggregate_id", "aggregate_type", "occurred_at", "version"],
+  "properties": {
+    "event_id": {"type": "string", "format": "uuid"},
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "WorkItemCreated", "WorkItemUpdated", "WorkItemStarted",
+        "WorkItemBlocked", "WorkItemUnblocked", "WorkItemCompleted",
+        "WorkItemReopened", "NoteAdded", "TagAdded", "TagRemoved"
+      ]
+    },
+    "aggregate_id": {"type": "string"},
+    "aggregate_type": {"type": "string", "enum": ["WorkItem", "Project", "Sprint"]},
+    "occurred_at": {"type": "string", "format": "date-time"},
+    "version": {"type": "integer", "minimum": 1},
+    "payload": {"type": "object"}
+  }
+}
+```
+
+#### 1.4.3 Event Sourcing Pattern
+
+WorkItem aggregates support reconstitution from events:
+
+```python
+class WorkItem:
+    @classmethod
+    def reconstitute(cls, events: list[DomainEvent]) -> "WorkItem":
+        """Rebuild aggregate state from event history."""
+        item = cls.__new__(cls)
+        for event in events:
+            item._apply(event)
+        return item
+
+    def _apply(self, event: DomainEvent) -> None:
+        """Apply event to update internal state."""
+        handler = getattr(self, f"_on_{event.event_type}", None)
+        if handler:
+            handler(event.payload)
+```
+
+### 1.5 Use Cases (CQRS)
+
+#### 1.5.1 Commands (Write Operations)
+
+| Command | Handler | Preconditions | Postconditions | Events |
+|---------|---------|---------------|----------------|--------|
+| `CreateWorkItemCommand` | `CreateWorkItemHandler` | Valid title, type | Item exists with PENDING status | WorkItemCreated |
+| `UpdateWorkItemCommand` | `UpdateWorkItemHandler` | Item exists, valid field values | Item updated | WorkItemUpdated |
+| `CompleteWorkItemCommand` | `CompleteWorkItemHandler` | Item exists, status allows completion | Status = COMPLETED | WorkItemCompleted |
+| `StartWorkItemCommand` | `StartWorkItemHandler` | Item exists, status = PENDING | Status = IN_PROGRESS | WorkItemStarted |
+| `BlockWorkItemCommand` | `BlockWorkItemHandler` | Item exists, status = IN_PROGRESS | Status = BLOCKED | WorkItemBlocked |
+| `UnblockWorkItemCommand` | `UnblockWorkItemHandler` | Item exists, status = BLOCKED | Status = IN_PROGRESS | WorkItemUnblocked |
+| `ReopenWorkItemCommand` | `ReopenWorkItemHandler` | Item exists, status = COMPLETED | Status = PENDING | WorkItemReopened |
+
+**Command Structure:**
+
+```python
+@dataclass
+class CreateWorkItemCommand:
+    title: str                          # Required
+    description: str = ""               # Optional
+    type: str = "task"                  # Default to task
+    priority: str = "medium"            # Default priority
+    parent_id: str | None = None        # Optional parent
+    tags: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        if not self.title or len(self.title) > 200:
+            raise ValidationError("Title must be 1-200 characters")
+        if self.type not in ["epic", "feature", "task", "bug", "spike"]:
+            raise ValidationError(f"Invalid type: {self.type}")
+```
+
+#### 1.5.2 Queries (Read Operations)
+
+| Query | Handler | Parameters | Returns |
+|-------|---------|------------|---------|
+| `GetWorkItemQuery` | `GetWorkItemHandler` | id: str | WorkItemDTO or None |
+| `ListWorkItemsQuery` | `ListWorkItemsHandler` | status[], priority[], type[], parent_id, limit, offset, sort_by | list[WorkItemSummaryDTO] |
+| `SearchWorkItemsQuery` | `SearchWorkItemsHandler` | query: str, include_completed, limit | list[WorkItemSummaryDTO] |
+| `GetWorkTrackerStatsQuery` | `GetStatsHandler` | time_range (optional) | WorkTrackerStatsDTO |
+
+**Query Structure:**
+
+```python
+@dataclass
+class ListWorkItemsQuery:
+    status: list[str] | None = None     # Filter by status
+    priority: list[str] | None = None   # Filter by priority
+    type: list[str] | None = None       # Filter by type
+    parent_id: str | None = None        # Filter by parent
+    limit: int = 50                     # Pagination
+    offset: int = 0                     # Pagination
+    sort_by: str = "created_at"         # Sort field
+    sort_order: str = "desc"            # asc/desc
+```
+
+### 1.6 Ports and Adapters (Hexagonal Architecture)
+
+#### 1.6.1 Port Interfaces (Domain Layer)
+
+```python
+# IWorkItemRepository - Persistence Port
+class IWorkItemRepository(Protocol):
+    def save(self, item: WorkItem) -> None: ...
+    def get(self, id: WorkItemId) -> WorkItem | None: ...
+    def get_all(self) -> list[WorkItem]: ...
+    def get_by_status(self, status: Status) -> list[WorkItem]: ...
+    def get_by_parent(self, parent_id: WorkItemId) -> list[WorkItem]: ...
+    def delete(self, id: WorkItemId) -> None: ...
+    def exists(self, id: WorkItemId) -> bool: ...
+    def next_id(self) -> WorkItemId: ...
+
+# IEventStore - Event Sourcing Port
+class IEventStore(Protocol):
+    def append(self, aggregate_id: str, events: list[DomainEvent]) -> None: ...
+    def get_events(self, aggregate_id: str) -> list[DomainEvent]: ...
+    def get_events_since(self, aggregate_id: str, version: int) -> list[DomainEvent]: ...
+    def get_all_events(self) -> list[DomainEvent]: ...
+
+# IEventDispatcher - Pub/Sub Port
+class IEventDispatcher(Protocol):
+    def dispatch(self, event: DomainEvent) -> None: ...
+    def dispatch_all(self, events: list[DomainEvent]) -> None: ...
+    def subscribe(self, event_type: str, handler: Callable) -> None: ...
+
+# IUnitOfWork - Transaction Port
+class IUnitOfWork(Protocol):
+    work_items: IWorkItemRepository
+    def __enter__(self) -> "IUnitOfWork": ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...
+```
+
+#### 1.6.2 Adapter Implementations (Infrastructure Layer)
+
+| Port | Adapter | Technology | Location |
+|------|---------|------------|----------|
+| `IWorkItemRepository` | `SQLiteRepository` | SQLite | `src/infrastructure/persistence/sqlite/` |
+| `IEventStore` | `SQLiteEventStore` | SQLite | `src/infrastructure/persistence/sqlite/` |
+| `IEventDispatcher` | `InMemoryEventDispatcher` | Python dict | `src/infrastructure/messaging/` |
+| `IUnitOfWork` | `SQLiteUnitOfWork` | SQLite transaction | `src/infrastructure/persistence/sqlite/` |
+
+**Dependency Rule Enforcement:**
+
+```
+interface/     → application/, infrastructure/, domain/
+application/   → domain/ ONLY
+infrastructure/→ domain/, application/
+domain/        → NOTHING (stdlib only)
+```
+
+---
+
+## 2. Knowledge Management Domain Analysis
+
+### 2.1 Domain Overview
+
+The Knowledge Management bounded context extends Jerry's mission of solving problems to **accruing a body of knowledge, wisdom, and experience**. It addresses the challenge that knowledge accumulates across Work Tracker entities and documentation but exists as isolated silos without semantic connections.
+
+**Bounded Context Definition:**
+
+| Attribute | Value |
+|-----------|-------|
+| **Context Name** | Knowledge Management |
+| **Subdomain Type** | Supporting Subdomain |
+| **Primary Actor** | Claude Code Agent, ps-* Agents |
+| **Secondary Actors** | Human Developer (reviewer/validator) |
+| **Ubiquitous Language** | Pattern, Lesson, Assumption, KnowledgeItem, Evidence, Validation |
+
+**Domain Problem Statement:**
+
+> Jerry agents cannot answer "what relates to X?" without manual cross-referencing. Knowledge discovered during work is not systematically captured, validated, or reused. LLM agents lack grounding mechanisms, leading to hallucinations.
+
+**Strategic Importance:**
+
+Knowledge Management is classified as a **Supporting Subdomain** because:
+1. It enhances Work Tracker value by capturing lessons learned
+2. It provides competitive differentiation through accumulated wisdom
+3. It enables LLM grounding via GraphRAG retrieval
+
+### 2.2 Aggregate Roots
+
+KM defines a single aggregate root with three specialized content types.
+
+#### 2.2.1 KnowledgeItem Aggregate
+
+```
+<<Aggregate Root>>
+KnowledgeItem (extends Vertex)
+├── Identity: KnowledgeItemId (PAT-001, LES-042, ASM-003)
+├── Type: KnowledgeType (PATTERN, LESSON, ASSUMPTION)
+├── Status: KnowledgeStatus lifecycle
+├── Content: Discriminated union (Pattern | Lesson | Assumption)
+├── Relationships: Graph edges to other KnowledgeItems, Tasks, Evidence
+└── Events: KnowledgeItemCreated, KnowledgeItemValidated, KnowledgeItemDeprecated
+```
+
+**Aggregate Invariants:**
+
+| Invariant | Enforcement | Violation Response |
+|-----------|-------------|-------------------|
+| ID prefix matches km_type | Constructor validation | ValueError |
+| Content type matches km_type | Type checking | TypeError |
+| Status transitions follow lifecycle | `validate()`, `deprecate()` methods | ValueError |
+| Title max 80 characters | Constructor validation | ValueError |
+| Evidence URIs are valid Jerry URIs | URI parsing | ValueError |
+
+**Lifecycle State Machine:**
+
+```
+                validate()
+    DRAFT ─────────────────► VALIDATED
+       │                          │
+       │    deprecate(reason)     │    deprecate(reason)
+       └─────────────────────────►│◄───────────────────
+                                  ▼
+                            DEPRECATED
+```
+
+**Valid State Transitions:**
+
+| From State | To State | Trigger | Event Emitted |
+|------------|----------|---------|---------------|
+| DRAFT | VALIDATED | `validate()` | KnowledgeItemValidated |
+| DRAFT | DEPRECATED | `deprecate(reason)` | KnowledgeItemDeprecated |
+| VALIDATED | DEPRECATED | `deprecate(reason)` | KnowledgeItemDeprecated |
+
+### 2.3 Entities and Value Objects
+
+#### 2.3.1 Entities
+
+| Entity | Attributes | Purpose |
+|--------|------------|---------|
+| **KnowledgeItem** | id, uri, title, km_type, status, content, context, tags, related_items, evidence_refs, created_at, created_by, modified_at, modified_by, version, content_hash | Primary knowledge unit |
+
+#### 2.3.2 Value Objects
+
+| Value Object | Attributes | Invariants |
+|--------------|------------|------------|
+| **KnowledgeItemId** | value: str | Pattern: `^(PAT|LES|ASM)-[0-9]+$`, prefix matches type |
+| **KnowledgeType** | Enum: PATTERN="PAT", LESSON="LES", ASSUMPTION="ASM" | Used for ID prefix and content discrimination |
+| **KnowledgeStatus** | Enum: DRAFT, VALIDATED, DEPRECATED | Lifecycle states |
+| **Pattern** | context, problem, solution, consequences, forces, alternatives | Immutable, serializable to markdown |
+| **Lesson** | what_happened, what_learned, prevention, impact, confidence | Immutable, confidence 0.0-1.0 |
+| **Assumption** | statement, impact_if_wrong, validation_path, confidence, review_date | Immutable, review_date is ISO 8601 |
+| **JerryUri** | partition, domain, resource, version | SPEC-001 compliant URI scheme |
+
+**Value Object Implementation Patterns:**
+
+```python
+# KnowledgeItemId - Strongly typed ID with type extraction
+@dataclass(frozen=True)
+class KnowledgeItemId(VertexId):
+    def __post_init__(self):
+        if not re.match(r"^(PAT|LES|ASM)-[0-9]+$", self.value):
+            raise ValueError(f"Invalid KnowledgeItemId: {self.value}")
+
+    @classmethod
+    def generate(cls, km_type: KnowledgeType, sequence: int) -> "KnowledgeItemId":
+        return cls(f"{km_type.value}-{sequence:03d}")
+
+    @property
+    def km_type(self) -> KnowledgeType:
+        return KnowledgeType(self.value.split("-")[0])
+
+# Pattern - ADR-style knowledge content
+@dataclass(frozen=True)
+class Pattern:
+    context: str
+    problem: str
+    solution: str
+    consequences: str
+    forces: list[str] | None = None
+    alternatives: list[str] | None = None
+
+    def to_markdown(self) -> str:
+        md = f"## Context\n\n{self.context}\n\n"
+        md += f"## Problem\n\n{self.problem}\n\n"
+        md += f"## Solution\n\n{self.solution}\n\n"
+        md += f"## Consequences\n\n{self.consequences}\n\n"
+        return md
+
+# Lesson - AAR-style learning
+@dataclass(frozen=True)
+class Lesson:
+    what_happened: str
+    what_learned: str
+    prevention: str
+    impact: str = ""
+    confidence: float = 1.0
+
+    def to_markdown(self) -> str:
+        md = f"## What Happened\n\n{self.what_happened}\n\n"
+        md += f"## What We Learned\n\n{self.what_learned}\n\n"
+        md += f"## How to Apply This\n\n{self.prevention}\n\n"
+        return md
+```
+
+### 2.4 Domain Events
+
+KM events follow CloudEvents 1.0 with Jerry-specific type URIs.
+
+#### 2.4.1 Event Catalog
+
+| Event Type | Type URI | Trigger | Payload Fields |
+|------------|----------|---------|----------------|
+| `KnowledgeItemCreated` | `jer:jer:knowledge:facts/KnowledgeItemCreated` | `CaptureKnowledgeHandler` | item_id, km_type, title, created_by |
+| `KnowledgeItemValidated` | `jer:jer:knowledge:facts/KnowledgeItemValidated` | `item.validate()` | item_id, validated_by |
+| `KnowledgeItemDeprecated` | `jer:jer:knowledge:facts/KnowledgeItemDeprecated` | `item.deprecate(reason)` | item_id, reason, deprecated_by |
+| `KnowledgeRelationCreated` | `jer:jer:knowledge:facts/KnowledgeRelationCreated` | `graph_store.add_edge()` | from_id, to_id, relation_type, created_by |
+
+#### 2.4.2 Event Schema
+
+```json
+{
+  "specversion": "1.0",
+  "type": "jer:jer:knowledge:facts/KnowledgeItemCreated",
+  "source": "jer:jer:knowledge:system",
+  "subject": "jer:jer:knowledge:pat:pat-001",
+  "time": "2026-01-09T10:30:00Z",
+  "data": {
+    "item_id": "PAT-001",
+    "km_type": "PATTERN",
+    "title": "Hybrid Architecture",
+    "created_by": "user:architect"
+  }
+}
+```
+
+### 2.5 Use Cases (CQRS)
+
+#### 2.5.1 Commands (Write Operations)
+
+| Command | Handler | Description |
+|---------|---------|-------------|
+| `CaptureKnowledgeCommand` | `CaptureKnowledgeHandler` | Create new knowledge item (PAT, LES, ASM) |
+| `ValidateKnowledgeCommand` | `ValidateKnowledgeHandler` | Transition from DRAFT to VALIDATED |
+| `DeprecateKnowledgeCommand` | `DeprecateKnowledgeHandler` | Mark knowledge as no longer applicable |
+| `RelateKnowledgeCommand` | `RelateKnowledgeHandler` | Create relationship between items |
+
+#### 2.5.2 Queries (Read Operations)
+
+| Query | Handler | Description |
+|-------|---------|-------------|
+| `SearchKnowledgeQuery` | `SearchKnowledgeHandler` | Semantic search via FAISS |
+| `GetRelatedKnowledgeQuery` | `GetRelatedKnowledgeHandler` | Graph traversal for related items |
+| `TraverseKnowledgeGraphQuery` | `TraverseKnowledgeGraphHandler` | Execute graph traversal patterns |
+| `ExportKnowledgeGraphQuery` | `ExportKnowledgeGraphHandler` | Export as RDF (Turtle, JSON-LD) |
+
+### 2.6 Ports and Adapters
+
+#### 2.6.1 Port Interfaces (Domain Layer)
+
+```python
+# IKnowledgeRepository - Persistence Port
+class IKnowledgeRepository(ABC):
+    @abstractmethod
+    def save(self, item: KnowledgeItem) -> None: ...
+    @abstractmethod
+    def find_by_id(self, id: KnowledgeItemId) -> Optional[KnowledgeItem]: ...
+    @abstractmethod
+    def find_by_type(self, km_type: KnowledgeType,
+                     status: Optional[KnowledgeStatus] = None) -> List[KnowledgeItem]: ...
+    @abstractmethod
+    def find_related(self, item_id: KnowledgeItemId,
+                     max_depth: int = 2) -> List[KnowledgeItem]: ...
+
+# ISemanticIndex - Vector Search Port
+class ISemanticIndex(ABC):
+    @abstractmethod
+    def index(self, item: KnowledgeItem) -> None: ...
+    @abstractmethod
+    def search(self, query: str, top_k: int = 5,
+               filters: dict = None) -> List[Tuple[KnowledgeItemId, float]]: ...
+    @abstractmethod
+    def reindex(self, items: List[KnowledgeItem]) -> None: ...
+
+# IGraphStore - Graph Operations Port
+class IGraphStore(ABC):
+    @abstractmethod
+    def add_vertex(self, item: KnowledgeItem) -> None: ...
+    @abstractmethod
+    def add_edge(self, from_id: KnowledgeItemId, to_id: KnowledgeItemId,
+                 label: str, properties: Dict[str, Any] = None) -> Edge: ...
+    @abstractmethod
+    def traverse(self, start_id: KnowledgeItemId, edge_label: str,
+                 max_depth: int = 2) -> List[KnowledgeItemId]: ...
+    @abstractmethod
+    def export_rdf(self, format: str = "turtle") -> str: ...
+```
+
+#### 2.6.2 Adapter Implementations
+
+| Port | Adapter | Technology | Phase |
+|------|---------|------------|-------|
+| `IKnowledgeRepository` | `FileSystemAdapter` | Python stdlib (Markdown) | 2 |
+| `ISemanticIndex` | `FAISSAdapter` | FAISS 1.7.4 | 2 |
+| `IGraphStore` | `NetworkXAdapter` | NetworkX 3.2.1 | 2 |
+| `IRDFSerializer` | `RDFLibAdapter` | RDFLib 7.0.0 | 2 |
+| `IGraphStore` | `PyoxigraphAdapter` | pyoxigraph | 3 |
+
+---
+
+## 3. Domain Synergy Analysis
+
+### 3.1 Shared Patterns
+
+Both domains independently adopted identical architectural patterns, enabling seamless integration.
+
+#### 3.1.1 Hexagonal Architecture (Ports & Adapters)
+
+| Aspect | Work Tracker | Knowledge Management | Synergy |
+|--------|--------------|---------------------|---------|
+| **Domain Layer** | Zero dependencies | Zero dependencies | Shared constraint |
+| **Ports** | IWorkItemRepository, IEventStore | IKnowledgeRepository, ISemanticIndex, IGraphStore | Common interface pattern |
+| **Adapters** | SQLite, In-Memory | FileSystem, NetworkX, FAISS | Can share infrastructure |
+| **Dependency Rule** | domain/ imports nothing | domain/ imports nothing | Identical |
+
+**Unified Hexagonal Diagram:**
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│                            INTERFACE LAYER                                   │
+│  CLI: jerry worktracker / jerry knowledge                                   │
+│  Skills: worktracker, knowledge-search                                       │
+│  Agents: ps-*, qa-*, orchestrator                                           │
+└────────────────────────────────────────────────────────────────────────────┘
+                                     ↓
+┌────────────────────────────────────────────────────────────────────────────┐
+│                           APPLICATION LAYER                                  │
+│                                                                              │
+│  Work Tracker Commands:        │  KM Commands:                              │
+│  ├─ CreateWorkItem             │  ├─ CaptureKnowledge                       │
+│  ├─ UpdateWorkItem             │  ├─ ValidateKnowledge                      │
+│  └─ CompleteWorkItem           │  └─ DeprecateKnowledge                     │
+│                                │                                             │
+│  Work Tracker Queries:         │  KM Queries:                               │
+│  ├─ GetWorkItem                │  ├─ SearchKnowledge                        │
+│  ├─ ListWorkItems              │  ├─ GetRelatedKnowledge                    │
+│  └─ SearchWorkItems            │  └─ TraverseKnowledgeGraph                 │
+│                                │                                             │
+│  ┌─────────────────────────────┴──────────────────────────────────┐        │
+│  │           CROSS-DOMAIN USE CASES (Future)                       │        │
+│  │  ├─ GenerateLessonFromTask                                      │        │
+│  │  ├─ ApplyPatternToPhase                                         │        │
+│  │  └─ ValidateAssumptionFromEvidence                              │        │
+│  └─────────────────────────────────────────────────────────────────┘        │
+└────────────────────────────────────────────────────────────────────────────┘
+                                     ↓
+┌────────────────────────────────────────────────────────────────────────────┐
+│                             DOMAIN LAYER                                     │
+│  (ZERO EXTERNAL DEPENDENCIES - Python stdlib only)                          │
+│                                                                              │
+│  Work Tracker Entities:        │  KM Entities:                              │
+│  ├─ WorkItem (Aggregate)       │  ├─ KnowledgeItem (Aggregate)              │
+│  ├─ WorkItemId (VO)            │  ├─ KnowledgeItemId (VO)                   │
+│  ├─ Status, Priority (VO)      │  ├─ Pattern, Lesson, Assumption (VO)       │
+│  └─ Note, Tag (VO)             │  └─ KnowledgeType, KnowledgeStatus (VO)    │
+│                                │                                             │
+│  Shared Ports:                                                              │
+│  ├─ IEventStore (Event Sourcing)                                            │
+│  ├─ IEventDispatcher (Pub/Sub)                                              │
+│  └─ IUnitOfWork (Transactions)                                              │
+│                                                                              │
+│  Work Tracker Ports:           │  KM Ports:                                 │
+│  ├─ IWorkItemRepository        │  ├─ IKnowledgeRepository                   │
+│  └─ (future: IGraphStore)      │  ├─ ISemanticIndex                         │
+│                                │  ├─ IGraphStore                             │
+│                                │  └─ IRDFSerializer                          │
+└────────────────────────────────────────────────────────────────────────────┘
+                                     ↓
+┌────────────────────────────────────────────────────────────────────────────┐
+│                          INFRASTRUCTURE LAYER                                │
+│                                                                              │
+│  Shared Adapters:              │  Technology:                               │
+│  ├─ SQLiteEventStore           │  SQLite                                    │
+│  ├─ InMemoryEventDispatcher    │  Python dict                               │
+│  └─ SQLiteUnitOfWork           │  SQLite                                    │
+│                                │                                             │
+│  Work Tracker Adapters:        │  Technology:                               │
+│  ├─ SQLiteRepository           │  SQLite                                    │
+│  └─ MarkdownAdapter            │  Python stdlib                             │
+│                                │                                             │
+│  KM Adapters:                  │  Technology:        │  Phase:              │
+│  ├─ FileSystemAdapter          │  Python stdlib      │  2                   │
+│  ├─ NetworkXAdapter            │  NetworkX 3.2.1     │  2                   │
+│  ├─ FAISSAdapter               │  FAISS 1.7.4        │  2                   │
+│  ├─ RDFLibAdapter              │  RDFLib 7.0.0       │  2                   │
+│  └─ PyoxigraphAdapter          │  pyoxigraph         │  3                   │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 3.1.2 CQRS Pattern
+
+Both domains separate read and write operations:
+
+| Aspect | Work Tracker | Knowledge Management |
+|--------|--------------|---------------------|
+| **Commands** | CreateWorkItem, UpdateWorkItem, CompleteWorkItem | CaptureKnowledge, ValidateKnowledge, DeprecateKnowledge |
+| **Queries** | GetWorkItem, ListWorkItems, SearchWorkItems | SearchKnowledge, GetRelatedKnowledge, TraverseKnowledgeGraph |
+| **Command Returns** | WorkItemDTO (or events) | KnowledgeItemId (or events) |
+| **Query Returns** | DTOs (never domain entities) | DTOs (never domain entities) |
+
+#### 3.1.3 Event Sourcing
+
+Both domains use event-based state management:
+
+| Aspect | Work Tracker | Knowledge Management |
+|--------|--------------|---------------------|
+| **Event Base** | DomainEvent abstract class | DomainEvent abstract class |
+| **Event Schema** | CloudEvents 1.0 | CloudEvents 1.0 |
+| **Aggregate Events** | WorkItemCreated, WorkItemCompleted | KnowledgeItemCreated, KnowledgeItemValidated |
+| **Event Store** | IEventStore port | IEventStore port (shared) |
+| **Reconstitution** | `WorkItem.reconstitute(events)` | `KnowledgeItem.reconstitute(events)` |
+
+#### 3.1.4 CloudEvents 1.0 Compliance
+
+Both domains use CloudEvents for interoperability:
+
+```json
+// Work Tracker Event
+{
+  "specversion": "1.0",
+  "type": "WorkItemCompleted",
+  "source": "jer:jer:work-tracker:system",
+  "subject": "jer:jer:work-tracker:task:WORK-042",
+  "time": "2026-01-09T14:30:00Z",
+  "data": {"completed_at": "2026-01-09T14:30:00Z", "notes": "Tests passing"}
+}
+
+// KM Event
+{
+  "specversion": "1.0",
+  "type": "jer:jer:knowledge:facts/KnowledgeItemCreated",
+  "source": "jer:jer:knowledge:system",
+  "subject": "jer:jer:knowledge:les:les-001",
+  "time": "2026-01-09T14:35:00Z",
+  "data": {"item_id": "LES-001", "km_type": "LESSON", "title": "SHACL catches drift"}
+}
+```
+
+#### 3.1.5 Strongly-Typed IDs (VertexId Pattern)
+
+Both domains use strongly-typed identifiers extending a common base:
+
+```python
+# Base class (shared)
+@dataclass(frozen=True)
+class VertexId:
+    value: str
+
+# Work Tracker
+@dataclass(frozen=True)
+class WorkItemId(VertexId):
+    # Pattern: WORK-001, WORK-002
+    prefix: ClassVar[str] = "WORK"
+
+# Knowledge Management
+@dataclass(frozen=True)
+class KnowledgeItemId(VertexId):
+    # Pattern: PAT-001, LES-042, ASM-003
+    @property
+    def km_type(self) -> KnowledgeType: ...
+```
+
+### 3.2 Entity Mapping
+
+The following table maps entities across domains and identifies their relationships:
+
+| Work Tracker Entity | KM Entity | Relationship Type | Description |
+|---------------------|-----------|------------------|-------------|
+| **Task** | **Lesson** | `LEARNED_FROM` | Task completion generates Lesson about what was learned |
+| **Task** | **Pattern** | `APPLIED_PATTERN` | Task applies existing Pattern to solve problem |
+| **Task** | **Assumption** | `VALIDATED_ASSUMPTION` | Task provides evidence validating/invalidating Assumption |
+| **Phase** | **Pattern** | `EMERGED_PATTERN` | Phase of work reveals new Pattern through multiple tasks |
+| **Phase** | **Lesson** | `CONSOLIDATED_LESSONS` | Phase aggregates Lessons from constituent tasks |
+| **Plan** | **Assumption** | `DEPENDS_ON_ASSUMPTION` | Plan relies on Assumptions that may prove wrong |
+| **Plan** | **Pattern** | `BASED_ON_PATTERN` | Plan structured around known Patterns |
+| **WorkItemType.SPIKE** | **Pattern** | `DISCOVERED_PATTERN` | Spike research discovers new Pattern |
+| **WorkItemType.BUG** | **Lesson** | `BUG_LESSON` | Bug fix generates Lesson about root cause |
+
+**Cross-Domain Graph Visualization:**
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        UNIFIED KNOWLEDGE GRAPH                               │
+│                                                                              │
+│   WORK TRACKER CONTEXT                    KNOWLEDGE MANAGEMENT CONTEXT       │
+│                                                                              │
+│   ┌──────────┐                           ┌──────────────┐                   │
+│   │  Plan    │──────DEPENDS_ON──────────►│  Assumption  │                   │
+│   │ PLAN-001 │                           │   ASM-001    │                   │
+│   └────┬─────┘                           └──────────────┘                   │
+│        │                                         ▲                           │
+│        │ PART_OF                                 │ VALIDATED_BY              │
+│        ▼                                         │                           │
+│   ┌──────────┐                                   │                           │
+│   │  Phase   │                                   │                           │
+│   │PHASE-001 │──────EMERGED_PATTERN────►┌───────┴──────┐                    │
+│   └────┬─────┘                          │   Pattern    │                    │
+│        │                                │   PAT-001    │                    │
+│        │ PART_OF                        └──────────────┘                    │
+│        ▼                                        ▲                            │
+│   ┌──────────┐                                  │                            │
+│   │   Task   │─────APPLIED_PATTERN─────────────┘                            │
+│   │ WORK-042 │                                                               │
+│   └────┬─────┘                                                               │
+│        │                                                                     │
+│        │ LEARNED_FROM                                                        │
+│        ▼                                                                     │
+│   ┌──────────────┐                                                          │
+│   │    Lesson    │                                                          │
+│   │   LES-001    │                                                          │
+│   └──────────────┘                                                          │
+│                                                                              │
+│   Legend:                                                                    │
+│   ────► : Directed edge (relationship)                                      │
+│   ┌───┐ : Vertex (entity)                                                   │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Graph Relationships
+
+#### 3.3.1 Edge Types (Relationship Labels)
+
+| Edge Label | From Domain | To Domain | Cardinality | Description |
+|------------|-------------|-----------|-------------|-------------|
+| `PART_OF` | Work Tracker | Work Tracker | Task→Phase, Phase→Plan | Hierarchical containment |
+| `BLOCKS` | Work Tracker | Work Tracker | Task→Task | Dependency blocking |
+| `DEPENDS_ON` | Work Tracker | Work Tracker | Task→Task | Logical dependency |
+| `LEARNED_FROM` | Work Tracker | KM | Task→Lesson | Knowledge extraction |
+| `APPLIED_PATTERN` | Work Tracker | KM | Task→Pattern | Pattern usage |
+| `VALIDATED_ASSUMPTION` | Work Tracker | KM | Task→Assumption | Evidence for/against |
+| `EMERGED_PATTERN` | Work Tracker | KM | Phase→Pattern | Pattern discovery |
+| `DEPENDS_ON_ASSUMPTION` | Work Tracker | KM | Plan→Assumption | Risk tracking |
+| `REFERENCES` | KM | KM | KnowledgeItem→KnowledgeItem | General citation |
+| `SUPERSEDES` | KM | KM | KnowledgeItem→KnowledgeItem | Version replacement |
+| `EVIDENCED_BY` | KM | External | KnowledgeItem→Evidence | Source documentation |
+
+#### 3.3.2 Bidirectional Traversal Patterns
+
+**From Work Tracker to KM:**
+
+```python
+# Query: What patterns were applied to complete WORK-042?
+def get_applied_patterns(graph: IGraphStore, task_id: WorkItemId) -> list[Pattern]:
+    pattern_ids = graph.traverse(
+        start_id=task_id,
+        edge_label="APPLIED_PATTERN",
+        max_depth=1
+    )
+    return [km_repo.find_by_id(pid) for pid in pattern_ids]
+
+# Query: What lessons emerged from PHASE-001?
+def get_phase_lessons(graph: IGraphStore, phase_id: PhaseId) -> list[Lesson]:
+    task_ids = graph.traverse(phase_id, "PART_OF", max_depth=1)
+    lessons = []
+    for task_id in task_ids:
+        lesson_ids = graph.traverse(task_id, "LEARNED_FROM", max_depth=1)
+        lessons.extend([km_repo.find_by_id(lid) for lid in lesson_ids])
+    return lessons
+```
+
+**From KM to Work Tracker:**
+
+```python
+# Query: Which tasks applied pattern PAT-001?
+def get_pattern_applications(graph: IGraphStore, pattern_id: KnowledgeItemId) -> list[Task]:
+    # Reverse traversal via incoming edges
+    task_ids = graph.traverse_incoming(
+        end_id=pattern_id,
+        edge_label="APPLIED_PATTERN"
+    )
+    return [wt_repo.get(tid) for tid in task_ids]
+
+# Query: Which plan depends on assumption ASM-003?
+def get_dependent_plans(graph: IGraphStore, assumption_id: KnowledgeItemId) -> list[Plan]:
+    plan_ids = graph.traverse_incoming(
+        end_id=assumption_id,
+        edge_label="DEPENDS_ON_ASSUMPTION"
+    )
+    return [wt_repo.get_plan(pid) for pid in plan_ids]
+```
+
+### 3.4 Shared Infrastructure
+
+Both domains can share infrastructure components, reducing implementation effort and ensuring consistency.
+
+#### 3.4.1 Shared Components
+
+| Component | Work Tracker Use | KM Use | Sharing Strategy |
+|-----------|------------------|--------|------------------|
+| **Event Store** | Persist WorkItem events | Persist KnowledgeItem events | Single `IEventStore` implementation |
+| **Event Dispatcher** | Publish WorkItemCompleted | Subscribe to generate Lessons | Shared in-memory dispatcher |
+| **Graph Store** | Task hierarchy, blocking | Knowledge relationships | Same NetworkX instance |
+| **Semantic Index** | Search WorkItems | Search KnowledgeItems | Unified FAISS index with type metadata |
+| **RDF Serializer** | Export tasks as RDF | Export knowledge as RDF | Same RDFLib adapter, different contexts |
+
+#### 3.4.2 Unified Event Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         UNIFIED EVENT BUS                                    │
+│                                                                              │
+│  ┌───────────────────┐                      ┌───────────────────┐           │
+│  │   Work Tracker    │                      │   Knowledge Mgmt  │           │
+│  │   Aggregates      │                      │   Handlers        │           │
+│  └─────────┬─────────┘                      └─────────▲─────────┘           │
+│            │                                          │                      │
+│            │ emit                                     │ subscribe            │
+│            ▼                                          │                      │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                        IEventDispatcher                               │  │
+│  │                                                                       │  │
+│  │  WorkItemCreated ──► Log audit trail                                  │  │
+│  │  WorkItemCompleted ──► Trigger AAR prompt ──► CaptureKnowledgeCommand │  │
+│  │  WorkItemBlocked ──► Alert dashboard                                  │  │
+│  │  KnowledgeItemCreated ──► Update indexes                              │  │
+│  │  KnowledgeItemValidated ──► Notify subscribers                        │  │
+│  │                                                                       │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+│                              │                                              │
+│                              ▼                                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                        IEventStore                                    │  │
+│  │                                                                       │  │
+│  │  ┌─────────────────────────────────────────────────────────────────┐ │  │
+│  │  │ Stream: WorkItem:WORK-042                                       │ │  │
+│  │  │ [WorkItemCreated, WorkItemStarted, WorkItemCompleted]           │ │  │
+│  │  └─────────────────────────────────────────────────────────────────┘ │  │
+│  │                                                                       │  │
+│  │  ┌─────────────────────────────────────────────────────────────────┐ │  │
+│  │  │ Stream: KnowledgeItem:LES-001                                   │ │  │
+│  │  │ [KnowledgeItemCreated, KnowledgeItemValidated]                  │ │  │
+│  │  └─────────────────────────────────────────────────────────────────┘ │  │
+│  │                                                                       │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Integration Points
+
+### 4.1 Event Integration
+
+Events flow between bounded contexts to enable automatic knowledge capture.
+
+#### 4.1.1 Cross-Context Event Handlers
+
+| Source Event | Handler | Target Action |
+|--------------|---------|---------------|
+| `WorkItemCompleted` | `AARPromptHandler` | Prompt user for AAR, create `CaptureKnowledgeCommand(LESSON)` |
+| `WorkItemCompleted` (Type=SPIKE) | `PatternDetectionHandler` | Analyze spike for patterns, create `CaptureKnowledgeCommand(PATTERN)` |
+| `PlanCreated` | `AssumptionExtractHandler` | Parse plan for assumptions, create `CaptureKnowledgeCommand(ASSUMPTION)` |
+| `KnowledgeItemValidated` (Type=PATTERN) | `PatternAvailabilityHandler` | Notify agents pattern is ready for use |
+| `KnowledgeItemDeprecated` | `DependentWorkItemsHandler` | Warn about tasks depending on deprecated knowledge |
+
+**Event Handler Implementation:**
+
+```python
+class AARPromptHandler:
+    """
+    Subscribe to WorkItemCompleted events.
+    Prompt for After-Action Review and capture as Lesson.
+    """
+
+    def __init__(self, event_dispatcher: IEventDispatcher,
+                 capture_handler: CaptureKnowledgeHandler):
+        self.capture_handler = capture_handler
+        event_dispatcher.subscribe("WorkItemCompleted", self.handle)
+
+    def handle(self, event: WorkItemCompleted) -> None:
+        # Only prompt for significant items
+        if event.payload.get("effort_hours", 0) > 2:
+            lesson = self._prompt_aar(event)
+            if lesson:
+                command = CaptureKnowledgeCommand(
+                    title=f"Lesson from {event.aggregate_id}",
+                    km_type=KnowledgeType.LESSON,
+                    content=lesson,
+                    evidence_refs=[str(JerryUri.for_task(event.aggregate_id))]
+                )
+                self.capture_handler.handle(command)
+
+    def _prompt_aar(self, event: WorkItemCompleted) -> Lesson | None:
+        # Generate AAR prompt for agent/user
+        # Return Lesson if captured, None if skipped
+        ...
+```
+
+### 4.2 Query Integration
+
+Cross-domain queries enable knowledge-enriched work tracking.
+
+#### 4.2.1 Enriched Queries
+
+| Query | Enhancement | Purpose |
+|-------|-------------|---------|
+| `GetWorkItemQuery` | Attach related Patterns/Lessons | Show applicable knowledge |
+| `ListWorkItemsQuery` | Filter by Assumption dependencies | Find assumption-dependent tasks |
+| `SearchKnowledgeQuery` | Include Work Tracker evidence | Ground knowledge in actual work |
+| `GetRelatedKnowledgeQuery` | Traverse into Work Tracker | Find tasks that used pattern |
+
+**Implementation:**
+
+```python
+class EnrichedGetWorkItemHandler:
+    """
+    Enhanced WorkItem query that includes related knowledge.
+    """
+
+    def __init__(self, wt_repo: IWorkItemRepository,
+                 km_repo: IKnowledgeRepository,
+                 graph: IGraphStore):
+        self.wt_repo = wt_repo
+        self.km_repo = km_repo
+        self.graph = graph
+
+    def handle(self, query: GetWorkItemQuery) -> EnrichedWorkItemDTO:
+        # Get base work item
+        item = self.wt_repo.get(WorkItemId(query.id))
+        if not item:
+            return None
+
+        # Find applied patterns
+        pattern_ids = self.graph.traverse(item.id, "APPLIED_PATTERN", max_depth=1)
+        patterns = [self.km_repo.find_by_id(pid) for pid in pattern_ids]
+
+        # Find lessons learned
+        lesson_ids = self.graph.traverse(item.id, "LEARNED_FROM", max_depth=1)
+        lessons = [self.km_repo.find_by_id(lid) for lid in lesson_ids]
+
+        # Find relevant assumptions
+        if item.parent_id:  # Task has parent phase/plan
+            plan_id = self._get_plan_id(item.parent_id)
+            assumption_ids = self.graph.traverse(plan_id, "DEPENDS_ON_ASSUMPTION", max_depth=1)
+            assumptions = [self.km_repo.find_by_id(aid) for aid in assumption_ids]
+        else:
+            assumptions = []
+
+        return EnrichedWorkItemDTO(
+            work_item=WorkItemDTO.from_entity(item),
+            applied_patterns=patterns,
+            learned_lessons=lessons,
+            related_assumptions=assumptions
+        )
+```
+
+### 4.3 Command Integration
+
+Cross-domain commands create relationships between contexts.
+
+#### 4.3.1 Relationship Commands
+
+| Command | Description | Creates Edge |
+|---------|-------------|--------------|
+| `ApplyPatternToTaskCommand` | Record pattern usage | Task→Pattern (APPLIED_PATTERN) |
+| `RecordLessonFromTaskCommand` | Capture lesson learned | Task→Lesson (LEARNED_FROM) |
+| `TrackAssumptionInPlanCommand` | Link assumption to plan | Plan→Assumption (DEPENDS_ON_ASSUMPTION) |
+| `ValidateAssumptionCommand` | Mark assumption as validated | Task→Assumption (VALIDATED_ASSUMPTION) |
+
+**Implementation:**
+
+```python
+@dataclass
+class ApplyPatternToTaskCommand:
+    """Command to record that a task applied a pattern."""
+    task_id: str
+    pattern_id: str
+    applied_by: str = "system:agent"
+    notes: str = ""
+
+class ApplyPatternToTaskHandler:
+    def __init__(self, wt_repo: IWorkItemRepository,
+                 km_repo: IKnowledgeRepository,
+                 graph: IGraphStore,
+                 event_publisher: DomainEventPublisher):
+        self.wt_repo = wt_repo
+        self.km_repo = km_repo
+        self.graph = graph
+        self.event_publisher = event_publisher
+
+    def handle(self, command: ApplyPatternToTaskCommand) -> None:
+        # Validate both entities exist
+        task = self.wt_repo.get(WorkItemId(command.task_id))
+        if not task:
+            raise ValueError(f"Task not found: {command.task_id}")
+
+        pattern = self.km_repo.find_by_id(KnowledgeItemId(command.pattern_id))
+        if not pattern:
+            raise ValueError(f"Pattern not found: {command.pattern_id}")
+
+        # Create relationship edge
+        edge = self.graph.add_edge(
+            from_id=task.id,
+            to_id=pattern.id,
+            label="APPLIED_PATTERN",
+            properties={
+                "applied_by": command.applied_by,
+                "applied_at": datetime.utcnow().isoformat(),
+                "notes": command.notes
+            }
+        )
+
+        # Add note to task
+        task.add_note(f"Applied pattern: {pattern.title} ({pattern.id})")
+        self.wt_repo.save(task)
+
+        # Emit event
+        event = KnowledgeRelationCreated(
+            from_id=task.id,
+            to_id=pattern.id,
+            relation_type="APPLIED_PATTERN",
+            created_by=command.applied_by
+        )
+        self.event_publisher.publish(event)
+```
+
+---
+
+## 5. Work Tracker as KM Proving Ground
+
+### 5.1 Rationale
+
+**Why implement Work Tracker first:**
+
+1. **Smaller Blast Radius**: Work Tracker targets ~500 nodes vs. KM's 5,000+ target. Bugs and performance issues are discovered with less impact.
+
+2. **Faster Feedback Loop**: Work Tracker changes are visible in days (task completion) vs. KM changes visible in weeks (pattern emergence). Faster iteration.
+
+3. **Already Has Domain Model**: Work Tracker's entities, events, and use cases are fully specified. KM can inherit proven patterns.
+
+4. **Validates KM Patterns at Small Scale**: Every KM infrastructure component (graph store, semantic index, event bus) works first with Work Tracker entities.
+
+5. **Lower Learning Curve**: Team learns hexagonal architecture, CQRS, event sourcing on simpler domain before tackling KM complexity.
+
+6. **Clear Success Criteria**: Work Tracker has concrete BDD scenarios. Success is measurable. KM success is more abstract.
+
+**Strategic Analogy:**
+
+> Work Tracker : Knowledge Management :: Unit Test : Integration Test
+>
+> Test at small scope first, then scale up.
+
+### 5.2 Implementation Sequence
+
+**Phase 1: Work Tracker Foundation (Current)**
+
+| Week | Deliverable | Validates For KM |
+|------|-------------|------------------|
+| 1-2 | Domain entities, value objects | Entity patterns, VertexId hierarchy |
+| 3-4 | SQLite repository, event store | IEventStore port pattern |
+| 5-6 | CQRS commands and queries | Use case patterns |
+| 7-8 | BDD tests, CLI adapter | Interface layer patterns |
+
+**Phase 2: Work Tracker + Basic KM (Unified Roadmap)**
+
+| Week | Deliverable | Validates For Full KM |
+|------|-------------|----------------------|
+| 9-10 | NetworkX graph adapter for Work Tracker | IGraphStore port |
+| 11-12 | RDFLib serialization for WorkItems | IRDFSerializer port |
+| 13-14 | FAISS semantic search for WorkItems | ISemanticIndex port |
+| 15-16 | KM entities (Pattern, Lesson, Assumption) | KM domain model |
+
+**Phase 3: Full KM + Cross-Domain Integration**
+
+| Month | Deliverable | Impact |
+|-------|-------------|--------|
+| 4-5 | Cross-domain event handlers | Automatic lesson capture |
+| 5-6 | HybridRAG with both domains | Agent knowledge grounding |
+| 6-7 | SPARQL endpoint for unified graph | External integration |
+
+### 5.3 Risk Mitigation
+
+**How Work Tracker first reduces risk:**
+
+| Risk | Without WT First | With WT First |
+|------|------------------|---------------|
+| **Performance Unknown** | Discover at 5,000 nodes (too late) | Discover at 500 nodes (fixable) |
+| **Supernode Issue** | Actor vertex has 5,000 edges | Catch at 500 edges, apply fix early |
+| **Event Store Scaling** | Unknown throughput | Measured with WT workload first |
+| **Query Latency** | P95 unknown | Benchmarked on WT, tuned before KM |
+| **Schema Evolution** | Breaking changes at scale | Practice migrations on WT |
+| **User Adoption** | AAR ignored by users | Learn from WT completion hooks |
+
+**Quantitative Risk Reduction:**
+
+| Risk Metric | WT First | Direct KM | Improvement |
+|-------------|----------|-----------|-------------|
+| Time to discover issues | 2 weeks | 8 weeks | 4x faster |
+| Cost to fix (lines changed) | ~200 LOC | ~2000 LOC | 10x smaller |
+| Users impacted | 1 (developer) | Many (all agents) | Isolated |
+| Rollback complexity | Simple (WT-only) | Complex (WT+KM) | Much simpler |
+
+---
+
+## 6. Unified Domain Model Proposal
+
+### 6.1 Bounded Context Diagram
+
+```mermaid
+graph TB
+    subgraph "Jerry Framework"
+        subgraph "Work Tracker Context (Core)"
+            WT_PLAN[Plan]
+            WT_PHASE[Phase]
+            WT_TASK[Task]
+            WT_SPRINT[Sprint]
+
+            WT_PLAN --> WT_PHASE
+            WT_PHASE --> WT_TASK
+            WT_SPRINT -.-> WT_TASK
+        end
+
+        subgraph "Knowledge Management Context (Supporting)"
+            KM_PATTERN[Pattern]
+            KM_LESSON[Lesson]
+            KM_ASSUMPTION[Assumption]
+
+            KM_PATTERN -.-> KM_PATTERN
+            KM_LESSON -.-> KM_PATTERN
+            KM_ASSUMPTION -.-> KM_LESSON
+        end
+
+        subgraph "Governance Context (Generic)"
+            GOV_AGENT[Agent]
+            GOV_RULE[Rule]
+            GOV_HOOK[Hook]
+        end
+
+        %% Cross-context relationships
+        WT_TASK -->|LEARNED_FROM| KM_LESSON
+        WT_TASK -->|APPLIED_PATTERN| KM_PATTERN
+        WT_PLAN -->|DEPENDS_ON| KM_ASSUMPTION
+        WT_PHASE -->|EMERGED_PATTERN| KM_PATTERN
+        WT_TASK -->|VALIDATED| KM_ASSUMPTION
+
+        %% Governance
+        GOV_AGENT -->|CREATED_BY| WT_TASK
+        GOV_AGENT -->|CAPTURED| KM_LESSON
+    end
+
+    subgraph "External"
+        EXT_DOCS[docs/ filesystem]
+        EXT_GIT[Git repository]
+    end
+
+    WT_TASK -.->|persisted to| EXT_DOCS
+    KM_PATTERN -.->|persisted to| EXT_DOCS
+    EXT_DOCS -.->|versioned by| EXT_GIT
+```
+
+### 6.2 Entity Relationships
+
+```mermaid
+classDiagram
+    class EntityBase {
+        <<abstract>>
+        +JerryId id
+        +JerryUri uri
+        +datetime created_at
+        +str created_by
+        +datetime modified_at
+        +str modified_by
+        +str version
+        +str content_hash
+    }
+
+    class Vertex {
+        <<abstract>>
+        +VertexId id
+        +str label
+        +Dict properties
+    }
+
+    class WorkItem {
+        +WorkItemId id
+        +str title
+        +WorkItemType type
+        +Status status
+        +Priority priority
+        +WorkItemId parent_id
+        +List~Note~ notes
+        +List~Tag~ tags
+        +start()
+        +block(reason)
+        +complete(notes)
+        +reopen()
+    }
+
+    class KnowledgeItem {
+        +KnowledgeItemId id
+        +str title
+        +KnowledgeType km_type
+        +KnowledgeStatus status
+        +Pattern|Lesson|Assumption content
+        +List~str~ tags
+        +List~KnowledgeItemId~ related_items
+        +validate()
+        +deprecate(reason)
+    }
+
+    class Pattern {
+        <<value object>>
+        +str context
+        +str problem
+        +str solution
+        +str consequences
+    }
+
+    class Lesson {
+        <<value object>>
+        +str what_happened
+        +str what_learned
+        +str prevention
+    }
+
+    class Assumption {
+        <<value object>>
+        +str statement
+        +str impact_if_wrong
+        +str validation_path
+    }
+
+    EntityBase <|-- Vertex
+    Vertex <|-- WorkItem
+    Vertex <|-- KnowledgeItem
+
+    KnowledgeItem o-- Pattern : content
+    KnowledgeItem o-- Lesson : content
+    KnowledgeItem o-- Assumption : content
+
+    WorkItem "1" --> "*" KnowledgeItem : LEARNED_FROM
+    WorkItem "1" --> "*" KnowledgeItem : APPLIED_PATTERN
+    WorkItem "1" --> "*" KnowledgeItem : VALIDATED_ASSUMPTION
+```
+
+### 6.3 Event Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI
+    participant WT as Work Tracker
+    participant EventBus
+    participant KM as Knowledge Mgmt
+    participant Graph
+    participant Index
+
+    User->>CLI: complete WORK-042
+    CLI->>WT: CompleteWorkItemCommand
+
+    WT->>WT: Validate status transition
+    WT->>EventBus: emit(WorkItemCompleted)
+
+    EventBus->>KM: WorkItemCompleted event
+
+    KM->>User: Prompt AAR (3 questions)
+    User->>KM: AAR responses
+
+    KM->>KM: CaptureKnowledgeCommand(LESSON)
+    KM->>Graph: add_vertex(LES-001)
+    KM->>Graph: add_edge(WORK-042, LES-001, LEARNED_FROM)
+    KM->>Index: index(LES-001)
+    KM->>EventBus: emit(KnowledgeItemCreated)
+
+    EventBus->>CLI: Update task with lesson link
+    CLI->>User: Task completed, lesson captured: LES-001
+```
+
+---
+
+## 7. Gap Analysis
+
+### 7.1 Missing from Work Tracker
+
+To support KM integration, Work Tracker needs:
+
+| Gap | Description | Priority | Effort |
+|-----|-------------|----------|--------|
+| **Graph Store Port** | `IGraphStore` interface for relationship queries | HIGH | 2 days |
+| **RDF Serialization** | `to_jsonld()`, `to_turtle()` methods on WorkItem | MEDIUM | 3 days |
+| **Semantic Index Port** | `ISemanticIndex` for semantic search | MEDIUM | 3 days |
+| **Cross-Domain Events** | Event handlers for KM triggers | HIGH | 2 days |
+| **AAR Integration Hook** | Hook in CompleteWorkItem for AAR prompt | HIGH | 1 day |
+| **Enriched Query DTOs** | DTOs with related knowledge attached | MEDIUM | 2 days |
+
+### 7.2 Missing from KM
+
+To be production-ready, KM needs:
+
+| Gap | Description | Priority | Effort |
+|-----|-------------|----------|--------|
+| **Validation Pipeline** | SHACL shapes for KnowledgeItem validation | HIGH | 3 days |
+| **Deprecation Cascade** | Handle deprecated knowledge in dependent items | MEDIUM | 2 days |
+| **Version History** | Track changes to knowledge content | MEDIUM | 3 days |
+| **Confidence Scoring** | Automatic confidence updates from usage | LOW | 5 days |
+| **Embedding Updates** | Re-index when content changes | MEDIUM | 2 days |
+| **Bulk Import** | Import existing docs/ as KnowledgeItems | MEDIUM | 3 days |
+
+### 7.3 Shared Missing Components
+
+Both domains need:
+
+| Gap | Description | Owner | Priority | Effort |
+|-----|-------------|-------|----------|--------|
+| **Unified Event Store** | Shared SQLite event store for both domains | Infrastructure | HIGH | 5 days |
+| **Graph Store Adapter** | NetworkX adapter implementing IGraphStore | Infrastructure | HIGH | 5 days |
+| **Semantic Index Adapter** | FAISS adapter implementing ISemanticIndex | Infrastructure | HIGH | 5 days |
+| **RDF Serialization Adapter** | RDFLib adapter for Turtle/JSON-LD | Infrastructure | MEDIUM | 4 days |
+| **Jerry URI Factory** | Unified URI generation for all entities | Domain | HIGH | 2 days |
+| **Cross-Domain Event Handlers** | Event routing between contexts | Application | HIGH | 3 days |
+| **Unified CLI** | `jerry` command with subcommands | Interface | MEDIUM | 3 days |
+| **Performance Monitoring** | Query latency, supernode detection | Infrastructure | MEDIUM | 3 days |
+
+---
+
+## 8. Technology Stack Validation
+
+### 8.1 NetworkX Fit
+
+**Assessment: EXCELLENT fit for both domains**
+
+| Criterion | Work Tracker | Knowledge Management | Combined |
+|-----------|--------------|---------------------|----------|
+| **Node Count** | ~500 tasks/phases/plans | ~5,000 knowledge items | ~5,500 total |
+| **Edge Count** | ~1,500 (hierarchy + blocks) | ~15,000 (relationships) | ~16,500 total |
+| **Query Pattern** | Traversal (parent/child) | Traversal + pattern matching | Traversal-heavy |
+| **Performance** | <10ms for typical queries | <50ms P95 target | Met with margin |
+
+**NetworkX Capabilities Match:**
+
+| Requirement | NetworkX Feature | Fit |
+|-------------|------------------|-----|
+| Directed edges | `DiGraph`, `MultiDiGraph` | Excellent |
+| Edge properties | Edge attributes | Excellent |
+| Vertex properties | Node attributes | Excellent |
+| Traversal | BFS, DFS, shortest path | Excellent |
+| Persistence | `read_gpickle`, `write_gpickle` | Good (not primary) |
+
+**Capacity Analysis:**
+
+```python
+# From NetworkX documentation and benchmarks:
+# - 10,000 nodes: sub-millisecond traversal
+# - 100,000 nodes: 10-100ms traversal
+# - Memory: ~1KB per node with attributes
+
+# Jerry projections:
+# - Year 1: 5,500 nodes (~5.5MB)
+# - Year 2: 15,000 nodes (~15MB)
+# - Year 3: 50,000 nodes (~50MB)
+
+# NetworkX comfortably handles Year 1-2
+# Year 3 may need migration to igraph (C-based, 10x faster)
+```
+
+**Recommendation**: Use NetworkX for Phase 2-3. Define migration path to igraph if >10K nodes.
+
+### 8.2 FAISS Fit
+
+**Assessment: GOOD fit for both domains**
+
+| Criterion | Work Tracker | Knowledge Management | Combined |
+|-----------|--------------|---------------------|----------|
+| **Vectors** | ~500 work items | ~5,000 knowledge items | ~5,500 total |
+| **Dimensions** | 1536 (text-embedding-3-small) | 1536 | Same |
+| **Search Latency** | <100ms | <2s target | Met easily |
+| **Index Size** | ~12MB | ~120MB | ~132MB total |
+
+**FAISS Configuration:**
+
+```python
+# Index type recommendation for Jerry scale:
+# - <10K vectors: IndexFlatL2 (exact search, no training)
+# - 10K-1M vectors: IndexIVFFlat (approximate, faster)
+
+# Jerry Year 1-2: IndexFlatL2
+import faiss
+index = faiss.IndexFlatL2(1536)  # Exact search
+index.add(embeddings)
+
+# If scaling needed:
+# index = faiss.index_factory(1536, "IVF100,Flat")
+# index.train(embeddings)
+# index.add(embeddings)
+```
+
+**Recommendation**: Use FAISS with IndexFlatL2. Define migration to IndexIVFFlat if >10K vectors.
+
+### 8.3 RDFLib Fit
+
+**Assessment: EXCELLENT fit for both domains**
+
+| Criterion | Work Tracker | Knowledge Management | Combined |
+|-----------|--------------|---------------------|----------|
+| **Triple Count** | ~10,000 (5 triples/entity) | ~75,000 | ~85,000 total |
+| **Serialization** | Turtle, JSON-LD | Turtle, JSON-LD | Same formats |
+| **SHACL Validation** | Optional | Required | Supported |
+| **Query** | Not needed | SPARQL via pyoxigraph | Separate adapter |
+
+**RDFLib Capabilities:**
+
+```python
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import RDF, RDFS, XSD
+
+JERRY = Namespace("https://jerry.framework/ontology/")
+
+def workitem_to_rdf(item: WorkItem) -> Graph:
+    g = Graph()
+    uri = URIRef(item.uri)
+
+    g.add((uri, RDF.type, JERRY.WorkItem))
+    g.add((uri, JERRY.title, Literal(item.title)))
+    g.add((uri, JERRY.status, Literal(item.status.value)))
+    g.add((uri, JERRY.priority, Literal(item.priority.value)))
+
+    if item.parent_id:
+        g.add((uri, JERRY.partOf, URIRef(item.parent_id.uri)))
+
+    return g
+
+# Serialize to Turtle
+turtle_str = g.serialize(format="turtle")
+
+# Serialize to JSON-LD
+jsonld_str = g.serialize(format="json-ld", context={"@vocab": str(JERRY)})
+```
+
+**Recommendation**: Use RDFLib for Phase 2. Add pyoxigraph for SPARQL in Phase 3.
+
+---
+
+## 9. BDD Test Strategy
+
+### 9.1 Work Tracker BDD Scenarios
+
+Key scenarios from WORK_TRACKER_PLAN.md:
+
+#### Create Work Item
+
+```gherkin
+Feature: Create Work Item
+  As a Claude Code agent
+  I want to create work items
+  So that I can track tasks across sessions
+
+  @unit @happy-path
+  Scenario: Create a simple task
+    Given the work tracker is initialized
+    And no work items exist
+    When I create a work item with title "Implement user authentication"
+    Then a work item should be created with id "WORK-001"
+    And the work item status should be "pending"
+    And a WorkItemCreated event should be raised
+
+  @unit @error-case
+  Scenario: Fail to create with empty title
+    When I attempt to create a work item with title ""
+    Then a ValidationError should be raised
+```
+
+#### State Transitions
+
+```gherkin
+Feature: Work Item State Transitions
+  As a Claude Code agent
+  I want to change work item status
+  So that I can track progress accurately
+
+  @unit @state-machine
+  Scenario: Complete an in-progress work item
+    Given a work item "WORK-001" exists with status "in_progress"
+    When I complete work item "WORK-001" with notes "All tests passing"
+    Then the work item status should be "completed"
+    And a WorkItemCompleted event should be raised
+
+  @unit @state-machine @error-case
+  Scenario: Cannot complete a pending work item directly
+    Given a work item "WORK-001" exists with status "pending"
+    When I attempt to complete work item "WORK-001"
+    Then an InvalidStateTransitionError should be raised
+```
+
+### 9.2 KM BDD Scenarios
+
+Key scenarios from ADR-033:
+
+#### Capture Knowledge
+
+```gherkin
+Feature: Capture Knowledge
+  As a Claude Code agent
+  I want to capture patterns, lessons, and assumptions
+  So that knowledge is preserved for future use
+
+  @unit @happy-path
+  Scenario: Capture a pattern from architecture decision
+    Given the knowledge management system is initialized
+    When I capture a pattern with:
+      | title    | Hybrid Architecture                    |
+      | context  | Need standards + performance           |
+      | problem  | Pure RDF too slow, pure graph no standards |
+      | solution | Property graph primary, RDF export     |
+    Then a knowledge item should be created with id "PAT-001"
+    And the knowledge item status should be "DRAFT"
+    And a KnowledgeItemCreated event should be raised
+
+  @unit @happy-path
+  Scenario: Capture a lesson from completed task
+    Given a task "WORK-042" is completed
+    When I capture a lesson with:
+      | title         | SHACL catches schema drift            |
+      | what_happened | Schema evolved without validation     |
+      | what_learned  | SHACL validation catches issues early |
+      | prevention    | Add SHACL validation to CI pipeline   |
+      | evidence_ref  | jer:jer:work-tracker:task:WORK-042    |
+    Then a knowledge item should be created with id "LES-001"
+    And the lesson should reference task "WORK-042"
+```
+
+#### Semantic Search
+
+```gherkin
+Feature: Semantic Knowledge Search
+  As a Claude Code agent
+  I want to find semantically similar knowledge
+  So that I can apply relevant patterns and lessons
+
+  @integration @query
+  Scenario: Find patterns related to database migration
+    Given patterns exist:
+      | id      | title                    |
+      | PAT-001 | Hybrid Architecture      |
+      | PAT-002 | Incremental Migration    |
+      | PAT-003 | Schema Versioning        |
+    When I search for "how to migrate database schema"
+    Then I should receive results including "PAT-002", "PAT-003"
+    And each result should have a similarity score > 0.5
+```
+
+### 9.3 Cross-Domain BDD Scenarios
+
+New scenarios for integration:
+
+#### Automatic Lesson Capture
+
+```gherkin
+Feature: Automatic Lesson Capture
+  As a Claude Code agent
+  When I complete a task
+  I want to be prompted for lessons learned
+  So that knowledge is captured systematically
+
+  @integration @cross-domain
+  Scenario: Prompt AAR on task completion
+    Given a task "WORK-042" exists with status "in_progress"
+    And the task has effort_hours > 2
+    When I complete task "WORK-042"
+    Then I should receive an AAR prompt with 3 questions
+    When I answer the AAR questions:
+      | what_happened | Implemented SHACL validation |
+      | what_learned  | Early validation saves time  |
+      | prevention    | Add to CI pipeline           |
+    Then a lesson "LES-001" should be created
+    And the lesson should have edge "LEARNED_FROM" to "WORK-042"
+```
+
+#### Pattern Application
+
+```gherkin
+Feature: Pattern Application
+  As a Claude Code agent
+  I want to record when I apply patterns
+  So that pattern usage is tracked
+
+  @integration @cross-domain
+  Scenario: Apply pattern to new task
+    Given a pattern "PAT-001" exists with title "Hybrid Architecture"
+    And a task "WORK-050" exists with status "in_progress"
+    When I apply pattern "PAT-001" to task "WORK-050"
+    Then task "WORK-050" should have edge "APPLIED_PATTERN" to "PAT-001"
+    And task "WORK-050" should have a note "Applied pattern: Hybrid Architecture"
+    And pattern "PAT-001" usage count should increase
+```
+
+#### Knowledge-Enriched Queries
+
+```gherkin
+Feature: Knowledge-Enriched Work Items
+  As a Claude Code agent
+  When I view a work item
+  I want to see related knowledge
+  So that I have relevant context
+
+  @integration @query
+  Scenario: View task with applied patterns
+    Given task "WORK-050" has applied pattern "PAT-001"
+    And task "WORK-050" has lesson "LES-003"
+    When I get task "WORK-050" with enrichment
+    Then the response should include:
+      | applied_patterns | PAT-001 |
+      | learned_lessons  | LES-003 |
+```
+
+---
+
+## 10. Recommendations
+
+### 10.1 Domain Model Recommendations
+
+1. **Unified Vertex Base Class**: Both WorkItem and KnowledgeItem should extend a shared `Vertex` base class with common graph properties. This enables unified graph operations.
+
+2. **Shared Event Infrastructure**: Use a single `IEventStore` and `IEventDispatcher` implementation for both domains. Events from Work Tracker can trigger KM handlers without tight coupling.
+
+3. **Cross-Domain Ports**: Define `IGraphStore` and `ISemanticIndex` ports in a shared domain module. Both Work Tracker and KM adapters implement these ports.
+
+4. **Jerry URI as Integration Key**: Use Jerry URI scheme consistently across both domains. URIs are the foreign keys in the knowledge graph.
+
+5. **Discriminated Value Objects**: KM's Pattern/Lesson/Assumption discriminated union is a proven pattern. Consider similar for Work Tracker types (Epic/Feature/Task/Bug).
+
+### 10.2 Implementation Recommendations
+
+1. **Start with Work Tracker Graph**: Add `IGraphStore` to Work Tracker first (Phase 2, Week 9-10). Validate NetworkX adapter. Then reuse for KM.
+
+2. **Unified Embedding Strategy**: Use same embedding model (text-embedding-3-small) for both Work Tracker search and KM semantic search. Single FAISS index with type metadata.
+
+3. **Incremental Cross-Domain**: Start with read-only cross-domain queries. Add write commands (ApplyPatternToTask) only after read path is stable.
+
+4. **Event-Driven Integration**: Use events for cross-domain communication, not direct method calls. Loose coupling, easier testing, clearer boundaries.
+
+5. **Phased Schema Evolution**: Work Tracker schema is simpler. Test schema evolution (P-030) on Work Tracker before applying to KM.
+
+### 10.3 Risk Recommendations
+
+1. **Monitor Supernode Early**: Implement edge count validator in Week 1-2. Alert at 100 edges. Don't wait for 1000.
+
+2. **Performance Baselines**: Establish query latency baselines on Work Tracker before adding KM. Document expected degradation.
+
+3. **Rollback Strategy**: Define rollback for each phase. Work Tracker can operate without KM. KM without cross-domain is still useful.
+
+4. **User Adoption Metrics**: Track AAR completion rate. If <20% after 2 weeks, simplify prompts. Don't blame users.
+
+5. **Quarterly ROI Review**: Measure time saved finding knowledge. If <10%, reconsider Phase 3 investment.
+
+---
+
+## 11. References
+
+### 11.1 Input Documents
+
+| Document | Path | Size | Purpose |
+|----------|------|------|---------|
+| WORK_TRACKER_PLAN.md | `docs/plans/WORK_TRACKER_PLAN.md` | 89KB | Work Tracker domain specification |
+| ADR-033 | `docs/decisions/ADR-033-unified-km-architecture.md` | 44KB | Unified KM architecture decision |
+| Unified Design | `docs/design/work-033-e-002-unified-design.md` | 64KB | KM domain model and ports |
+| Integration Analysis | `docs/research/work-033-e-001-integration-analysis.md` | 72KB | WORK-031 + WORK-032 integration |
+
+### 11.2 External References
+
+| Reference | Citation | Relevance |
+|-----------|----------|-----------|
+| Hexagonal Architecture | Cockburn, A. (2005) | Core architectural pattern |
+| Domain-Driven Design | Evans, E. (2003) | Bounded contexts, aggregates |
+| CQRS Pattern | Cosmic Python | Command/query separation |
+| Event Sourcing | Microsoft Patterns | Event-based state management |
+| CloudEvents 1.0 | CNCF Specification | Event interoperability |
+| Netflix UDA | Netflix Tech Blog | Multi-representation pattern |
+| Context Rot | Chroma Research | LLM context degradation |
+| FalkorDB GraphRAG | Case Study | 90% hallucination reduction |
+
+### 11.3 Jerry Internal References
+
+| Document | Purpose |
+|----------|---------|
+| CLAUDE.md | Framework root context |
+| Jerry Constitution | Governance principles |
+| SPEC-001 | Jerry URI scheme |
+| coding-standards.md | Code style and patterns |
+
+---
+
+## Appendix A: Work Tracker Entity Details
+
+### A.1 WorkItem Full Specification
+
+```python
+@dataclass
+class WorkItem:
+    """
+    Aggregate root for work tracking.
+
+    Attributes:
+        _id: Unique identifier (WORK-001, WORK-002, ...)
+        _title: Short description (max 200 chars)
+        _description: Detailed description (max 10000 chars)
+        _type: WorkItemType enum (EPIC, FEATURE, TASK, BUG, SPIKE)
+        _status: Status enum (PENDING, IN_PROGRESS, BLOCKED, COMPLETED)
+        _priority: Priority enum (CRITICAL=1, HIGH=2, MEDIUM=3, LOW=4)
+        _parent_id: Optional parent WorkItemId
+        _created_at: Creation timestamp (UTC)
+        _updated_at: Last modification timestamp (UTC)
+        _completed_at: Completion timestamp (UTC, None if not completed)
+        _notes: List of Note value objects
+        _tags: List of Tag value objects
+        _events: Pending domain events
+
+    Invariants:
+        - Title must be 1-200 characters
+        - Status transitions follow state machine
+        - Tasks/Bugs can only have Features/Epics as parents
+        - Completed items cannot be modified (except reopen)
+    """
+
+    # Identity
+    _id: WorkItemId
+
+    # Core properties
+    _title: str
+    _description: str = ""
+    _type: WorkItemType = WorkItemType.TASK
+    _status: Status = Status.PENDING
+    _priority: Priority = Priority.MEDIUM
+    _parent_id: WorkItemId | None = None
+
+    # Timestamps
+    _created_at: datetime = field(default_factory=datetime.utcnow)
+    _updated_at: datetime = field(default_factory=datetime.utcnow)
+    _completed_at: datetime | None = None
+
+    # Collections
+    _notes: list[Note] = field(default_factory=list)
+    _tags: list[Tag] = field(default_factory=list)
+
+    # Events
+    _events: list[DomainEvent] = field(default_factory=list)
+
+    # Factory methods
+    @classmethod
+    def create(cls, title: str, type: WorkItemType = WorkItemType.TASK,
+               priority: Priority = Priority.MEDIUM,
+               parent_id: WorkItemId | None = None,
+               id: WorkItemId | None = None) -> "WorkItem":
+        """Factory method to create new WorkItem."""
+        ...
+
+    @classmethod
+    def reconstitute(cls, events: list[DomainEvent]) -> "WorkItem":
+        """Rebuild from event history."""
+        ...
+
+    # Properties (readonly)
+    @property
+    def id(self) -> WorkItemId: ...
+    @property
+    def title(self) -> str: ...
+    @property
+    def status(self) -> Status: ...
+    @property
+    def is_completed(self) -> bool: ...
+    @property
+    def is_blocked(self) -> bool: ...
+    @property
+    def pending_events(self) -> list[DomainEvent]: ...
+
+    # Commands
+    def update_title(self, new_title: str) -> None: ...
+    def update_description(self, desc: str) -> None: ...
+    def change_priority(self, priority: Priority) -> None: ...
+    def start(self) -> None: ...
+    def block(self, reason: str) -> None: ...
+    def unblock(self) -> None: ...
+    def complete(self, notes: str | None = None) -> None: ...
+    def reopen(self) -> None: ...
+    def add_note(self, content: str) -> None: ...
+    def add_tag(self, tag: Tag) -> None: ...
+    def remove_tag(self, tag: Tag) -> None: ...
+
+    # Internal
+    def _apply(self, event: DomainEvent) -> None: ...
+    def _raise_event(self, event: DomainEvent) -> None: ...
+    def _validate_state_transition(self, target: Status) -> None: ...
+```
+
+### A.2 JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/work-item.json",
+  "title": "WorkItem",
+  "type": "object",
+  "required": ["id", "title", "type", "status", "priority", "created_at", "updated_at"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^WORK-[0-9]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 10000,
+      "default": ""
+    },
+    "type": {
+      "type": "string",
+      "enum": ["epic", "feature", "task", "bug", "spike"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "in_progress", "blocked", "completed"]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"]
+    },
+    "parent_id": {
+      "type": ["string", "null"],
+      "pattern": "^WORK-[0-9]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "notes": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/Note"}
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "$defs": {
+    "Note": {
+      "type": "object",
+      "required": ["content", "created_at"],
+      "properties": {
+        "content": {"type": "string", "maxLength": 5000},
+        "created_at": {"type": "string", "format": "date-time"},
+        "author": {"type": "string", "default": "claude"}
+      }
+    }
+  }
+}
+```
+
+---
+
+## Appendix B: KM Entity Details
+
+### B.1 KnowledgeItem Full Specification
+
+```python
+@dataclass
+class KnowledgeItem(Vertex):
+    """
+    Aggregate root for knowledge management.
+
+    Extends Vertex for graph storage compatibility.
+
+    Attributes:
+        id: Unique identifier (PAT-001, LES-042, ASM-003)
+        uri: Jerry URI (SPEC-001 compliant)
+        title: Short description (max 80 chars)
+        km_type: KnowledgeType enum (PATTERN, LESSON, ASSUMPTION)
+        status: KnowledgeStatus enum (DRAFT, VALIDATED, DEPRECATED)
+        content: Discriminated union (Pattern | Lesson | Assumption)
+        context: When/where this applies
+        tags: Categorization labels
+        related_items: References to other KnowledgeItemIds
+        evidence_refs: Jerry URIs to supporting evidence
+        created_at, created_by, modified_at, modified_by: Audit trail
+        version, content_hash: Versioning
+        metadata: Extension properties
+
+    Invariants:
+        - ID prefix must match km_type (PAT, LES, ASM)
+        - Content type must match km_type
+        - Status transitions follow lifecycle
+        - Evidence URIs must be valid Jerry URIs
+    """
+
+    # Identity (VertexId base class)
+    id: KnowledgeItemId
+    uri: JerryUri = field(init=False)
+
+    # Core properties
+    title: str
+    km_type: KnowledgeType
+    status: KnowledgeStatus = KnowledgeStatus.DRAFT
+    content: Pattern | Lesson | Assumption
+
+    # Context
+    context: str = ""
+    tags: list[str] = field(default_factory=list)
+
+    # Relationships
+    related_items: list[KnowledgeItemId] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)
+
+    # Audit (IAuditable)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_by: str = "system:km"
+    modified_at: datetime = field(default_factory=datetime.utcnow)
+    modified_by: str = "system:km"
+
+    # Versioning (IVersioned)
+    version: str = ""
+    content_hash: str = ""
+
+    # Extension
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    # Commands
+    def validate(self) -> None:
+        """Transition from DRAFT to VALIDATED."""
+        ...
+
+    def deprecate(self, reason: str) -> None:
+        """Mark as no longer applicable."""
+        ...
+
+    def add_evidence(self, evidence_uri: JerryUri) -> None:
+        """Link supporting evidence."""
+        ...
+
+    def relate_to(self, other: KnowledgeItemId) -> None:
+        """Create relationship to another item."""
+        ...
+```
+
+### B.2 Value Object Details
+
+```python
+@dataclass(frozen=True)
+class Pattern:
+    """
+    ADR-style pattern for reusable solutions.
+
+    Fields:
+        context: Situation where problem occurs
+        problem: Challenge to be solved
+        solution: Approach that addresses problem
+        consequences: Trade-offs and implications
+        forces: Optional competing concerns
+        alternatives: Optional other options considered
+    """
+    context: str
+    problem: str
+    solution: str
+    consequences: str
+    forces: list[str] | None = None
+    alternatives: list[str] | None = None
+
+    def to_markdown(self) -> str: ...
+
+@dataclass(frozen=True)
+class Lesson:
+    """
+    AAR-style lesson learned.
+
+    Fields:
+        what_happened: Specific situation or incident
+        what_learned: Insight gained from experience
+        prevention: How to avoid or repeat outcome
+        impact: Magnitude of learning (LOW, MEDIUM, HIGH)
+        confidence: How certain we are (0.0-1.0)
+    """
+    what_happened: str
+    what_learned: str
+    prevention: str
+    impact: str = ""
+    confidence: float = 1.0
+
+    def to_markdown(self) -> str: ...
+
+@dataclass(frozen=True)
+class Assumption:
+    """
+    Tracked assumption requiring validation.
+
+    Fields:
+        statement: What we're assuming to be true
+        impact_if_wrong: Consequences if false
+        validation_path: How to verify or invalidate
+        confidence: How confident we are (0.0-1.0)
+        review_date: When to re-evaluate (ISO 8601)
+    """
+    statement: str
+    impact_if_wrong: str
+    validation_path: str
+    confidence: float = 0.5
+    review_date: str = ""
+
+    def to_markdown(self) -> str: ...
+```
+
+---
+
+## Appendix C: Glossary
+
+| Term | Definition |
+|------|------------|
+| **AAR** | After-Action Review - lightweight knowledge capture protocol (3 questions, <5 min) |
+| **A3** | Toyota problem-solving methodology using A3-sized paper |
+| **Aggregate** | DDD cluster of entities treated as a unit for data changes |
+| **Aggregate Root** | Entry point to an aggregate that enforces invariants |
+| **Assumption** | Belief requiring validation; tracked in KM domain |
+| **Bounded Context** | DDD boundary within which a particular model is defined |
+| **CloudEvents** | CNCF specification for describing events in a common way |
+| **CQRS** | Command Query Responsibility Segregation - separate read/write models |
+| **Domain Event** | Record of something significant that happened in the domain |
+| **Entity** | Object defined primarily by identity rather than attributes |
+| **Event Sourcing** | Pattern where state is derived from sequence of events |
+| **FAISS** | Facebook AI Similarity Search - vector similarity library |
+| **GraphRAG** | Graph-enhanced Retrieval Augmented Generation for LLM grounding |
+| **Hexagonal Architecture** | Ports & Adapters pattern isolating domain from infrastructure |
+| **HybridRAG** | Combined vector + graph retrieval approach |
+| **Jerry URI** | Jerry's unified resource identifier scheme (SPEC-001) |
+| **KM** | Knowledge Management |
+| **Lesson** | Learning captured from past work; KM entity type |
+| **NetworkX** | Python library for graph data structures and algorithms |
+| **Netflix UDA** | Unified Data Architecture - "Model Once, Represent Everywhere" pattern |
+| **Pattern** | Reusable solution to recurring problem; KM entity type |
+| **Port** | Interface defined in domain layer (hexagonal architecture) |
+| **Adapter** | Implementation of port in infrastructure layer |
+| **RDF** | Resource Description Framework - W3C standard for semantic data |
+| **RDFLib** | Python library for RDF processing |
+| **SHACL** | Shapes Constraint Language for RDF validation |
+| **SPARQL** | Query language for RDF databases |
+| **Supernode** | Graph vertex with high edge count causing performance degradation |
+| **Task** | Work Tracker entity representing unit of work |
+| **Value Object** | Object defined by attributes, not identity; immutable |
+| **Vertex** | Node in a graph; base class for Jerry graph entities |
+| **VertexId** | Strongly-typed identifier for graph vertices |
+| **WorkItem** | Work Tracker aggregate root; encompasses tasks, bugs, etc. |
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | `docs/research/work-034-e-001-domain-analysis.md` |
+| **Created** | 2026-01-09 |
+| **Author** | ps-researcher v2.0.0 |
+| **Word Count** | ~12,500 words |
+| **Diagrams** | 8 (ASCII + Mermaid) |
+| **Tables** | 45+ |
+| **Status** | COMPLETE |
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): All claims cited to input documents
+- P-002 (File Persistence): Analysis persisted to markdown file
+- P-004 (Reasoning Transparency): Decision rationale documented throughout
+
+**Next Steps:**
+1. Review with user for accuracy and completeness
+2. Create implementation tasks in Work Tracker
+3. Begin Phase 2 unified implementation per roadmap

--- a/docs/archive/projects-archive/synthesis/work-031-e-006-synthesis.md
+++ b/docs/archive/projects-archive/synthesis/work-031-e-006-synthesis.md
@@ -1,0 +1,1141 @@
+# Unified Knowledge Architecture for Jerry: Cross-Document Synthesis
+
+> **Synthesis ID:** work-031-e-006
+> **Date:** 2026-01-08
+> **Method:** Braun & Clarke Thematic Analysis
+> **Source Count:** 5 research documents
+> **Status:** DECISION-GRADE
+> **Purpose:** Synthesize findings on graph modeling, semantic representations, technologies, semantic data, and LLM grounding
+
+---
+
+## L0: Executive Summary (ELI5)
+
+### What This Synthesis Covers
+
+This document analyzes 5 in-depth research reports on knowledge architecture for Jerry, covering everything from graph database design to LLM grounding. Think of it as connecting the dots between different technologies to see the bigger picture.
+
+### The Big Picture: Five Technologies, One Vision
+
+Across all 5 research documents, a clear pattern emerges: **Jerry should adopt a unified hybrid architecture** that combines:
+
+1. **Property graphs** for fast operational queries (Gremlin)
+2. **RDF/Semantic Web** for standards-based interoperability (SPARQL)
+3. **JSON-LD** for practical semantic data (web integration)
+4. **Vector embeddings** for semantic search (RAG)
+5. **Knowledge graph grounding** for LLM accuracy (GraphRAG)
+
+### Top Cross-Cutting Patterns Found
+
+**Pattern 1: Hybrid-First Architecture**
+Every single document recommends hybrid approaches rather than choosing one paradigm. Property graphs for performance, RDF for standards, vector embeddings for search—use all three together.
+
+**Pattern 2: Four-Phase Implementation Roadmap**
+All documents independently recommend the same phased approach:
+- Phase 1: Property graph + file storage (Jerry is here now ✅)
+- Phase 2: Add semantic layer (JSON-LD, RDF serialization)
+- Phase 3: Advanced capabilities (SPARQL, reasoning, GraphRAG)
+- Phase 4: Scale as needed (cloud deployment, server-based)
+
+**Pattern 3: Netflix UDA as North Star**
+The Netflix "Model Once, Represent Everywhere" pattern is cited in 4 out of 5 documents as the architectural ideal. Jerry's existing EntityBase design already follows this pattern.
+
+**Pattern 4: Pragmatic Semantic Web**
+Don't build everything from scratch. Reuse Schema.org (45M+ websites use it), adopt JSON-LD (70% adoption), and create custom vocabularies only for domain-specific concepts.
+
+**Pattern 5: Performance-Driven Design with Semantic Enhancement**
+Start with what's fast (property graphs, embedded databases), then add semantic capabilities incrementally. Never sacrifice performance for theoretical purity.
+
+**Pattern 6: Validation as Multi-Layer Governance**
+Schema validation, SHACL constraints, supernode detection, grounding verification—multiple layers catch different kinds of errors.
+
+**Pattern 7: LLM Grounding is the Killer App**
+GraphRAG (knowledge graph-based retrieval) achieves 90% hallucination reduction and 63% faster resolution times. This is the strategic "why" behind Jerry's knowledge architecture investment.
+
+### Key Tensions and Tradeoffs
+
+| Tension | Property Graph Side | RDF/Semantic Web Side | Resolution Strategy |
+|---------|--------------------|-----------------------|---------------------|
+| **Performance vs Interoperability** | Fast traversal | Standards-based | Hybrid: property graph primary, RDF export |
+| **Simplicity vs Expressiveness** | Implicit schema | OWL reasoning | Start simple, add reasoning when needed |
+| **Embedded vs Server** | Zero dependencies | Horizontal scale | Embedded first, migrate if scale demands |
+| **Vector vs Graph Retrieval** | Semantic similarity | Relational reasoning | HybridRAG: use both |
+| **Custom vs Standard Vocabularies** | Jerry-specific | Schema.org reuse | Map to standards where possible |
+
+### Strategic Recommendations for Jerry
+
+1. **Implement HybridRAG** (Phase 2): Combine vector retrieval for `docs/` with graph traversal for Work Tracker
+2. **Adopt JSON-LD as semantic layer** (Phase 2): 70% web adoption, practical over RDFa/Microdata
+3. **Use Oxigraph for embedded RDF** (Phase 2): Pure Rust, zero Java, modern standards (RDF 1.2, SPARQL 1.2, RDF*)
+4. **Extend Jerry URI scheme for RAG** (Phase 2): Enable citations with Jerry URIs as source identifiers
+5. **Deploy in production incrementally** (Phase 3): FalkorDB and LinkedIn case studies show 90% hallucination reduction, 63% faster resolution
+
+### What This Means for Jerry's Evolution
+
+Jerry is currently at **4-star Linked Open Data status** (Tim Berners-Lee's scale):
+- ★★★★ **Achieved**: URIs to denote things (Jerry URI scheme SPEC-001)
+- ★★★★★ **Target**: Link data to other data (JSON-LD + Schema.org integration)
+
+The path to 5 stars is clear: implement the patterns identified in this synthesis.
+
+---
+
+## L1: Technical Synthesis (Software Engineer)
+
+### Pattern Catalog
+
+#### PAT-001: Hybrid Property Graph + RDF Architecture
+
+**Context:** When building a knowledge system that needs both operational performance and standards-based interoperability.
+
+**Problem:**
+- Property graphs excel at traversal performance but lack standardization
+- RDF provides standards and reasoning but has performance overhead
+- Choosing one paradigm forces suboptimal tradeoffs
+
+**Solution:**
+Use property graph as primary storage with RDF serialization as export/integration layer:
+```
+Domain Model (Property Graph)
+    ├─ Primary Storage: File-based JSON/TOON
+    ├─ Operational Queries: Gremlin traversal
+    └─ Serialization Adapters:
+        ├─ JSON-LD (web integration)
+        ├─ Turtle (human-readable RDF)
+        ├─ GraphSON (TinkerPop export)
+        └─ RDF* (edge properties without reification)
+```
+
+**Quality:** HIGH
+
+**Sources:**
+- e-001 (Section 11): "Netflix 'Conceptual RDF, Flexible Physical' pattern"
+- e-002 (L2.1): "Hybrid approach: Property graph for operations, RDF for interoperability"
+- e-003 (Section 2.4): "Jerry Alignment: Property graph for storage"
+- e-004 (L2.3): "Jerry URI scheme already RDF-compatible"
+
+**Evidence:**
+- Netflix UDA uses conceptual RDF without requiring RDF end-to-end
+- Jerry URI scheme (SPEC-001) is already RDF-compatible
+- 4 out of 5 documents independently recommend this pattern
+
+---
+
+#### PAT-002: Four-Phase Knowledge Architecture Maturity Model
+
+**Context:** When planning the evolution of a knowledge management system from simple file storage to advanced semantic capabilities.
+
+**Problem:**
+- Building everything at once creates analysis paralysis
+- Premature optimization wastes effort on unused features
+- Missing a clear roadmap leads to architectural inconsistency
+
+**Solution:**
+Adopt a four-phase capability maturity model:
+
+| Phase | Focus | Jerry Implementation | Status |
+|-------|-------|---------------------|--------|
+| **Phase 1: Foundation** | Property graph abstractions, file-based storage | Vertex/Edge/VertexProperty, JSON/TOON | ✅ COMPLETE |
+| **Phase 2: Semantic Layer** | RDF serialization, JSON-LD, SPARQL queries | pyoxigraph, JSON-LD contexts | 🎯 NEXT |
+| **Phase 3: Advanced Capabilities** | SPARQL endpoint, OWL reasoning, GraphRAG | Content negotiation, kglab | 🔮 FUTURE |
+| **Phase 4: Scale** | Server-based deployment, cloud migration | Neptune/Fuseki evaluation | 🔮 OPTIONAL |
+
+**Quality:** HIGH
+
+**Sources:**
+- e-001 (Section L2.4): 3-phase migration + Phase 4 evaluation
+- e-002 (Recommendations): "Immediate (0-3 months), Short-term (3-6), Long-term (6-12)"
+- e-003 (Section L2.7): "Q1-Q4 2026 roadmap"
+- e-004 (L2.1): "Phase 1-4 Integration Roadmap"
+- e-005 (L2.5): "Phase 1-3 Implementation Strategy"
+
+**Evidence:**
+- All 5 documents independently converged on 4-phase structure
+- Aligns with industry best practices (crawl, walk, run, fly)
+- Matches Jerry's existing phase-based Work Tracker model
+
+---
+
+#### PAT-003: Netflix UDA "Model Once, Represent Everywhere"
+
+**Context:** When domain entities need multiple serialization formats for different use cases without duplicating modeling effort.
+
+**Problem:**
+- Each representation format requires separate modeling
+- Changes require updating multiple models
+- Inconsistencies emerge between representations
+
+**Solution:**
+Define canonical domain model once, generate all representations via adapters:
+
+```python
+# Single source of truth
+@dataclass
+class Task(EntityBase):
+    id: VertexId
+    title: str
+    status: str
+    # ... domain logic
+
+# Multiple representations
+TaskJsonSerializer → JSON
+TaskToonSerializer → TOON (human-readable)
+TaskJsonLdSerializer → JSON-LD (semantic web)
+TaskGraphSonSerializer → GraphSON (TinkerPop)
+TaskRdfSerializer → Turtle (RDF)
+TaskEmbeddingSerializer → Vector (RAG)
+```
+
+**Quality:** HIGH
+
+**Sources:**
+- e-001 (DISC-064): "Netflix UDA: Model Once, Represent Everywhere"
+- e-003 (Section L2.4): "Netflix UDA Pattern Application"
+- e-004 (L2.3): "Netflix UDA 'conceptual RDF for knowledge graph'"
+- e-005 (L2.6): "Alignment with Netflix UDA Pattern"
+
+**Evidence:**
+- Netflix deployed this pattern at scale for Unified Data Architecture
+- Jerry's EntityBase already implements this pattern for JSON/TOON
+- Extension to RDF/JSON-LD/embeddings is natural evolution
+
+---
+
+#### PAT-004: Supernode Detection and Mitigation
+
+**Context:** When building property graphs that could develop high-degree vertices causing performance degradation.
+
+**Problem:**
+- High cardinality relationships create "supernodes" (nodes with thousands of edges)
+- Graph traversals become O(n) where n = edge count
+- Performance degrades catastrophically
+- Example: 20M products → 12 categories = 12 supernodes with ~1.67M edges each
+
+**Solution:**
+Implement multi-layer supernode prevention:
+
+1. **Detection:** Monitor edge counts, warn at 100, error at 1000
+2. **Mitigation Strategies:**
+   - Time-based partitioning: `CREATED_BY_2026_01` instead of generic `CREATED_BY`
+   - Hierarchical decomposition: Multi-level taxonomies
+   - Relationship type diversification: Specific edge labels
+   - Intermediate index nodes: For range queries
+
+**Code Example:**
+```python
+class SupernodeValidator:
+    def validate_vertex_degree(
+        self,
+        vertex_id: VertexId,
+        edge_label: str,
+        edge_count: int
+    ) -> ValidationResult:
+        if edge_count >= 1000:
+            return Error(f"Supernode detected: {vertex_id}")
+        elif edge_count >= 100:
+            return Warning(f"Approaching supernode: {vertex_id}")
+        return Ok()
+```
+
+**Quality:** HIGH
+
+**Sources:**
+- e-001 (Section 2.1): "The Supernode Problem" with detailed mitigation strategies
+- e-001 (Table): Jerry supernode risk analysis (Actor = HIGH risk, Phase = MEDIUM)
+
+**Evidence:**
+- Cited by Neo4j, DataStax as primary graph modeling pitfall
+- Jerry faces HIGH risk for Actor vertices (Claude could create thousands of tasks)
+- Preventive implementation cheaper than reactive fixes
+
+---
+
+#### PAT-005: JSON-LD as Pragmatic Semantic Layer
+
+**Context:** When adding semantic meaning to existing JSON data without breaking backward compatibility.
+
+**Problem:**
+- RDFa requires HTML
+- RDF/XML is verbose and not JSON-compatible
+- Microdata has limited adoption (3%)
+- Need semantic web integration without rewriting everything
+
+**Solution:**
+Use JSON-LD as optional extension layer:
+
+```json
+{
+  "@context": "https://jerry.dev/contexts/worktracker.jsonld",
+  "@id": "jer:jer:work-tracker:task:TASK-042",
+  "@type": "Task",
+  "title": "Implement feature",
+  "status": "IN_PROGRESS"
+}
+```
+
+**Benefits:**
+- 70% web adoption (vs 3% RDFa, 46% Microdata)
+- Backward compatible (plain JSON still works)
+- Separates data from presentation
+- Google recommends for SEO
+
+**Quality:** HIGH
+
+**Sources:**
+- e-004 (Section 5.1): "JSON-LD: 70%, Microdata: 46%, RDFa: 3%"
+- e-004 (AD-001): "JSON-LD as Optional Extension Layer"
+- e-002 (Section L2.1): "Use JSON-LD in Phase 2"
+
+**Evidence:**
+- Web Data Commons 2024: 70% of structured data uses JSON-LD
+- Schema.org (45M+ websites) primarily uses JSON-LD
+- W3C recommendation with active community
+
+---
+
+#### PAT-006: HybridRAG (Vector + Graph Retrieval)
+
+**Context:** When building LLM grounding systems that need both semantic similarity search and relational reasoning.
+
+**Problem:**
+- Vector-only RAG lacks relational context (can't answer "what blocks this task?")
+- Graph-only RAG lacks semantic similarity (misses paraphrases)
+- Traditional RAG has 300-token chunk limits that break context
+
+**Solution:**
+Combine vector retrieval and graph traversal in parallel:
+
+```
+User Query: "What tasks block TASK-042?"
+    │
+    ├─ Vector RAG: Embed query → retrieve semantically similar chunks
+    │  └─ Top-5 chunks from docs/ (broad coverage)
+    │
+    ├─ Graph RAG: Parse entities → traverse BLOCKS edges
+    │  └─ Direct relationships from Work Tracker (structured reasoning)
+    │
+    └─ Context Merger: Deduplicate, rank, inject into LLM prompt
+```
+
+**Performance:**
+- 90% hallucination reduction (FalkorDB)
+- 63% faster ticket resolution (LinkedIn: 40hrs → 15hrs)
+- 49% → 86% accuracy (Amazon Finance)
+
+**Quality:** HIGH
+
+**Sources:**
+- e-005 (Section 1.5): "HybridRAG Architecture" with detailed diagram
+- e-005 (Section 5): Production case studies (FalkorDB, LinkedIn, Amazon)
+- e-001 (Section L2.1): Graph traversal patterns for Work Tracker
+
+**Evidence:**
+- Microsoft Research GraphRAG shows substantial improvements over vector-only
+- HybridRAG paper (ArXiv 2024) demonstrates balanced performance
+- Multiple production deployments (FalkorDB, Memgraph, Neo4j)
+
+---
+
+#### PAT-007: Embedded-First, Scale-Later
+
+**Context:** When choosing database architecture for knowledge systems.
+
+**Problem:**
+- Server-based databases require infrastructure setup, monitoring, backups
+- Cloud databases create vendor lock-in and cost commitments
+- Over-engineering for scale that may never be needed
+
+**Solution:**
+Start with embedded databases, migrate only when scale demands:
+
+| Phase | Storage | When to Migrate |
+|-------|---------|-----------------|
+| **Phase 1-2** | Embedded (pyoxigraph, SQLite) | < 10M triples, single-user |
+| **Phase 3** | Hybrid (embedded + SPARQL endpoint) | Multi-user access needed |
+| **Phase 4** | Server-based (Fuseki, Neptune) | > 10M triples, clustering, high availability |
+
+**Quality:** MEDIUM
+
+**Sources:**
+- e-003 (Section 7): "Embedded vs Server-Based Tradeoffs"
+- e-003 (L2.3): "Start embedded, defer server decision until user demand validates need"
+- e-002 (Section L2.4): Technology stack recommendations with phase-based migration
+
+**Evidence:**
+- Oxigraph handles millions of triples in embedded mode
+- Jerry's zero-dependency principle aligns with embedded approach
+- Production migration only needed if specific scale/availability requirements emerge
+
+---
+
+#### PAT-008: Schema.org First, Custom Vocabulary Second
+
+**Context:** When designing semantic vocabularies for domain-specific entities.
+
+**Problem:**
+- Creating vocabularies from scratch is time-consuming
+- Custom vocabularies lack interoperability
+- Maintenance burden for proprietary terms
+
+**Solution:**
+Map to Schema.org where semantically appropriate, extend only when necessary:
+
+| Jerry Concept | Schema.org Mapping | Custom Extension |
+|---------------|-------------------|------------------|
+| Task | `schema:Action` | `jerry:Task` (subclass) |
+| Phase | `schema:Project` | `jerry:Phase` |
+| Actor (Human) | `schema:Person` | None needed |
+| Actor (Claude) | `schema:SoftwareApplication` | None needed |
+| Status | None (domain-specific) | `jerry:TaskStatus` |
+| BlockingReason | None (domain-specific) | `jerry:blockingReason` |
+
+**Quality:** MEDIUM
+
+**Sources:**
+- e-002 (Section 4): "Schema.org 803 types, 1,461 properties, 45M+ websites"
+- e-004 (Section 3.1): "Mapping Jerry Concepts to Schema.org"
+- e-004 (AD-002): "Reuse Schema.org Where Possible"
+
+**Evidence:**
+- Schema.org has massive adoption (45M+ websites, 450B+ objects)
+- Google, Microsoft, Yahoo, Yandex all support Schema.org
+- Reuse reduces maintenance and improves interoperability
+
+---
+
+#### PAT-009: Grounding Verification as Quality Gate
+
+**Context:** When using LLMs to generate responses from retrieved knowledge, ensure factual accuracy.
+
+**Problem:**
+- LLMs hallucinate even when provided grounding context
+- Manual fact-checking doesn't scale
+- Users need confidence in AI-generated responses
+
+**Solution:**
+Add automated grounding verification step:
+
+```
+LLM Response + Retrieved Context
+    ↓
+MiniCheck/FACTS Grounding Verification
+    ↓
+Supported/Not Supported + Confidence Score
+    ↓
+If Not Supported: Emit warning, log to CloudEvents
+```
+
+**Performance:**
+- MiniCheck: GPT-4-level accuracy at 400x lower cost
+- 770M parameter model (small enough for local deployment)
+
+**Quality:** MEDIUM
+
+**Sources:**
+- e-005 (Section 3.1): "MiniCheck (2024)" with benchmark details
+- e-005 (Section 3.2): "FACTS Grounding Benchmark (Google DeepMind, 2025)"
+- e-005 (Section 4.1): Integration into Jerry RAG architecture
+
+**Evidence:**
+- Academic validation (ArXiv paper, LLM-AggreFact benchmark)
+- Industry adoption (Google DeepMind benchmarking)
+- Practical model size (770M parameters)
+
+---
+
+#### PAT-010: Content Negotiation for URI Dereferencing
+
+**Context:** When exposing Jerry entities via HTTP, support multiple representation formats.
+
+**Problem:**
+- Different consumers need different formats (humans want HTML, machines want JSON-LD)
+- Maintaining separate endpoints for each format creates duplication
+- URIs should be dereferenceable (return useful information when accessed)
+
+**Solution:**
+Implement HTTP content negotiation based on Accept header:
+
+```python
+@app.route('/jer/work-tracker/task/<task_id>')
+def resolve_task_uri(task_id: str):
+    accept = request.headers.get('Accept', 'application/json')
+
+    if 'application/ld+json' in accept:
+        return jsonify(task_as_jsonld), 200
+    elif 'text/turtle' in accept:
+        return task_as_turtle, 200
+    elif 'text/html' in accept:
+        return render_template('task.html'), 200
+    else:
+        return jsonify(task_as_json), 200
+```
+
+**Quality:** MEDIUM
+
+**Sources:**
+- e-004 (Section 4): "Content Negotiation for Jerry URIs"
+- e-004 (AD-004): Implementation sketch with Accept header routing
+- e-002 (Section L2.1): Phase 2 RDF serialization adapter
+
+**Evidence:**
+- Tim Berners-Lee Linked Data principle #2: "Use HTTP URIs for dereferencing"
+- W3C Best Practice for content negotiation
+- DBpedia and Wikidata successfully implement this pattern
+
+---
+
+### Cross-Reference Matrix
+
+This matrix shows how patterns appear across the 5 research documents:
+
+| Pattern | e-001 (Gremlin) | e-002 (Semantics) | e-003 (Tech) | e-004 (JSON-LD) | e-005 (LLM) | Agreement Level |
+|---------|-----------------|-------------------|--------------|-----------------|-------------|-----------------|
+| **PAT-001: Hybrid Property Graph + RDF** | ✅ Section 11 | ✅ L2.1 | ✅ Section 2.4 | ✅ L2.3 | ✅ L2.6 | **UNANIMOUS** (5/5) |
+| **PAT-002: Four-Phase Maturity Model** | ✅ L2.4 | ✅ Recommendations | ✅ L2.7 | ✅ L2.1 | ✅ L2.5 | **UNANIMOUS** (5/5) |
+| **PAT-003: Netflix UDA Pattern** | ✅ DISC-064 | ❌ | ✅ L2.4 | ✅ L2.3 | ✅ L2.6 | **STRONG** (4/5) |
+| **PAT-004: Supernode Detection** | ✅ Section 2.1 | ❌ | ❌ | ❌ | ❌ | **SPECIFIC** (1/5) |
+| **PAT-005: JSON-LD as Semantic Layer** | ❌ | ✅ L2.1 | ❌ | ✅ All sections | ❌ | **MODERATE** (2/5) |
+| **PAT-006: HybridRAG** | ✅ Traversal patterns | ❌ | ❌ | ❌ | ✅ Section 1.5 | **MODERATE** (2/5) |
+| **PAT-007: Embedded-First** | ✅ L2.4 | ✅ L2.4 | ✅ Section 7 | ❌ | ❌ | **MODERATE** (3/5) |
+| **PAT-008: Schema.org First** | ❌ | ✅ Section 4 | ❌ | ✅ Section 3.1 | ❌ | **MODERATE** (2/5) |
+| **PAT-009: Grounding Verification** | ❌ | ✅ SHACL | ❌ | ❌ | ✅ Section 3 | **MODERATE** (2/5) |
+| **PAT-010: Content Negotiation** | ❌ | ❌ | ❌ | ✅ Section 4 | ❌ | **SPECIFIC** (1/5) |
+
+**Key Insights:**
+- **Unanimous patterns** (PAT-001, PAT-002) are high-confidence, foundational architecture decisions
+- **Strong patterns** (PAT-003) have broad support but aren't universal
+- **Moderate patterns** (PAT-005-009) are important but context-specific
+- **Specific patterns** (PAT-004, PAT-010) address particular concerns but still critical
+
+---
+
+### Implementation Recommendations by Pattern
+
+#### Immediate (Week 1-2)
+
+1. **PAT-001**: Define RDF serialization adapter architecture
+   - Create `src/infrastructure/persistence/rdf_adapter.py`
+   - Implement Turtle and JSON-LD export for Task/Phase/Plan entities
+
+2. **PAT-004**: Implement supernode validator
+   - Create `src/domain/validation/supernode_validator.py`
+   - Add edge count monitoring to repository save operations
+
+3. **PAT-005**: Create Jerry JSON-LD context
+   - File: `contexts/worktracker.jsonld`
+   - Define @context mappings to Schema.org + Jerry vocabulary
+
+#### Short-term (Month 1-2)
+
+4. **PAT-002**: Document Jerry's four-phase roadmap
+   - Create `docs/design/KNOWLEDGE_ARCHITECTURE_ROADMAP.md`
+   - Map current state and next milestones
+
+5. **PAT-006**: Prototype HybridRAG
+   - Index `docs/` with simple embedding model
+   - Combine vector retrieval + graph traversal
+   - Test with Claude Code agents
+
+6. **PAT-007**: Evaluate Oxigraph integration
+   - Install pyoxigraph: `pip install pyoxigraph`
+   - Create proof-of-concept with 1000 entities
+   - Benchmark vs RDFLib
+
+#### Medium-term (Quarter 1)
+
+7. **PAT-008**: Map Jerry entities to Schema.org
+   - Create `docs/specifications/SCHEMA_ORG_MAPPING.md`
+   - Extend JSON-LD context with Schema.org terms
+
+8. **PAT-009**: Integrate grounding verification
+   - Evaluate MiniCheck model
+   - Add verification step to RAG pipeline
+   - Log results as CloudEvents
+
+9. **PAT-010**: Implement content negotiation
+   - Create Flask endpoint for Jerry URI resolution
+   - Support JSON, JSON-LD, Turtle, HTML
+
+#### Long-term (Quarter 2+)
+
+10. **PAT-003**: Formalize Netflix UDA pattern in Jerry
+    - Document in `docs/design/MULTI_REPRESENTATION_PATTERN.md`
+    - Create adapter registry for new formats
+    - Ensure all entities support multiple serializations
+
+---
+
+## L2: Strategic Synthesis (Principal Architect)
+
+### Emergent Architectural Themes
+
+#### Theme 1: Knowledge Architecture as Competitive Advantage
+
+**Synthesis Across Documents:**
+
+The most striking finding across all 5 documents is that **knowledge architecture is no longer infrastructure—it's strategic differentiation**. The evidence:
+
+| Source | Strategic Evidence |
+|--------|-------------------|
+| **e-001** | Graph query performance determines system responsiveness |
+| **e-002** | Schema.org integration enables Google Knowledge Graph indexing |
+| **e-003** | Embedded vs server-based choice affects total cost of ownership |
+| **e-004** | 5-star Linked Open Data enables ecosystem participation |
+| **e-005** | GraphRAG achieves 300-320% ROI, 90% hallucination reduction |
+
+**Implication for Jerry:**
+Jerry's knowledge architecture decisions directly impact:
+- **Agent effectiveness** (grounding accuracy, hallucination rates)
+- **System evolution** (ability to add new capabilities without rewrites)
+- **Ecosystem integration** (interoperability with external systems)
+- **User trust** (transparency through citations, verification)
+
+This elevates knowledge architecture from "technical concern" to "strategic capability."
+
+---
+
+#### Theme 2: The Semantic Web Pragmatic Turn (2024-2025)
+
+**Historical Context:**
+The Semantic Web was proposed in 2001 by Tim Berners-Lee. For 20+ years, it was viewed as academic, over-engineered, and impractical.
+
+**2024-2025 Shift:**
+The research documents reveal a **pragmatic semantic web** emerging:
+
+| Evolution | Old Semantic Web | New Pragmatic Web |
+|-----------|-----------------|-------------------|
+| **Adoption** | Academic projects | 45M+ websites (Schema.org) |
+| **Format** | RDF/XML (verbose) | JSON-LD (70% adoption) |
+| **Tools** | Java-heavy (Jena) | Modern (Oxigraph Rust/Python) |
+| **Reasoning** | OWL Full (undecidable) | OWL DL + lightweight inference |
+| **Use Case** | Open-world research | Closed-world enterprise KGs |
+| **Killer App** | Federated queries | LLM grounding (GraphRAG) |
+
+**Tipping Point:** LLM grounding via knowledge graphs is the "killer app" that makes semantic technologies mainstream.
+
+**Implication for Jerry:**
+Jerry is well-positioned to adopt semantic web technologies **now** because:
+- JSON-LD has critical mass (70% adoption)
+- Embedded options exist (pyoxigraph)
+- LLM grounding provides clear ROI (90% hallucination reduction)
+- Jerry URI scheme is already RDF-compatible
+
+---
+
+#### Theme 3: Performance-Semantics Tradeoff Resolution via Hybrid Architectures
+
+**The Core Tension:**
+
+Every document grapples with the same tradeoff:
+
+```
+Property Graphs               RDF/Semantic Web
+├─ Fast traversal            ├─ Standards-based
+├─ Implicit schema           ├─ Explicit ontologies
+├─ Edge properties native    ├─ Reasoning capabilities
+├─ Vendor-specific queries   ├─ W3C specifications
+└─ Limited interoperability  └─ Performance overhead
+```
+
+**Traditional Approach:** Choose one paradigm, accept limitations.
+
+**Emerging Consensus:** Don't choose—use both via **hybrid architecture**.
+
+**Evidence Across Documents:**
+
+| Document | Hybrid Recommendation |
+|----------|----------------------|
+| **e-001** | "Proceed with property graph for Phase 1-3. Add RDF serialization in Phase 4" |
+| **e-002** | "Hybrid approach: Property graph for operations, RDF for interoperability" |
+| **e-003** | "Use property graph for operational queries, RDF for interoperability and reasoning" |
+| **e-004** | "Jerry can follow this hybrid pattern" (Netflix UDA reference) |
+| **e-005** | "HybridRAG: Combining vector retrieval with graph traversal" |
+
+**Resolution Strategy:**
+
+```
+UNIFIED ARCHITECTURE
+├─ Core: Property graph (TinkerPop)
+│   └─ Fast operational queries (Gremlin)
+├─ Layer 1: RDF serialization (pyoxigraph)
+│   └─ Standards-based export (Turtle, JSON-LD)
+├─ Layer 2: Vector embeddings (RAG)
+│   └─ Semantic search (cosine similarity)
+└─ Layer 3: LLM grounding (HybridRAG)
+    └─ Graph traversal + vector retrieval
+```
+
+**Implication for Jerry:**
+Jerry should **not choose** between property graphs and RDF. Implement hybrid architecture with property graph as primary, RDF as serialization layer, and vectors as search index.
+
+---
+
+#### Theme 4: Validation as Multi-Layer Defense
+
+**Synthesis Finding:**
+All documents emphasize validation, but at different layers:
+
+| Layer | Document | Validation Type | Purpose |
+|-------|----------|----------------|---------|
+| **Layer 1: Schema** | e-001 | Explicit schema definition | Prevent accidental drift |
+| **Layer 2: Constraints** | e-002 | SHACL shapes | Enforce business rules |
+| **Layer 3: Performance** | e-001 | Supernode detection | Prevent degradation |
+| **Layer 4: Semantics** | e-004 | Content negotiation | Ensure dereferenceability |
+| **Layer 5: Grounding** | e-005 | MiniCheck verification | Reduce hallucinations |
+
+**Strategic Pattern:**
+Validation isn't a single checkpoint—it's a **defense-in-depth** strategy where each layer catches different error classes.
+
+**Implication for Jerry:**
+Implement validation at all 5 layers:
+
+```python
+# Jerry validation pipeline
+class ValidationPipeline:
+    def validate(self, entity: EntityBase) -> ValidationResult:
+        results = []
+
+        # Layer 1: Schema validation
+        results.append(self.schema_validator.validate(entity))
+
+        # Layer 2: SHACL constraints (if RDF serializable)
+        if hasattr(entity, 'to_rdf'):
+            results.append(self.shacl_validator.validate(entity.to_rdf()))
+
+        # Layer 3: Supernode detection (if graph vertex)
+        if isinstance(entity, Vertex):
+            results.append(self.supernode_validator.validate(entity))
+
+        # Layer 4: URI dereferenceability
+        results.append(self.uri_validator.validate(entity.uri))
+
+        # Layer 5: Grounding verification (if LLM-generated)
+        if entity.metadata.get('llm_generated'):
+            results.append(self.grounding_validator.verify(entity))
+
+        return ValidationResult.combine(results)
+```
+
+---
+
+#### Theme 5: Incremental Capability Maturity Over Big Bang
+
+**Cross-Document Pattern:**
+Every document recommends **incremental** over **big bang** adoption:
+
+| Phase | Capability Added | Risk Level | Reversibility |
+|-------|------------------|------------|---------------|
+| **Phase 1** | Property graph foundation | Low | N/A (prerequisite) |
+| **Phase 2** | RDF serialization, JSON-LD | Low | High (optional export) |
+| **Phase 3** | SPARQL, reasoning, GraphRAG | Medium | Medium (additional layer) |
+| **Phase 4** | Server-based, cloud scale | High | Low (migration effort) |
+
+**Why This Matters:**
+
+1. **Risk Management**: Each phase can fail without destroying previous phases
+2. **Value Delivery**: Each phase provides immediate value
+3. **Learning Loops**: Feedback from Phase N informs Phase N+1
+4. **Resource Allocation**: Defer expensive capabilities until validated
+
+**Anti-Pattern (Observed in Industry):**
+Many organizations attempt "semantic web all at once" projects:
+- Define OWL ontology (months)
+- Build triple store infrastructure (months)
+- Migrate all data (months)
+- → Project fails before delivering value
+
+**Jerry's Advantage:**
+Already at Phase 1 (property graph abstractions), can incrementally add semantic capabilities without disruption.
+
+---
+
+### Strategic Tensions and Trade-offs
+
+#### Tension 1: Simplicity vs Expressiveness
+
+**The Dilemma:**
+- **Simplicity** (property graphs, JSON) enables fast iteration but limits formal reasoning
+- **Expressiveness** (OWL Full, complex ontologies) enables powerful inference but creates cognitive overhead
+
+**Resolution Strategy:** Start simple, add expressiveness incrementally
+
+**Evidence:**
+- e-001: "Use Gremlin, defer SPARQL to Phase 4"
+- e-002: "Use OWL DL (decidable) over OWL Full (undecidable)"
+- e-003: "Embedded first, server-based only if scale demands"
+
+**Decision Framework:**
+```
+IF use_case == "simple_crud":
+    USE property_graph
+ELIF use_case == "relational_queries":
+    USE property_graph + Gremlin
+ELIF use_case == "semantic_interoperability":
+    ADD rdf_serialization
+ELIF use_case == "formal_reasoning":
+    ADD owl_dl_ontology
+ELIF use_case == "open_world_research":
+    CONSIDER owl_full  # Rarely needed
+```
+
+---
+
+#### Tension 2: Standards Compliance vs Performance Optimization
+
+**The Dilemma:**
+- **Standards** (W3C RDF, SPARQL) enable interoperability but have performance overhead
+- **Optimizations** (custom formats, proprietary queries) improve performance but reduce portability
+
+**Resolution Strategy:** Optimize primary path, standardize export path
+
+**Evidence:**
+- e-001: "Property graph for performance, RDF for export"
+- e-003: "Embedded databases faster than server-based"
+- e-005: "HybridRAG combines both for balanced performance"
+
+**Jerry's Approach:**
+```
+Primary Path (Hot Path):
+├─ Property graph in memory
+├─ Gremlin traversal (fast)
+└─ JSON/TOON serialization (simple)
+
+Export Path (Interoperability):
+├─ RDF serialization on-demand
+├─ JSON-LD for web integration
+└─ SPARQL endpoint (optional)
+```
+
+---
+
+#### Tension 3: Custom Vocabulary vs Standard Vocabulary
+
+**The Dilemma:**
+- **Custom vocabulary** (Jerry-specific terms) precisely models domain but lacks interoperability
+- **Standard vocabulary** (Schema.org) enables integration but may not fit domain perfectly
+
+**Resolution Strategy:** Map to standards where appropriate, extend where necessary
+
+**Evidence:**
+- e-002: "Schema.org has 803 types, 1,461 properties"
+- e-004: "Map Jerry entities to Schema.org types where semantically appropriate"
+- e-004: PAT-008: "Schema.org First, Custom Vocabulary Second"
+
+**Decision Matrix:**
+
+| Concept | Standard Exists? | Semantic Fit? | Decision |
+|---------|-----------------|---------------|----------|
+| Person | ✅ schema:Person | ✅ Exact | **USE STANDARD** |
+| Task | 🟡 schema:Action | 🟡 Close | **EXTEND** (schema:Action + jerry:Task) |
+| BlockingReason | ❌ None | N/A | **CREATE CUSTOM** |
+| Phase | 🟡 schema:Project | 🟡 Close | **EXTEND** |
+
+---
+
+### Recommendations for Jerry's Knowledge Architecture
+
+#### Strategic Decision 1: Adopt Hybrid Architecture (Phase 2)
+
+**Decision:** Implement property graph + RDF hybrid with JSON-LD as semantic layer.
+
+**Rationale:**
+- **Unanimous support** across all 5 documents (PAT-001)
+- Netflix UDA pattern validation (production-proven)
+- Jerry URI scheme already RDF-compatible
+- Maintains backward compatibility (JSON still works)
+
+**Implementation:**
+```
+Phase 2a (Month 1-2):
+├─ Create JSON-LD context (contexts/worktracker.jsonld)
+├─ Implement RDF serialization adapters
+├─ Add optional @context to entity serialization
+└─ Document hybrid pattern in design docs
+
+Phase 2b (Month 3-4):
+├─ Integrate pyoxigraph for embedded RDF storage
+├─ Enable Turtle export for all entities
+├─ Create SHACL validation shapes
+└─ Test with external RDF tools (RDFLib, Protégé)
+```
+
+**Success Metrics:**
+- ✅ All Jerry entities serializable to JSON-LD
+- ✅ RDF export validates against SHACL shapes
+- ✅ Backward compatibility maintained (plain JSON still works)
+
+---
+
+#### Strategic Decision 2: Implement HybridRAG for LLM Grounding (Phase 2-3)
+
+**Decision:** Deploy HybridRAG combining vector retrieval (docs/) with graph traversal (Work Tracker).
+
+**Rationale:**
+- 90% hallucination reduction (FalkorDB case study)
+- 63% faster resolution (LinkedIn case study)
+- Addresses Jerry's core mission (knowledge accumulation + problem solving)
+- Property graph already exists (Work Tracker)
+
+**Implementation:**
+```
+Phase 2 (Vector RAG - Month 2-3):
+├─ Index docs/ with text-embedding-3-small
+├─ Store embeddings alongside documents (TOON format)
+├─ Implement cosine similarity search
+└─ Inject top-k results into Claude Code prompts
+
+Phase 3 (Graph RAG - Month 4-5):
+├─ Extend Work Tracker with embedding properties
+├─ Implement graph traversal retrieval (Gremlin)
+├─ Create context merger (vector + graph results)
+└─ Add Jerry URI citations to responses
+
+Phase 3 (Grounding Verification - Month 5-6):
+├─ Integrate MiniCheck model (optional)
+├─ Log verification results as CloudEvents
+└─ Emit warnings for unsupported claims
+```
+
+**Success Metrics:**
+- ✅ Claude Code agents can retrieve from Jerry knowledge base
+- ✅ Responses include Jerry URI citations
+- ✅ Measurable reduction in hallucinations (baseline vs RAG)
+
+---
+
+#### Strategic Decision 3: Four-Phase Roadmap as Master Plan
+
+**Decision:** Formalize Jerry's evolution using the four-phase maturity model found across all documents.
+
+**Rationale:**
+- **Unanimous support** across all 5 documents (PAT-002)
+- Aligns with industry best practices (crawl, walk, run, fly)
+- Provides clear decision framework for future capabilities
+- Matches Work Tracker's phase-based structure
+
+**Implementation:**
+Create `docs/design/KNOWLEDGE_ARCHITECTURE_ROADMAP.md`:
+
+```markdown
+# Jerry Knowledge Architecture Roadmap
+
+## Phase 1: Foundation (✅ COMPLETE)
+- Property graph abstractions (Vertex, Edge, VertexProperty)
+- File-based storage (JSON, TOON)
+- Jerry URI scheme (SPEC-001)
+- Work Tracker graph model
+- CloudEvents integration
+
+## Phase 2: Semantic Layer (🎯 CURRENT - Q1 2026)
+- RDF serialization (pyoxigraph)
+- JSON-LD contexts
+- SHACL validation
+- Vector RAG (docs/ indexing)
+- GraphRAG (Work Tracker traversal)
+
+## Phase 3: Advanced Capabilities (🔮 FUTURE - Q2-Q3 2026)
+- SPARQL endpoint (Flask + content negotiation)
+- OWL ontology (jerry-ontology.ttl)
+- Reasoning engine (OWL-RL)
+- Cytoscape.js visualization
+- Grounding verification (MiniCheck)
+
+## Phase 4: Scale (Optional - Q4 2026+)
+- Server-based deployment evaluation
+- Cloud migration (Neptune/Fuseki)
+- Clustering, high availability
+- Performance at 10M+ triples
+```
+
+---
+
+#### Strategic Decision 4: Validation as Constitutional Requirement
+
+**Decision:** Extend Jerry Constitution with governance for knowledge architecture decisions.
+
+**Rationale:**
+- Multi-layer validation pattern found across documents
+- Supernode risk requires proactive governance
+- Grounding verification aligns with P-001 (Truth and Accuracy)
+
+**Implementation:**
+Add to `docs/governance/JERRY_CONSTITUTION.md`:
+
+```markdown
+## P-030: Schema Evolution Governance (Hard Principle)
+
+All graph schema changes MUST:
+1. Be documented in schema changelog
+2. Include forward migration script
+3. Include rollback migration script
+4. Pass validation tests before deployment
+
+Rationale: Schema changes affect traversal semantics and query assumptions.
+
+## P-031: Supernode Prevention (Medium Principle)
+
+Vertices SHOULD be validated for edge degree:
+- Warning threshold: 100 edges of same label
+- Error threshold: 1000 edges of same label
+- HIGH-risk vertices (Actor) require mitigation strategy
+
+Rationale: Supernodes degrade performance catastrophically.
+
+## P-032: Grounding Verification (Medium Principle)
+
+LLM-generated content that includes Jerry knowledge SHOULD:
+1. Include source citations (Jerry URIs)
+2. Log retrieval context for reproducibility
+3. Pass grounding verification (if enabled)
+
+Rationale: Aligns with P-001 (Truth and Accuracy).
+```
+
+---
+
+### Knowledge Items to Generate
+
+Based on this synthesis, the following knowledge artifacts should be created:
+
+#### PAT (Pattern) Items
+
+✅ **PAT-001 through PAT-010** documented in this synthesis
+
+#### LES (Lesson) Items
+
+1. **LES-001: Hybrid Architecture Prevents Vendor Lock-In**
+   - Topic: Architecture decisions
+   - Lesson: Don't choose property graph OR RDF—use both via adapters
+   - Context: Multiple documents independently recommend hybrid approach
+   - File: `docs/experience/LES-001-hybrid-prevents-lockin.md`
+
+2. **LES-002: Semantic Web Reached Pragmatic Maturity in 2024-2025**
+   - Topic: Technology adoption timing
+   - Lesson: JSON-LD, Oxigraph, GraphRAG make semantic web practical
+   - Context: 70% JSON-LD adoption, 45M+ Schema.org websites, production GraphRAG
+   - File: `docs/experience/LES-002-semantic-web-pragmatic-turn.md`
+
+3. **LES-003: LLM Grounding is Knowledge Architecture's Killer App**
+   - Topic: Strategic ROI
+   - Lesson: GraphRAG achieves 90% hallucination reduction, 300-320% ROI
+   - Context: Multiple production case studies (FalkorDB, LinkedIn, Amazon)
+   - File: `docs/experience/LES-003-llm-grounding-killer-app.md`
+
+#### ASM (Assumption) Items
+
+1. **ASM-001: Jerry Will Remain Single-Tenant Through Phase 3**
+   - Assumption: No multi-user, no clustering requirements
+   - Validation: Phase 2-3 design assumes embedded databases sufficient
+   - Risk: If multi-tenant SaaS needed, requires Phase 4 migration
+   - File: `docs/assumptions/ASM-001-single-tenant-through-phase-3.md`
+
+2. **ASM-002: Property Graph Performance Sufficient for Jerry Scale**
+   - Assumption: File-based graph handles expected Jerry workload
+   - Validation: Work Tracker unlikely to exceed 10M entities
+   - Risk: If scale exceeds 10M entities, requires Phase 4 migration
+   - File: `docs/assumptions/ASM-002-property-graph-sufficient-scale.md`
+
+---
+
+### Source Summary Table
+
+| Source | Key Contribution | Patterns Contributed | Unique Insights |
+|--------|------------------|---------------------|----------------|
+| **e-001: Gremlin Modeling** | Graph modeling best practices, supernode detection, migration patterns | PAT-001, PAT-002, PAT-004, PAT-007 | Supernode risk analysis specific to Jerry (Actor = HIGH), Netflix UDA citation |
+| **e-002: Semantic Representations** | OWL/SKOS/RDF-S/Schema.org comparison, when to use each standard | PAT-001, PAT-002, PAT-008 | OWL expressiveness levels (Lite/DL/Full decidability), Schema.org massive adoption (45M+ sites) |
+| **e-003: Semantic Technologies** | Triple stores, graph databases, Python libraries, embedded vs server | PAT-001, PAT-002, PAT-007 | Oxigraph as modern embedded option (Rust, zero Java), tool comparison matrices |
+| **e-004: Semantic Data** | JSON-LD patterns, content negotiation, 5-star Linked Open Data | PAT-001, PAT-002, PAT-005, PAT-008, PAT-010 | JSON-LD 70% adoption, Tim Berners-Lee 5-star model, CloudEvents + JSON-LD integration |
+| **e-005: LLM Grounding** | RAG architectures, GraphRAG, HybridRAG, grounding verification, production case studies | PAT-001, PAT-002, PAT-006, PAT-009 | 90% hallucination reduction, 300-320% ROI, MiniCheck (GPT-4 accuracy at 400x lower cost) |
+
+**Cross-Document Themes:**
+- All 5 documents recommend **hybrid architecture** (property graph + RDF)
+- All 5 documents recommend **four-phase implementation**
+- 4/5 documents cite **Netflix UDA pattern** as architectural ideal
+- 3/5 documents recommend **embedded-first, scale-later**
+- Production evidence concentrated in e-005 (LLM grounding case studies)
+
+---
+
+### Contradictions and Tensions Identified
+
+#### Contradiction 1: Reasoning Utility
+
+**Position A** (e-002):
+> "OWL reasoning enables automatic inference and consistency checking. Use OWL DL for decidable reasoning."
+
+**Position B** (e-001, e-003):
+> "Property graphs provide no native reasoning. Netflix UDA uses conceptual RDF without requiring reasoning end-to-end."
+
+**Resolution:**
+- Reasoning is **useful but not critical** for Jerry Phase 1-2
+- Defer to Phase 3 when semantic interoperability becomes requirement
+- If reasoning needed, use OWL DL (decidable) over OWL Full
+
+**Recommendation:** Document in `docs/design/REASONING_STRATEGY.md` that reasoning is Phase 3 capability, not Phase 2.
+
+---
+
+#### Contradiction 2: Embedded vs Server-Based Timing
+
+**Position A** (e-003):
+> "Embedded databases sufficient for < 10M triples, single-user deployments."
+
+**Position B** (e-001, e-002):
+> "Server-based solutions (Fuseki, Neptune) needed for production scale."
+
+**Resolution:**
+This isn't a true contradiction—it's a **threshold question**:
+- **Embedded**: Sufficient for Jerry Phase 1-3 (expected < 10M entities)
+- **Server**: Required only if multi-tenant SaaS or > 10M entities
+
+**Recommendation:** Adopt ASM-001 and ASM-002 (documented above) to make assumptions explicit. Trigger Phase 4 evaluation only when thresholds crossed.
+
+---
+
+#### Contradiction 3: GraphRAG vs Traditional RAG Complexity
+
+**Position A** (e-005):
+> "GraphRAG provides substantial improvements over vector-only RAG for complex reasoning."
+
+**Position B** (e-005):
+> "Traditional RAG is simpler and works well for semantic similarity."
+
+**Resolution:**
+This is a **use case distinction**, not a contradiction:
+- **Traditional RAG**: Simple facts, semantic similarity ("What is X?")
+- **GraphRAG**: Multi-hop reasoning ("What blocks X?", "What depends on X?")
+- **HybridRAG**: Best of both (recommended)
+
+**Recommendation:** Implement **HybridRAG** to avoid choosing. Use query patterns to route to appropriate retrieval method.
+
+---
+
+## Validation Checklist
+
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| **Read all 5 source documents** | ✅ COMPLETE | All files read and analyzed |
+| **Used Write tool to create output** | ✅ COMPLETE | This file created via Write tool |
+| **Cited sources for patterns** | ✅ COMPLETE | Each pattern includes Sources section |
+| **Noted contradictions** | ✅ COMPLETE | Section "Contradictions and Tensions Identified" |
+| **L0 Executive Summary** | ✅ COMPLETE | Plain language, 2-3 paragraphs, key insights |
+| **L1 Technical Synthesis** | ✅ COMPLETE | 10 patterns with context/problem/solution, cross-reference matrix |
+| **L2 Strategic Synthesis** | ✅ COMPLETE | Emergent themes, strategic tensions, recommendations |
+| **Pattern Catalog (PAT-XXX)** | ✅ COMPLETE | PAT-001 through PAT-010 with quality ratings |
+| **Source Summary Table** | ✅ COMPLETE | Table with key contributions and patterns |
+| **Braun & Clarke methodology** | ✅ COMPLETE | Thematic analysis phases applied |
+
+---
+
+## Changelog
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-08 | ps-synthesizer agent (v2.0.0) | Initial synthesis of 5 research documents using Braun & Clarke thematic analysis |
+
+---
+
+*Synthesis Method: Braun & Clarke 6-Phase Thematic Analysis*
+*Pattern Quality: HIGH (unanimous/strong), MEDIUM (moderate support), LOW (specific/contextual)*
+*Agent: ps-synthesizer (v2.0.0)*
+*Constitution Compliance: P-001 (Truth & Accuracy - all claims cited), P-002 (File Persistence - synthesis documented)*

--- a/docs/archive/projects-archive/synthesis/work-032-e-006-km-synthesis.md
+++ b/docs/archive/projects-archive/synthesis/work-032-e-006-km-synthesis.md
@@ -1,0 +1,858 @@
+# Knowledge Management Domain Synthesis
+
+**PS ID:** work-032
+**Entry ID:** e-006
+**Topic:** Cross-Document Thematic Synthesis
+**Date:** 2026-01-08
+**Agent:** ps-synthesizer v2.0.0
+**Analysis Method:** Braun & Clarke Thematic Analysis
+
+---
+
+## L0: Executive Summary (ELI5)
+
+**What This Document Does:**
+
+This synthesis combines findings from five research documents (358KB total) about Knowledge Management to create a clear picture of how Jerry should handle knowledge. Think of it like combining five puzzle pieces to see the full picture.
+
+**The Big Discovery:**
+
+Knowledge Management isn't just about storing information—it's about creating a living system where knowledge flows through different stages (from tacit hunches to explicit documents), using the right tools (graphs, databases, AI), following proven processes (standards, frameworks), and continuously improving through structured reflection.
+
+**What Jerry Should Do:**
+
+1. **Start Simple**: Use lightweight Python libraries (NetworkX, RDFLib, FAISS) in the infrastructure layer
+2. **Follow Proven Methods**: Implement A3 problem-solving and After-Action Reviews to capture learning
+3. **Build Smart**: Create a three-tier architecture (filesystem → graph → AI) that grows with needs
+4. **Think Long-Term**: Align toward ISO 30401 standard as Jerry matures
+
+**Why This Matters:**
+
+Jerry's mission is to accrue knowledge, wisdom, and experience. This synthesis provides the blueprint for HOW to do that systematically, not just hope it happens.
+
+---
+
+## L1: Technical Synthesis
+
+### Cross-Reference Matrix: How Documents Connect
+
+| Concept | Fundamentals (e-001) | Protocols (e-002) | Products (e-003) | SDKs (e-004) | Frameworks (e-005) |
+|---------|----------------------|-------------------|------------------|--------------|-------------------|
+| **SECI Model** | ✓ Core theory | ✓ Knowledge flow | - | - | ✓ Layer 2 framework |
+| **Graph-based KM** | ○ Mentioned | ○ GraphRAG | ✓ Neo4j primary | ✓ NetworkX recommended | ✓ GraphRAG framework |
+| **ISO 30401** | ✓ Standard defined | ✓ Implementation guide | - | - | ○ Governance alignment |
+| **RAG/AI** | ✓ Trend identified | - | ✓ Glean, Coveo | ✓ FAISS, ChromaDB | ✓ RAG/GraphRAG frameworks |
+| **Cynefin** | ✓ Context framework | ○ Problem classification | - | - | ✓ Layer 1 classification |
+| **Communities of Practice** | ✓ Wenger theory | - | - | - | ○ Agent analogy |
+| **Local-First** | - | - | ✓ Obsidian, Logseq | ✓ NetworkX, RDFLib | - |
+| **After-Action Review** | ○ Learning process | ✓ Protocol detailed | - | - | ✓ Documentation layer |
+| **A3 Thinking** | ○ Toyota reference | ✓ Protocol detailed | - | - | ✓ Primary framework |
+| **Vector Search** | ✓ AI trend | - | ✓ FAISS, ChromaDB | ✓ FAISS primary | ✓ RAG component |
+| **RDF/Semantic Web** | ○ Standards mentioned | - | - | ✓ RDFLib foundation | - |
+| **Knowledge Audit** | ○ Assessment | ✓ 6-step process | - | - | - |
+| **Hexagonal Architecture** | - | - | ✓ Jerry alignment | ✓ Port/adapter pattern | - |
+
+**Legend:** ✓ Primary coverage | ○ Supporting mention | - Not covered
+
+### Thematic Analysis Results
+
+Using Braun & Clarke's six-phase method, I identified **6 major themes** across the 5 documents:
+
+---
+
+#### Theme 1: **The Knowledge Lifecycle is Circular, Not Linear**
+
+**Pattern Across Documents:**
+- **Fundamentals**: SECI Model shows tacit↔explicit conversion spiral
+- **Protocols**: PDCA and Knowledge Flow (7 steps) emphasize cycles
+- **Frameworks**: A3 integrates PDCA; ReAct shows iterative loops
+- **Products**: RAG systems continuously retrieve-generate-feedback
+- **SDKs**: Graph libraries enable circular traversal patterns
+
+**Key Insight:**
+All sources converge on knowledge as a PROCESS, not a PRODUCT. Jerry's filesystem-as-memory must support iteration, not just accumulation.
+
+**Evidence:**
+- Nonaka: "Knowledge creation is a continual process... evolving spiral" (e-001)
+- PDCA: "Just as a circle has no end, the PDCA cycle should be repeated" (e-002)
+- A3: "Follow-up links to subsequent activities" (e-005)
+- RAG: "Retrieval → Generation → Feedback → Improved Retrieval" (e-005)
+
+**Implication for Jerry:**
+- Implement feedback loops in Work Tracker (not just linear task completion)
+- Add "lessons applied" field to track knowledge reuse
+- Create closed-loop learning cycles (AAR → docs/wisdom/ → future tasks)
+
+**Contradictions:** None found. All sources align on circular knowledge flow.
+
+---
+
+#### Theme 2: **Tacit Knowledge is the Hidden Half**
+
+**Pattern Across Documents:**
+- **Fundamentals**: Tacit vs. Explicit distinction is foundational (Nonaka, Polanyi)
+- **Protocols**: AAR captures tacit through dialogue; mentoring transfers tacit
+- **Products**: Personal KM tools (Obsidian, Roam) support externalization
+- **Frameworks**: SECI's Socialization and Externalization modes address tacit
+- **SDKs**: spaCy extracts explicit, but tacit requires human processes
+
+**Key Insight:**
+Technology excels at explicit knowledge (documents, graphs) but struggles with tacit (intuition, context, expertise). Successful KM requires BOTH technical and social solutions.
+
+**Evidence:**
+- "Cultural issues, not technology, are usually the primary obstacle" (e-001)
+- "The template is less important than the thinking process" (A3, e-005)
+- "CoPs address the kind of dynamic 'knowing' that makes a difference in practice" (e-001)
+- Obsidian/Logseq popularity shows need for personal knowledge externalization (e-003)
+
+**Implication for Jerry:**
+- Can't purely automate knowledge capture
+- Agents need "reflection prompts" to externalize reasoning
+- Skills should ask "What did you learn?" not just execute
+- docs/wisdom/ and docs/experience/ are tacit→explicit conversion zones
+
+**Contradictions:**
+- SDKs research focuses heavily on technical solutions (e-004)
+- Fundamentals emphasizes culture and behavior (e-001)
+- **Resolution**: Need BOTH layers—technical infrastructure + behavioral protocols
+
+---
+
+#### Theme 3: **Graph-Based Thinking Dominates Modern KM**
+
+**Pattern Across Documents:**
+- **Fundamentals**: Knowledge as network, not hierarchy
+- **Protocols**: Knowledge maps visualize relationships
+- **Products**: Neo4j adoption by 75% of Fortune 500; Obsidian graph view central
+- **SDKs**: NetworkX, igraph, graph-tool all primary tools
+- **Frameworks**: GraphRAG emerging as state-of-art for complex queries
+
+**Key Insight:**
+The shift from hierarchical taxonomies to graph-based knowledge models is complete. Modern KM = graph databases + vector search + semantic reasoning.
+
+**Evidence:**
+- "GraphRAG: Unlocking LLM discovery on narrative private data" (e-005)
+- "Neo4j adopted by over 75% of Fortune 500" (e-003)
+- "Knowledge graphs becoming critical for advanced RAG" (e-003)
+- NetworkX: 14.9M weekly downloads (e-004)
+
+**Implication for Jerry:**
+- Jerry's docs/ hierarchy should be augmented with graph layer
+- Entity-relationship extraction from markdown files
+- Cross-reference detection as graph edges
+- Knowledge graph = second-order structure over filesystem
+
+**Contradictions:** None. Unanimous support for graph-based approaches.
+
+---
+
+#### Theme 4: **Standards Provide Frameworks, Not Straightjackets**
+
+**Pattern Across Documents:**
+- **Fundamentals**: ISO 30401, SECI, Wiig provide structure
+- **Protocols**: APQC, Kepner-Tregoe offer detailed processes
+- **Products**: RDFLib (RDF standard), ISO compliance features
+- **Frameworks**: Cynefin classifies WHEN to apply standards
+- **SDKs**: RDFLib for standards-based interoperability
+
+**Key Insight:**
+Standards (ISO 30401, RDF, APQC) are valuable for maturity and interoperability, but must be adapted to organizational context. Rigid adherence is counterproductive.
+
+**Evidence:**
+- "Maturity models can be 'inappropriate and dangerous' if followed slavishly" (e-002)
+- "Use maturity models as sources of ideas, not rigid prescriptions" (e-002)
+- ISO 30401: "Applicable to any organization, regardless of type, size" (flexibility) (e-001)
+- Cynefin: "No one-size-fits-all management approach" (e-005)
+
+**Implication for Jerry:**
+- Adopt standards as INSPIRATION, not requirements
+- Start with lightweight protocols (AAR, A3)
+- Progress toward ISO 30401 alignment as Jerry matures
+- Use RDFLib for interoperability, not because "must use RDF"
+
+**Contradictions:**
+- Protocols document heavily prescriptive (Kepner-Tregoe, APQC)
+- Frameworks document emphasizes adaptation (Cynefin, A3 flexibility)
+- **Resolution**: Use Cynefin to determine WHEN prescriptive vs. adaptive
+
+---
+
+#### Theme 5: **AI Integration Requires Grounding**
+
+**Pattern Across Documents:**
+- **Fundamentals**: AI-driven KM market growing 42.3% CAGR; hallucination risks noted
+- **Protocols**: No direct AI coverage (gap)
+- **Products**: RAG as "strategic imperative"; data quality bottleneck
+- **SDKs**: FAISS, ChromaDB for embeddings; transformers for extraction
+- **Frameworks**: RAG/GraphRAG/ReAct all emphasize grounding via retrieval
+
+**Key Insight:**
+LLMs are powerful but unreliable without grounding. Modern KM stacks combine neural (embeddings, generation) with symbolic (graphs, retrieval) for trustworthy AI.
+
+**Evidence:**
+- "KM is foundational for optimizing... ROI from investments in GenAI" (e-001)
+- "Many AI initiatives stalled in 2024 due to data quality issues" (e-003)
+- "Overcomes hallucination by grounding in real data" (ReAct, e-005)
+- "Production RAG reduces post-deployment issues by 50-70%" (e-003)
+
+**Implication for Jerry:**
+- Implement RAG over docs/ hierarchy (vector search + retrieval)
+- Use GraphRAG when relationships matter (multi-hop reasoning)
+- Always provide source citations (grounding)
+- Validate LLM outputs against knowledge base
+
+**Contradictions:**
+- Fundamentals: Optimistic about AI benefits
+- Products/Frameworks: Cautious about hallucination risks
+- **Resolution**: "Trust but verify"—use AI with retrieval grounding
+
+---
+
+#### Theme 6: **Local-First vs. Cloud is a False Dichotomy**
+
+**Pattern Across Documents:**
+- **Fundamentals**: No strong position
+- **Protocols**: File-based emphasis (Dublin Core metadata)
+- **Products**: Obsidian/Logseq (local) vs. Confluence/Notion (cloud)
+- **SDKs**: NetworkX/RDFLib (local) vs. Pinecone/Weaviate (cloud)
+- **Frameworks**: No preference stated
+
+**Key Insight:**
+The dichotomy is dissolving. Modern architecture: local-first WITH optional cloud sync (Obsidian model). Best of both: ownership + collaboration.
+
+**Evidence:**
+- "Local-first is core architecture, not afterthought" (Jerry opportunity, e-003)
+- "49% of enterprise LLM implementations are cloud-based" (e-003)
+- "Hybrid deployments becoming common" (e-003)
+- Jerry's filesystem + optional Wiki.js/cloud features (e-003)
+
+**Implication for Jerry:**
+- Core: Local filesystem (ownership, privacy)
+- Optional: Cloud sync/collaboration (Wiki.js, Obsidian Sync)
+- Hybrid: Local compute + cloud LLMs (via API)
+- Never require cloud for core functionality
+
+**Contradictions:** None. Emerging consensus on hybrid approach.
+
+---
+
+### Cross-Cutting Patterns Summary
+
+| Pattern | Frequency | Significance |
+|---------|-----------|--------------|
+| **Knowledge as cycle, not sequence** | 5/5 documents | Core principle |
+| **Tacit knowledge requires social processes** | 4/5 documents | Critical gap |
+| **Graph-based models dominate** | 5/5 documents | Architectural choice |
+| **Standards guide, don't dictate** | 4/5 documents | Implementation philosophy |
+| **AI needs grounding** | 4/5 documents | Safety requirement |
+| **Local-first with cloud options** | 3/5 documents | Deployment strategy |
+| **Filesystem as foundation** | 3/5 documents (implicit in all) | Jerry's core strength |
+| **Python ecosystem maturity** | 1/5 documents (e-004) | Implementation feasibility |
+
+---
+
+## L2: Strategic Synthesis
+
+### Technology Stack Recommendations
+
+#### Tier 1: Immediate Adoption (Infrastructure Layer)
+
+**Graph Operations:**
+- **Primary**: NetworkX (pure Python, 14.9M downloads/week, minimal deps)
+- **Rationale**: e-004 analysis shows best Jerry fit for prototyping
+- **Migration Path**: igraph (performance) → graph-tool (scale)
+- **Port**: `src/domain/ports/graph_port.py`
+- **Adapter**: `src/infrastructure/graph/networkx_adapter.py`
+
+**Semantic Web:**
+- **Primary**: RDFLib (pure Python, 14M downloads/week, RDF standard)
+- **Rationale**: Standards-based (e-002), interoperable, Jerry-compatible (e-004)
+- **Use Cases**: Knowledge graph serialization, SPARQL queries, ontology integration
+- **Port**: `src/domain/ports/knowledge_port.py`
+- **Adapter**: `src/infrastructure/knowledge/rdflib_adapter.py`
+
+**Vector Search:**
+- **Primary**: FAISS (C++ core, no framework deps, billions of vectors)
+- **Rationale**: e-004 identifies as "best fit for infrastructure layer"
+- **Use Cases**: Semantic search over docs/, RAG implementation
+- **Port**: `src/domain/ports/vector_store_port.py`
+- **Adapter**: `src/infrastructure/embeddings/faiss_adapter.py`
+
+**Document Processing:**
+- **Primary**: Docling (IBM, multi-format, well-packaged)
+- **Rationale**: e-004 recommends as "primary choice for document processing"
+- **Use Cases**: PDF→Markdown, structured extraction, batch processing
+- **Port**: `src/domain/ports/document_port.py`
+- **Adapter**: `src/infrastructure/documents/docling_adapter.py`
+
+**NLP (Optional):**
+- **Primary**: spaCy with en_core_web_sm (12MB model)
+- **Rationale**: Entity extraction, dependency parsing, acceptable infrastructure fit (e-004)
+- **Caution**: Keep models small, consider separate service for large models
+- **Port**: `src/domain/ports/nlp_port.py`
+- **Adapter**: `src/infrastructure/nlp/spacy_adapter.py`
+
+#### Tier 2: Medium-Term Enhancement (Interface Layer)
+
+**Embedding Database:**
+- **Primary**: ChromaDB (for RAG workflows)
+- **Rationale**: e-003/e-004 identify as good for prototyping LLM applications
+- **Use Cases**: Document Q&A, semantic search with metadata filtering
+- **Location**: `src/interface/rag/chroma_rag.py`
+
+**Advanced NLP:**
+- **Primary**: Hugging Face Transformers (REBEL for relation extraction)
+- **Rationale**: State-of-art but heavy (e-004); use in separate service
+- **Use Cases**: Knowledge graph construction from unstructured text
+- **Location**: `src/interface/extraction/` (or separate microservice)
+
+**Visualization:**
+- **Primary**: Obsidian (optional user-facing layer)
+- **Rationale**: e-003 recommends for graph view, Markdown-native
+- **Use Cases**: Jerry vault pointing to docs/, graph visualization
+- **Integration**: User installs Obsidian, points to /home/user/jerry/docs/
+
+#### Tier 3: Long-Term / Advanced (Optional)
+
+**Graph Database:**
+- **Primary**: Neo4j Community Edition (when corpus >1000 docs)
+- **Rationale**: e-003 shows 75% Fortune 500 adoption; e-005 GraphRAG support
+- **Trigger**: Knowledge graph complexity requires ACID, multi-hop reasoning
+- **Location**: `src/infrastructure/graph/neo4j_adapter.py` (swappable via port)
+
+**Production Vector DB:**
+- **Primary**: Qdrant (Rust-based, scalable)
+- **Rationale**: e-004 analysis for production deployment
+- **Trigger**: Vector corpus >10M, need distributed search
+- **Location**: External service with client adapter
+
+**Advanced Frameworks:**
+- **Consider**: LlamaIndex (data ingestion), LangChain (RAG orchestration)
+- **Rationale**: e-004 cautions against deep integration
+- **Strategy**: Use for prototyping, extract patterns, implement natively
+- **Location**: `src/interface/experimental/` (thin adapters only)
+
+### Framework and Protocol Recommendations
+
+#### Immediate Implementation (Q1 2026)
+
+**Layer 1: Problem Classification**
+- **Framework**: Cynefin (e-005 recommendation)
+- **Implementation**: Create `problem-classifier` skill
+- **Purpose**: Classify problem domain before framework selection
+- **Output**: Domain assignment (clear/complicated/complex/chaotic)
+- **Location**: `skills/problem-classifier/SKILL.md`
+
+**Layer 4: Continuous Learning**
+- **Protocol**: After-Action Review (AAR) (e-002 detailed)
+- **Implementation**: AAR template after each work item
+- **Purpose**: Capture lessons learned systematically
+- **Output**: `docs/experience/aar-{work-id}.md`
+- **Template**: `.claude/templates/aar-template.md`
+
+**Layer 4: Documentation**
+- **Protocol**: A3 Problem Solving (e-002, e-005)
+- **Implementation**: One-page problem-solving reports
+- **Purpose**: Combine solving + documentation
+- **Output**: `docs/a3/{work-id}.md`
+- **Template**: `.claude/templates/a3-template.md`
+
+#### Medium-Term Implementation (Q2-Q3 2026)
+
+**Layer 2: Knowledge Flow**
+- **Framework**: SECI Model (e-001 foundation, e-005 integration)
+- **Implementation**: Tag work and docs by SECI mode
+- **Purpose**: Understand knowledge conversion patterns
+- **Metadata**: Add `seci_mode: [socialization|externalization|combination|internalization]`
+
+**Layer 3: AI-Augmented Problem Solving**
+- **Framework**: ReAct + RAG (e-005 detailed)
+- **Implementation**:
+  - Phase 1: Standard RAG over docs/ with FAISS
+  - Phase 2: ReAct pattern formalization in problem-solving skill
+  - Phase 3: GraphRAG for complex queries
+- **Purpose**: Grounded AI reasoning with knowledge retrieval
+
+**Assessment Protocol**
+- **Protocol**: Knowledge Audit (e-002 6-step process)
+- **Implementation**: Quarterly or semi-annual
+- **Purpose**: Assess knowledge coverage, identify gaps
+- **Output**: `docs/governance/knowledge-audit-{YYYY-QN}.md`
+
+#### Long-Term Alignment (Q4 2026+)
+
+**Maturity Framework**
+- **Framework**: APQC Maturity Model (e-002)
+- **Implementation**: Annual self-assessment
+- **Purpose**: Track KM progression: Initiate → Develop → Standardize → Optimize
+- **Current State**: Develop (structured approaches emerging)
+- **Target State**: Standardize (consistent practices, documented processes)
+
+**Standard Alignment**
+- **Standard**: ISO 30401:2018 (e-001, e-002)
+- **Implementation**: Progressive alignment, not certification
+- **Purpose**: Systematic KM maturity, interoperability
+- **Phases**:
+  - Year 1: Informal gap analysis
+  - Year 2: Address major gaps
+  - Year 3+: Full alignment (certification optional)
+
+### Architectural Integration Strategy
+
+#### Hexagonal Architecture Mapping
+
+```
+┌───────────────────────────────────────────────────────┐
+│                 Interface Layer                        │
+│  Heavy Frameworks (LangChain, Transformers, PyG)      │
+│  User-Facing (Obsidian, Wiki.js optional)             │
+│  Agents: ps-*, qa-*, security-auditor                 │
+└───────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────┐
+│            Application Layer (CQRS)                    │
+│  Use Cases: Commands (CreateTask, ExtractKnowledge)   │
+│  Use Cases: Queries (FindRelated, SearchDocs)         │
+│  NO external dependencies                              │
+└───────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────┐
+│         Infrastructure Layer (Adapters)                │
+│  Lightweight: NetworkX, RDFLib, FAISS, Docling        │
+│  Implements: GraphPort, KnowledgePort, VectorPort     │
+│  Swappable: NetworkX → igraph → graph-tool            │
+└───────────────────────────────────────────────────────┘
+                         ↓
+┌───────────────────────────────────────────────────────┐
+│              Domain Layer (Pure Logic)                 │
+│  Entities: Task, Phase, Plan, Knowledge, Relation     │
+│  Ports: GraphPort, KnowledgePort, VectorStorePort     │
+│  ZERO external dependencies                            │
+└───────────────────────────────────────────────────────┘
+```
+
+#### Three-Tier Knowledge Architecture
+
+**Tier 1: Filesystem (Current)**
+- Source of truth: Markdown files in docs/
+- Git versioning
+- Direct agent access
+- Human-readable, portable
+
+**Tier 2: Graph Layer (Q2 2026)**
+- Augments filesystem with relationships
+- NetworkX/RDFLib in infrastructure
+- Cross-reference detection
+- Entity-relationship extraction
+
+**Tier 3: AI Layer (Q3 2026)**
+- RAG: FAISS embeddings over docs/
+- GraphRAG: Multi-hop reasoning
+- ReAct: Grounded agent workflows
+- Source attribution always
+
+### Implementation Roadmap
+
+#### Phase 1: Foundation (Q1 2026) - CURRENT
+
+**Immediate Actions:**
+1. Create AAR template in `.claude/templates/aar-template.md`
+2. Create A3 template in `.claude/templates/a3-template.md`
+3. Implement `problem-classifier` skill using Cynefin
+4. Document SECI mapping in `docs/knowledge/seci-mapping.md`
+
+**Dependencies to Add:**
+```bash
+# Infrastructure layer (acceptable)
+pip install networkx rdflib faiss-cpu docling
+
+# Optional for enhanced capabilities
+pip install spacy
+python -m spacy download en_core_web_sm
+```
+
+**Deliverables:**
+- [ ] AAR template ready
+- [ ] A3 template ready
+- [ ] problem-classifier skill functional
+- [ ] First Knowledge Audit completed
+- [ ] SECI mapping documented
+
+#### Phase 2: Graph Layer (Q2 2026)
+
+**Implement Graph Adapters:**
+```python
+# Port definition
+class GraphPort(ABC):
+    @abstractmethod
+    def add_node(self, node_id: str, properties: dict) -> None: ...
+
+    @abstractmethod
+    def add_edge(self, source: str, target: str, edge_type: str) -> None: ...
+
+    @abstractmethod
+    def traverse(self, start: str, pattern: TraversalPattern) -> List[Node]: ...
+
+# NetworkX adapter
+class NetworkXAdapter(GraphPort):
+    def __init__(self):
+        import networkx as nx
+        self._graph = nx.MultiDiGraph()
+    # ... implementation
+```
+
+**Knowledge Extraction:**
+- Index existing docs/ into graph
+- Extract entities (tasks, phases, plans, documents, concepts)
+- Extract relationships (BELONGS_TO, PART_OF, REFERENCES, USES)
+- Store graph alongside filesystem
+
+**Deliverables:**
+- [ ] GraphPort interface defined
+- [ ] NetworkX adapter implemented
+- [ ] RDFLib adapter implemented
+- [ ] docs/ indexed into graph
+- [ ] Graph query interface available
+
+#### Phase 3: Vector Search (Q3 2026)
+
+**Implement Vector Store:**
+```python
+# Port definition
+class VectorStorePort(ABC):
+    @abstractmethod
+    def add_vectors(self, ids: List[str], vectors: np.ndarray) -> None: ...
+
+    @abstractmethod
+    def search(self, query_vector: np.ndarray, k: int) -> List[SearchResult]: ...
+
+# FAISS adapter
+class FAISSAdapter(VectorStorePort):
+    def __init__(self, dimension: int):
+        import faiss
+        self._index = faiss.IndexFlatL2(dimension)
+    # ... implementation
+```
+
+**RAG Implementation:**
+- Embed all markdown documents
+- Store embeddings in FAISS
+- Create semantic search interface
+- Integrate with agent reasoning
+
+**Deliverables:**
+- [ ] VectorStorePort interface defined
+- [ ] FAISS adapter implemented
+- [ ] docs/ embedded and indexed
+- [ ] Semantic search functional
+- [ ] RAG query interface available
+
+#### Phase 4: Advanced Features (Q4 2026+)
+
+**GraphRAG (Optional):**
+- Upgrade to GraphRAG when corpus >500 docs
+- Multi-hop reasoning across documents
+- Community detection for topic clustering
+- Hierarchical summarization
+
+**Production Scaling (Optional):**
+- Swap NetworkX → igraph for performance
+- Consider Neo4j for ACID + complex queries
+- Consider Qdrant for distributed vector search
+- Evaluate LlamaIndex for data pipelines
+
+**Deliverables:**
+- [ ] GraphRAG evaluated and implemented if needed
+- [ ] Performance optimization completed
+- [ ] Production deployment guide written
+- [ ] ISO 30401 gap analysis completed
+
+### Contradictions Found and Resolved
+
+#### Contradiction 1: Prescriptive vs. Adaptive
+
+**Conflict:**
+- Protocols document (e-002): Highly prescriptive frameworks (Kepner-Tregoe, APQC, ISO 30401)
+- Frameworks document (e-005): Emphasizes adaptation, flexibility (Cynefin, A3 thinking)
+
+**Analysis:**
+- Both are correct for different contexts
+- Cynefin explains WHEN to be prescriptive vs. adaptive
+
+**Resolution:**
+- Use Cynefin as meta-framework
+- Clear/Complicated domains: Apply prescriptive methods (K-T, APQC)
+- Complex/Chaotic domains: Use adaptive methods (Design Thinking, OODA)
+- Implement `problem-classifier` skill to route appropriately
+
+#### Contradiction 2: Technology-Centric vs. Culture-Centric
+
+**Conflict:**
+- SDKs document (e-004): Heavy focus on technical solutions
+- Fundamentals document (e-001): "Cultural issues, not technology, are usually the primary obstacle"
+
+**Analysis:**
+- Both are necessary; neither is sufficient alone
+- Technology enables, culture activates
+
+**Resolution:**
+- Two-layer approach:
+  - **Technical**: Infrastructure (NetworkX, RDFLib, FAISS)
+  - **Behavioral**: Protocols (AAR, A3, knowledge-sharing norms)
+- Jerry Constitution provides culture layer
+- SDKs provide technology layer
+- Integration through skills and agent behaviors
+
+#### Contradiction 3: Local vs. Cloud Deployment
+
+**Conflict:**
+- Products document (e-003): "49% of enterprise LLM implementations are cloud-based"
+- Jerry principle: Local-first, filesystem-as-memory
+
+**Analysis:**
+- Not a contradiction—a design choice
+- Hybrid architectures emerging as solution
+
+**Resolution:**
+- Core: Local filesystem (ownership, privacy, zero-cost)
+- Optional: Cloud sync (Obsidian Sync, Wiki.js deployment)
+- Hybrid: Local compute + cloud LLM APIs
+- Never require cloud for core functionality
+- Progressive enhancement: works locally, better with cloud
+
+#### Contradiction 4: Standards Adherence vs. Agility
+
+**Conflict:**
+- ISO 30401 requires systematic, documented processes
+- Jerry's agile, file-based approach values speed
+
+**Analysis:**
+- Standards are goals, not starting points
+- Progressive alignment over time
+
+**Resolution:**
+- Phase 1: Informal practices (AAR, A3)
+- Phase 2: Systematize successful patterns
+- Phase 3: Document as processes
+- Phase 4: Align with ISO 30401
+- Use maturity model to track progression (APQC: Initiate → Develop → Standardize)
+
+### Strategic Recommendations Summary
+
+**1. Start with Lightweight, Proven Tools**
+- NetworkX (not Neo4j)
+- RDFLib (not complex triple stores)
+- FAISS (not managed vector DBs)
+- AAR/A3 (not full ISO 30401)
+
+**2. Build in Layers (Vertical Scaling)**
+- Layer 1: Filesystem (done)
+- Layer 2: Graph augmentation (Q2 2026)
+- Layer 3: AI/RAG integration (Q3 2026)
+- Each layer optional but additive
+
+**3. Use Ports for Future-Proofing**
+- Define ports in domain layer (no deps)
+- Implement adapters in infrastructure
+- Swap implementations without domain changes
+- Example: NetworkX → igraph → graph-tool
+
+**4. Implement Cynefin as Meta-Framework**
+- Always classify before solving
+- Route to appropriate framework/tool
+- Prevents framework misapplication
+- Supports evidence-based method selection
+
+**5. Prioritize Knowledge Flow Over Storage**
+- SECI model emphasizes conversion
+- PDCA emphasizes cycles
+- AAR emphasizes reflection
+- A3 emphasizes learning
+- Design for circulation, not just capture
+
+**6. Maintain Constitutional Alignment**
+- P-002 (File Persistence): Filesystem remains source of truth
+- P-003 (No Recursive Subagents): ReAct uses tools, not recursive agents
+- P-020 (User Authority): Recommendations, not mandates
+- P-022 (No Deception): Always cite sources, expose uncertainty
+
+---
+
+## Knowledge Items
+
+### Patterns Identified
+
+**PAT-001: Knowledge Spiral Pattern**
+- **Description**: Knowledge creation follows circular pattern (SECI, PDCA, AAR all spiral)
+- **Sources**: e-001, e-002, e-005
+- **Application**: Design feedback loops in Work Tracker
+- **Status**: Validated across 5/5 documents
+
+**PAT-002: Tacit-Explicit Duality**
+- **Description**: All knowledge exists on tacit↔explicit spectrum; successful KM addresses both
+- **Sources**: e-001, e-002, e-005
+- **Application**: Social protocols (AAR, mentoring) + technical tools (graphs, vectors)
+- **Status**: Validated, with noted tension (technology vs. culture)
+
+**PAT-003: Graph Dominance**
+- **Description**: Graph-based models replacing hierarchical taxonomies as KM standard
+- **Sources**: e-001, e-003, e-004, e-005
+- **Application**: NetworkX/RDFLib in infrastructure, GraphRAG in AI layer
+- **Status**: Unanimous support, no contradictions
+
+**PAT-004: Grounded AI**
+- **Description**: LLMs require grounding via retrieval to be trustworthy
+- **Sources**: e-001, e-003, e-005
+- **Application**: RAG/GraphRAG mandatory for LLM knowledge access
+- **Status**: Validated, critical safety requirement
+
+**PAT-005: Standards as Guides**
+- **Description**: Standards (ISO 30401, APQC) provide direction, not dictation
+- **Sources**: e-001, e-002, e-005
+- **Application**: Progressive alignment, not rigid compliance
+- **Status**: Validated, with caution against "slavish" adherence
+
+**PAT-006: Local-First Hybrid**
+- **Description**: Modern architecture: local ownership + optional cloud sync
+- **Sources**: e-003, e-004
+- **Application**: Filesystem core + optional Obsidian Sync/Wiki.js
+- **Status**: Emerging consensus, aligns with Jerry philosophy
+
+**PAT-007: Three-Tier KM Stack**
+- **Description**: Filesystem (L1) + Graph (L2) + AI (L3) = complete KM system
+- **Sources**: Synthesis finding across all documents
+- **Application**: Jerry's recommended architecture
+- **Status**: Novel synthesis, supported by evidence from all sources
+
+### Lessons Learned
+
+**LES-001: No Pure Stdlib Solution**
+- **Lesson**: Modern KM requires external dependencies (graphs, embeddings, NLP)
+- **Source**: e-004 analysis
+- **Impact**: Revise Jerry's zero-dependency aspiration for infrastructure layer
+- **Action**: Accept lightweight dependencies (NetworkX, RDFLib, FAISS) as acceptable
+
+**LES-002: Technology Alone is Insufficient**
+- **Lesson**: "Cultural issues, not technology, are usually the primary obstacle"
+- **Source**: e-001 (multiple citations)
+- **Impact**: Must implement behavioral protocols (AAR, A3), not just tools
+- **Action**: Create social processes alongside technical infrastructure
+
+**LES-003: Start Simple, Evolve Gradually**
+- **Lesson**: NetworkX before Neo4j; FAISS before Qdrant; AAR before ISO 30401
+- **Source**: e-004 recommendations, e-002 maturity models
+- **Impact**: Prevents over-engineering, enables learning
+- **Action**: Tiered implementation roadmap (Phase 1-4)
+
+**LES-004: Cynefin Prevents Misapplication**
+- **Lesson**: Framework selection depends on problem complexity; no one-size-fits-all
+- **Source**: e-005 strategic recommendations
+- **Impact**: Prevents applying PDCA to chaos or Design Thinking to clear domains
+- **Action**: Implement problem-classifier skill as first step
+
+**LES-005: Contradictions Reveal Trade-Offs**
+- **Lesson**: Apparent contradictions often show legitimate trade-offs requiring balance
+- **Source**: Synthesis analysis
+- **Impact**: Don't seek single "right" answer; design for flexibility
+- **Action**: Use ports/adapters to support multiple valid approaches
+
+### Assumptions Identified
+
+**ASM-001: Graph Complexity Threshold**
+- **Assumption**: Jerry's knowledge graph won't exceed 10K nodes for 1-2 years
+- **Basis**: e-004 performance data (NetworkX acceptable <10K nodes)
+- **Risk**: Rapid growth could require earlier migration to igraph/graph-tool
+- **Mitigation**: Monitor graph size; design ports for easy adapter swap
+
+**ASM-002: LLM API Availability**
+- **Assumption**: Access to LLM APIs (OpenAI, Anthropic) for embeddings and generation
+- **Basis**: RAG/GraphRAG frameworks assume LLM access (e-005)
+- **Risk**: Cost, rate limits, API changes
+- **Mitigation**: Support local embedding models (sentence-transformers); design for API swapping
+
+**ASM-003: User Willingness to Adopt Protocols**
+- **Assumption**: Users will complete AARs and A3s consistently
+- **Basis**: Protocols require behavioral change (e-002)
+- **Risk**: Compliance fatigue, seen as bureaucratic
+- **Mitigation**: Keep simple, show value, make optional initially
+
+**ASM-004: Markdown as Stable Format**
+- **Assumption**: Markdown will remain viable long-term for knowledge storage
+- **Basis**: Jerry's file-based architecture (e-003 local-first trend)
+- **Risk**: Future formats may be more expressive
+- **Mitigation**: Use RDFLib for semantic export; design for format conversion
+
+**ASM-005: Python Ecosystem Stability**
+- **Assumption**: NetworkX, RDFLib, FAISS will remain maintained
+- **Basis**: e-004 maintenance analysis (all active, high download counts)
+- **Risk**: Library abandonment, breaking changes
+- **Mitigation**: Hexagonal architecture allows adapter replacement
+
+---
+
+## Source Summary Table
+
+| Document | Size | Lines | Key Contributions | Jerry Impact |
+|----------|------|-------|-------------------|--------------|
+| **e-001: Fundamentals** | ~60 KB | 803 | SECI model, Cynefin, Wiig, ISO 30401, thought leaders, tacit knowledge theory | Foundation for understanding KM; justifies Jerry's knowledge-centric mission |
+| **e-002: Protocols** | ~85 KB | 1849 | ISO 30401 details, APQC framework, AAR, Knowledge Audit, maturity models, decision frameworks | Actionable protocols for immediate implementation (AAR, A3); roadmap structure |
+| **e-003: Products** | ~80 KB | 1551 | Market trends, Neo4j/graph DBs, Obsidian/personal KM, RAG products, TCO analysis | Technology selection guidance; validates graph + local-first approach |
+| **e-004: Python SDKs** | ~95 KB | 2499 | NetworkX, RDFLib, FAISS, spaCy, Docling, hexagonal architecture fit | Specific implementation choices; code examples; dependency strategy |
+| **e-005: Frameworks** | ~38 KB | 1936 | SECI, Cynefin, TRIZ, Design Thinking, Systems Thinking, OODA, PDCA, A3, ReAct, RAG, GraphRAG | Framework selection logic; strategic integration for Jerry; decision matrix |
+
+**Total Research Corpus:** ~358 KB, 8,638 lines, 71+ unique citations
+
+**Cross-Document Validation:**
+- SECI Model: 3/5 documents (e-001, e-002, e-005) = **Core concept**
+- Cynefin: 2/5 documents (e-001, e-005) but referenced implicitly in e-002 = **Strategic framework**
+- Graph-based KM: 5/5 documents = **Unanimous recommendation**
+- RAG/AI: 4/5 documents (e-001, e-003, e-004, e-005) = **Critical capability**
+- ISO 30401: 3/5 documents (e-001, e-002, e-005) = **Long-term goal**
+- Local-first: 3/5 documents (e-003, e-004, implicit in Jerry context) = **Architectural principle**
+
+**Synthesis Quality Indicators:**
+- **Convergence**: 6/7 major patterns validated across multiple sources
+- **Contradictions**: 4 identified and resolved
+- **Novel Insights**: 3-tier architecture (PAT-007), Cynefin as meta-framework
+- **Actionability**: Specific libraries, frameworks, protocols recommended
+- **Timeline**: Clear phases (Q1-Q4 2026) with dependencies
+
+---
+
+## Conclusion
+
+This synthesis of five KM research documents (358KB, 8,638 lines) reveals a coherent picture:
+
+**Modern Knowledge Management = Filesystem + Graph + AI**
+
+Jerry's path forward is clear:
+1. **Immediate**: Implement AAR/A3 protocols, add NetworkX/RDFLib/FAISS
+2. **Medium**: Build graph layer over docs/, implement RAG
+3. **Long-term**: Align toward ISO 30401, consider GraphRAG
+
+The thematic analysis identified 7 cross-cutting patterns, with unanimous support for graph-based approaches, AI grounding via retrieval, and local-first architecture. Four apparent contradictions were resolved, revealing design trade-offs requiring balance rather than single "right answers."
+
+Jerry's filesystem-as-memory approach is not a limitation but a competitive advantage, validated by:
+- Local-first KM trends (Obsidian, Logseq adoption)
+- Hybrid architectures (local core + optional cloud)
+- RDFLib/NetworkX enabling standards without cloud lock-in
+
+The recommended technology stack (NetworkX, RDFLib, FAISS, Docling) aligns with Jerry's hexagonal architecture and zero-dependency domain layer while acknowledging that modern KM requires selective, lightweight dependencies in the infrastructure layer.
+
+Implementation follows a phased roadmap:
+- Q1 2026: Foundation (AAR, A3, Cynefin, libraries)
+- Q2 2026: Graph layer (NetworkX, RDFLib, entity extraction)
+- Q3 2026: AI layer (FAISS, RAG, semantic search)
+- Q4 2026+: Optimization (GraphRAG, Neo4j, ISO alignment)
+
+This synthesis provides a **decision-grade** foundation for implementing WORK-032 (Knowledge Architecture) with evidence-based recommendations validated across multiple authoritative sources.
+
+---
+
+**File:** `/home/user/jerry/docs/synthesis/work-032-e-006-km-synthesis.md`
+**Status:** COMPLETE
+**Word Count:** ~6,800 words
+**Patterns Identified:** 7 major themes
+**Contradictions Resolved:** 4
+**Sources Synthesized:** 5 documents (71+ citations)
+**Deliverable:** Decision-grade synthesis ready for ps-validator approval

--- a/docs/archive/projects-archive/synthesis/work-034-e-002-domain-synthesis.md
+++ b/docs/archive/projects-archive/synthesis/work-034-e-002-domain-synthesis.md
@@ -1,0 +1,1445 @@
+# WORK-034 Domain Synthesis: Unified Work Tracker + KM Model
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **PS ID** | work-034 |
+| **Entry ID** | e-002 |
+| **Date** | 2026-01-09 |
+| **Author** | ps-synthesizer v2.0.0 |
+| **Input** | work-034-e-001-domain-analysis.md (93KB) |
+| **Output Target** | 30-50KB |
+| **Status** | COMPLETE |
+
+---
+
+## Executive Summary
+
+This document synthesizes the comprehensive domain analysis from WORK-034 Entry 001 into a unified domain model that integrates Work Tracker and Knowledge Management (KM) bounded contexts within the Jerry Framework. The synthesis establishes a coherent architecture where both domains share common infrastructure while maintaining clear boundaries, enabling Work Tracker to serve as a proving ground for KM patterns.
+
+The unified model leverages three key architectural convergences identified in the analysis: (1) both domains independently adopted identical patterns including Hexagonal Architecture, CQRS, Event Sourcing, and CloudEvents 1.0 compliance; (2) Work Tracker entities naturally produce KM entities through completion workflows (Tasks generate Lessons, Phases reveal Patterns, Plans track Assumptions); and (3) both domains require the same infrastructure components (Event Store, Graph Store, Semantic Index, RDF Serialization).
+
+The synthesis proposes a four-phase implementation strategy starting with Work Tracker foundation, progressing through shared infrastructure validation, then KM entity implementation, and culminating in cross-domain integration. This approach reduces risk by validating KM infrastructure patterns at Work Tracker's smaller scale (~500 nodes) before scaling to KM's target (~5,000+ nodes), providing 4x faster issue discovery and 10x smaller fix costs.
+
+---
+
+## 1. Unified Domain Model
+
+### 1.1 Bounded Contexts
+
+The Jerry Framework organizes into three distinct bounded contexts with clear responsibilities and relationships:
+
+| Context | Type | Primary Purpose | Key Entities |
+|---------|------|-----------------|--------------|
+| **Work Tracker** | Core Subdomain | Persist task state across Claude Code sessions | WorkItem, Project, Sprint |
+| **Knowledge Management** | Supporting Subdomain | Capture and retrieve patterns, lessons, assumptions | KnowledgeItem (Pattern, Lesson, Assumption) |
+| **Governance** | Generic Subdomain | Agent rules and constitution enforcement | Agent, Rule, Hook |
+
+**Context Relationships:**
+
+- **Work Tracker <-> KM**: Customer-Supplier pattern where Work Tracker produces events consumed by KM handlers
+- **Work Tracker <-> Governance**: Governance hooks intercept Work Tracker operations for compliance
+- **KM <-> Governance**: KM captures lessons about governance effectiveness
+
+### 1.2 Shared Kernel
+
+The following components form a shared kernel used by both Work Tracker and KM contexts:
+
+#### 1.2.1 VertexId Base Class
+
+```python
+@dataclass(frozen=True)
+class VertexId:
+    """Base class for strongly-typed graph vertex identifiers."""
+    value: str
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+```
+
+#### 1.2.2 Jerry URI Scheme (SPEC-001)
+
+```
+jerry://{partition}:{tenant}:{domain}:{resource_type}:{resource_id}[/{version}]
+
+Examples:
+- jer:jer:work-tracker:task:WORK-042
+- jer:jer:knowledge:pat:PAT-001
+- jer:jer:knowledge:les:LES-042
+```
+
+#### 1.2.3 CloudEvents Infrastructure
+
+Both domains emit events conforming to CloudEvents 1.0:
+
+```json
+{
+  "specversion": "1.0",
+  "type": "{domain_prefix}/{EventType}",
+  "source": "jer:jer:{domain}:system",
+  "subject": "{jerry_uri}",
+  "time": "{ISO8601}",
+  "data": { /* event-specific payload */ }
+}
+```
+
+#### 1.2.4 Graph Store Abstractions
+
+```python
+class IGraphStore(Protocol):
+    """Shared graph operations for both domains."""
+    def add_vertex(self, id: VertexId, label: str, properties: dict) -> None: ...
+    def add_edge(self, from_id: VertexId, to_id: VertexId,
+                 label: str, properties: dict | None = None) -> Edge: ...
+    def traverse(self, start_id: VertexId, edge_label: str,
+                 max_depth: int = 2) -> list[VertexId]: ...
+    def traverse_incoming(self, end_id: VertexId, edge_label: str) -> list[VertexId]: ...
+```
+
+### 1.3 Context Map
+
+```mermaid
+graph TB
+    subgraph "Jerry Framework Unified Model"
+        subgraph "Work Tracker Context [Core]"
+            WT[Work Tracker Aggregate]
+            WT_EVENTS[WorkItem Events]
+        end
+
+        subgraph "Knowledge Management Context [Supporting]"
+            KM[KnowledgeItem Aggregate]
+            KM_EVENTS[Knowledge Events]
+        end
+
+        subgraph "Shared Kernel"
+            SK_VERTEX[VertexId Base]
+            SK_EVENTS[IEventStore]
+            SK_GRAPH[IGraphStore]
+            SK_INDEX[ISemanticIndex]
+            SK_URI[JerryUri Factory]
+        end
+
+        subgraph "Infrastructure Layer"
+            INFRA_SQLITE[SQLite Adapters]
+            INFRA_NETWORKX[NetworkX Adapter]
+            INFRA_FAISS[FAISS Adapter]
+            INFRA_RDFLIB[RDFLib Adapter]
+        end
+    end
+
+    %% Context relationships
+    WT -->|"produces events"| WT_EVENTS
+    WT_EVENTS -->|"Customer-Supplier"| KM
+    KM -->|"produces events"| KM_EVENTS
+
+    %% Shared kernel usage
+    WT --> SK_VERTEX
+    KM --> SK_VERTEX
+    WT_EVENTS --> SK_EVENTS
+    KM_EVENTS --> SK_EVENTS
+    WT --> SK_GRAPH
+    KM --> SK_GRAPH
+
+    %% Infrastructure bindings
+    SK_EVENTS --> INFRA_SQLITE
+    SK_GRAPH --> INFRA_NETWORKX
+    SK_INDEX --> INFRA_FAISS
+```
+
+---
+
+## 2. Unified Aggregate Roots
+
+### 2.1 Work Tracker Aggregates
+
+#### 2.1.1 WorkItem Aggregate (Primary)
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `id` | WorkItemId | WORK-001, WORK-002, ... |
+| `title` | str | Short description (1-200 chars) |
+| `description` | str | Detailed description (0-10000 chars) |
+| `type` | WorkItemType | EPIC, FEATURE, TASK, BUG, SPIKE |
+| `status` | Status | PENDING, IN_PROGRESS, BLOCKED, COMPLETED |
+| `priority` | Priority | CRITICAL, HIGH, MEDIUM, LOW |
+| `parent_id` | WorkItemId | None | Optional parent reference |
+| `notes` | list[Note] | Timestamped observations |
+| `tags` | list[Tag] | Categorization labels |
+
+**State Machine:**
+
+```
+PENDING ----start()----> IN_PROGRESS ----complete()----> COMPLETED
+    ^                        |                              |
+    |                        | block()                      |
+    |                        v                              |
+    |                    BLOCKED                            |
+    |                        |                              |
+    |       unblock()        |                              |
+    |<-----------------------+                              |
+    |                                                       |
+    +-----------------reopen()------------------------------+
+```
+
+#### 2.1.2 Project Aggregate (Secondary)
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `id` | ProjectId | Unique project identifier |
+| `name` | str | Project name |
+| `description` | str | Project description |
+| `work_items` | list[WorkItemId] | References (not embedded) |
+
+#### 2.1.3 Sprint Aggregate (Secondary)
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `id` | SprintId | Unique sprint identifier |
+| `start_date` | date | Sprint start |
+| `end_date` | date | Sprint end |
+| `work_items` | list[WorkItemId] | Planned work items |
+| `velocity` | int | Planned story points |
+
+### 2.2 KM Aggregates
+
+#### 2.2.1 KnowledgeItem Aggregate (Primary)
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `id` | KnowledgeItemId | PAT-001, LES-042, ASM-003 |
+| `uri` | JerryUri | SPEC-001 compliant URI |
+| `title` | str | Short description (1-80 chars) |
+| `km_type` | KnowledgeType | PATTERN, LESSON, ASSUMPTION |
+| `status` | KnowledgeStatus | DRAFT, VALIDATED, DEPRECATED |
+| `content` | Pattern \| Lesson \| Assumption | Discriminated union |
+| `tags` | list[str] | Categorization labels |
+| `related_items` | list[KnowledgeItemId] | References to related knowledge |
+| `evidence_refs` | list[JerryUri] | References to supporting evidence |
+
+**Lifecycle State Machine:**
+
+```
+DRAFT ----validate()----> VALIDATED
+  |                           |
+  | deprecate(reason)         | deprecate(reason)
+  v                           v
+DEPRECATED <------------------+
+```
+
+### 2.3 Cross-Aggregate Relationships
+
+Cross-aggregate relationships are implemented as graph edges, not direct object references:
+
+| From Aggregate | To Aggregate | Edge Label | Direction | Description |
+|----------------|--------------|------------|-----------|-------------|
+| WorkItem | WorkItem | `PART_OF` | Task -> Phase/Plan | Hierarchy |
+| WorkItem | WorkItem | `BLOCKS` | Task -> Task | Dependency |
+| WorkItem | KnowledgeItem | `LEARNED_FROM` | Task -> Lesson | Knowledge extraction |
+| WorkItem | KnowledgeItem | `APPLIED_PATTERN` | Task -> Pattern | Pattern usage |
+| WorkItem | KnowledgeItem | `VALIDATED_ASSUMPTION` | Task -> Assumption | Evidence |
+| Phase | KnowledgeItem | `EMERGED_PATTERN` | Phase -> Pattern | Discovery |
+| Plan | KnowledgeItem | `DEPENDS_ON_ASSUMPTION` | Plan -> Assumption | Risk |
+| KnowledgeItem | KnowledgeItem | `REFERENCES` | Any -> Any | Citation |
+| KnowledgeItem | KnowledgeItem | `SUPERSEDES` | New -> Old | Versioning |
+
+---
+
+## 3. Unified Entity Model
+
+### 3.1 Complete Entity Hierarchy
+
+```mermaid
+classDiagram
+    class VertexId {
+        <<abstract>>
+        +str value
+        +__str__() str
+        +__hash__() int
+    }
+
+    class Vertex {
+        <<abstract>>
+        +VertexId id
+        +JerryUri uri
+        +datetime created_at
+        +str created_by
+        +datetime modified_at
+        +str modified_by
+        +str version
+        +str content_hash
+    }
+
+    class WorkItemId {
+        +str value
+        +ClassVar~str~ prefix = "WORK"
+        +generate(sequence: int) WorkItemId
+    }
+
+    class KnowledgeItemId {
+        +str value
+        +km_type KnowledgeType
+        +generate(km_type: KnowledgeType, sequence: int) KnowledgeItemId
+    }
+
+    class WorkItem {
+        +WorkItemId id
+        +str title
+        +str description
+        +WorkItemType type
+        +Status status
+        +Priority priority
+        +WorkItemId parent_id
+        +list~Note~ notes
+        +list~Tag~ tags
+        +list~DomainEvent~ events
+        +start() void
+        +block(reason: str) void
+        +unblock() void
+        +complete(notes: str) void
+        +reopen() void
+        +add_note(content: str) void
+    }
+
+    class KnowledgeItem {
+        +KnowledgeItemId id
+        +str title
+        +KnowledgeType km_type
+        +KnowledgeStatus status
+        +Pattern|Lesson|Assumption content
+        +str context
+        +list~str~ tags
+        +list~KnowledgeItemId~ related_items
+        +list~JerryUri~ evidence_refs
+        +validate() void
+        +deprecate(reason: str) void
+        +add_evidence(uri: JerryUri) void
+    }
+
+    class Pattern {
+        <<value object>>
+        +str context
+        +str problem
+        +str solution
+        +str consequences
+        +list~str~ forces
+        +list~str~ alternatives
+        +to_markdown() str
+    }
+
+    class Lesson {
+        <<value object>>
+        +str what_happened
+        +str what_learned
+        +str prevention
+        +str impact
+        +float confidence
+        +to_markdown() str
+    }
+
+    class Assumption {
+        <<value object>>
+        +str statement
+        +str impact_if_wrong
+        +str validation_path
+        +float confidence
+        +str review_date
+        +to_markdown() str
+    }
+
+    VertexId <|-- WorkItemId
+    VertexId <|-- KnowledgeItemId
+    Vertex <|-- WorkItem
+    Vertex <|-- KnowledgeItem
+
+    KnowledgeItem o-- Pattern : content
+    KnowledgeItem o-- Lesson : content
+    KnowledgeItem o-- Assumption : content
+
+    WorkItem "1" --> "*" KnowledgeItem : LEARNED_FROM
+    WorkItem "1" --> "*" KnowledgeItem : APPLIED_PATTERN
+    WorkItem "1" --> "*" KnowledgeItem : VALIDATED_ASSUMPTION
+```
+
+### 3.2 Value Object Catalog
+
+#### 3.2.1 Work Tracker Value Objects
+
+| Value Object | Attributes | Invariants |
+|--------------|------------|------------|
+| **WorkItemId** | value: str | Pattern: `^WORK-[0-9]+$`, immutable |
+| **Status** | PENDING, IN_PROGRESS, BLOCKED, COMPLETED | Valid transitions enforced |
+| **Priority** | CRITICAL=1, HIGH=2, MEDIUM=3, LOW=4 | Comparable for sorting |
+| **WorkItemType** | EPIC, FEATURE, TASK, BUG, SPIKE | Hierarchy rules enforced |
+| **Tag** | name: str, color: str | Immutable, comparable |
+| **Note** | content: str, created_at: datetime, author: str | Immutable |
+
+#### 3.2.2 KM Value Objects
+
+| Value Object | Attributes | Invariants |
+|--------------|------------|------------|
+| **KnowledgeItemId** | value: str | Pattern: `^(PAT|LES|ASM)-[0-9]+$`, prefix matches type |
+| **KnowledgeType** | PATTERN="PAT", LESSON="LES", ASSUMPTION="ASM" | ID prefix discrimination |
+| **KnowledgeStatus** | DRAFT, VALIDATED, DEPRECATED | Lifecycle transitions enforced |
+| **Pattern** | context, problem, solution, consequences, forces, alternatives | Immutable, markdown serializable |
+| **Lesson** | what_happened, what_learned, prevention, impact, confidence | Immutable, confidence 0.0-1.0 |
+| **Assumption** | statement, impact_if_wrong, validation_path, confidence, review_date | Immutable, ISO 8601 date |
+
+#### 3.2.3 Shared Value Objects
+
+| Value Object | Attributes | Invariants |
+|--------------|------------|------------|
+| **JerryUri** | partition, tenant, domain, resource_type, resource_id, version | SPEC-001 compliant |
+| **VertexId** | value: str | Base class for all IDs |
+| **Edge** | from_id, to_id, label, properties, created_at | Immutable relationship |
+
+### 3.3 Edge Types
+
+Complete catalog of graph edge types across both domains:
+
+| Edge Label | Source Type | Target Type | Properties | Description |
+|------------|-------------|-------------|------------|-------------|
+| `PART_OF` | WorkItem | WorkItem | None | Task belongs to Phase/Plan |
+| `BLOCKS` | WorkItem | WorkItem | reason: str | Dependency blocking |
+| `DEPENDS_ON` | WorkItem | WorkItem | None | Logical dependency |
+| `LEARNED_FROM` | WorkItem | KnowledgeItem(Lesson) | captured_at: datetime | Knowledge extraction |
+| `APPLIED_PATTERN` | WorkItem | KnowledgeItem(Pattern) | applied_at, notes | Pattern usage tracking |
+| `VALIDATED_ASSUMPTION` | WorkItem | KnowledgeItem(Assumption) | result: CONFIRMED/INVALIDATED | Evidence |
+| `EMERGED_PATTERN` | Phase | KnowledgeItem(Pattern) | discovered_at | Pattern discovery |
+| `DEPENDS_ON_ASSUMPTION` | Plan | KnowledgeItem(Assumption) | impact: HIGH/MEDIUM/LOW | Risk tracking |
+| `REFERENCES` | KnowledgeItem | KnowledgeItem | None | Citation link |
+| `SUPERSEDES` | KnowledgeItem | KnowledgeItem | reason: str | Version replacement |
+| `EVIDENCED_BY` | KnowledgeItem | JerryUri | None | External evidence |
+| `CREATED_BY` | Any | Agent | None | Audit trail |
+
+---
+
+## 4. Unified Event Model
+
+### 4.1 Event Categories
+
+#### 4.1.1 Work Tracker Events
+
+| Event Type | CloudEvents Type | Aggregate | Trigger |
+|------------|------------------|-----------|---------|
+| `WorkItemCreated` | `WorkItemCreated` | WorkItem | `create()` factory |
+| `WorkItemStarted` | `WorkItemStarted` | WorkItem | `start()` |
+| `WorkItemBlocked` | `WorkItemBlocked` | WorkItem | `block(reason)` |
+| `WorkItemUnblocked` | `WorkItemUnblocked` | WorkItem | `unblock()` |
+| `WorkItemCompleted` | `WorkItemCompleted` | WorkItem | `complete(notes)` |
+| `WorkItemReopened` | `WorkItemReopened` | WorkItem | `reopen()` |
+| `WorkItemUpdated` | `WorkItemUpdated` | WorkItem | `update_*()` methods |
+| `NoteAdded` | `NoteAdded` | WorkItem | `add_note(content)` |
+| `TagAdded` | `TagAdded` | WorkItem | `add_tag(tag)` |
+| `TagRemoved` | `TagRemoved` | WorkItem | `remove_tag(tag)` |
+
+#### 4.1.2 KM Events
+
+| Event Type | CloudEvents Type | Aggregate | Trigger |
+|------------|------------------|-----------|---------|
+| `KnowledgeItemCreated` | `jer:jer:knowledge:facts/KnowledgeItemCreated` | KnowledgeItem | `CaptureKnowledgeHandler` |
+| `KnowledgeItemValidated` | `jer:jer:knowledge:facts/KnowledgeItemValidated` | KnowledgeItem | `validate()` |
+| `KnowledgeItemDeprecated` | `jer:jer:knowledge:facts/KnowledgeItemDeprecated` | KnowledgeItem | `deprecate(reason)` |
+| `KnowledgeRelationCreated` | `jer:jer:knowledge:facts/KnowledgeRelationCreated` | KnowledgeItem | `graph.add_edge()` |
+
+#### 4.1.3 Cross-Domain Events
+
+| Event Type | Source | Target | Description |
+|------------|--------|--------|-------------|
+| `LessonCapturedFromTask` | Work Tracker | KM | Task completion triggered lesson capture |
+| `PatternAppliedToTask` | KM | Work Tracker | Pattern usage recorded on task |
+| `AssumptionValidatedByTask` | Work Tracker | KM | Task provided assumption evidence |
+
+### 4.2 Event Catalog
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/unified-domain-event.json",
+  "title": "UnifiedDomainEvent",
+  "type": "object",
+  "required": ["specversion", "type", "source", "id", "time", "data"],
+  "properties": {
+    "specversion": {"const": "1.0"},
+    "type": {
+      "type": "string",
+      "oneOf": [
+        {"pattern": "^WorkItem(Created|Started|Blocked|Unblocked|Completed|Reopened|Updated)$"},
+        {"pattern": "^(Note|Tag)(Added|Removed)$"},
+        {"pattern": "^jer:jer:knowledge:facts/KnowledgeItem(Created|Validated|Deprecated)$"},
+        {"pattern": "^jer:jer:knowledge:facts/KnowledgeRelationCreated$"}
+      ]
+    },
+    "source": {"type": "string", "format": "uri"},
+    "subject": {"type": "string"},
+    "id": {"type": "string", "format": "uuid"},
+    "time": {"type": "string", "format": "date-time"},
+    "data": {"type": "object"}
+  }
+}
+```
+
+### 4.3 Event Flow Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as CLI/Skill
+    participant WT as Work Tracker Domain
+    participant EventBus as Event Bus
+    participant EventStore as Event Store
+    participant KM as Knowledge Management
+    participant Graph as Graph Store
+    participant Index as Semantic Index
+
+    User->>CLI: complete WORK-042 --notes "Tests passing"
+    CLI->>WT: CompleteWorkItemCommand
+
+    WT->>WT: Validate state transition (IN_PROGRESS -> COMPLETED)
+    WT->>WT: Apply WorkItemCompleted event to state
+
+    WT->>EventBus: emit(WorkItemCompleted)
+    EventBus->>EventStore: append(WORK-042, [WorkItemCompleted])
+
+    EventBus->>KM: WorkItemCompleted event (subscriber)
+
+    alt Effort Hours > 2
+        KM->>User: AAR Prompt: What happened? What learned? How to apply?
+        User->>KM: AAR responses
+
+        KM->>KM: CaptureKnowledgeCommand(LESSON)
+        KM->>Graph: add_vertex(LES-001, "Lesson", {...})
+        KM->>Graph: add_edge(WORK-042, LES-001, "LEARNED_FROM")
+        KM->>Index: index(LES-001, embedding)
+        KM->>EventBus: emit(KnowledgeItemCreated)
+        EventBus->>EventStore: append(LES-001, [KnowledgeItemCreated])
+    end
+
+    KM->>CLI: Response: Lesson captured LES-001
+    CLI->>User: Task WORK-042 completed. Lesson LES-001 captured.
+```
+
+---
+
+## 5. Unified Port Model
+
+### 5.1 Shared Ports
+
+These port interfaces are defined in the shared kernel and implemented once for both domains:
+
+```python
+# IEventStore - Event Sourcing Port
+class IEventStore(Protocol):
+    """Append-only event log for domain events."""
+    def append(self, aggregate_id: str, events: list[DomainEvent]) -> None: ...
+    def get_events(self, aggregate_id: str) -> list[DomainEvent]: ...
+    def get_events_since(self, aggregate_id: str, version: int) -> list[DomainEvent]: ...
+    def get_all_events(self) -> list[DomainEvent]: ...
+
+# IEventDispatcher - Pub/Sub Port
+class IEventDispatcher(Protocol):
+    """Event routing for domain events."""
+    def dispatch(self, event: DomainEvent) -> None: ...
+    def dispatch_all(self, events: list[DomainEvent]) -> None: ...
+    def subscribe(self, event_type: str, handler: Callable[[DomainEvent], None]) -> None: ...
+
+# IGraphStore - Graph Operations Port
+class IGraphStore(Protocol):
+    """Property graph operations for both domains."""
+    def add_vertex(self, id: VertexId, label: str, properties: dict[str, Any]) -> None: ...
+    def get_vertex(self, id: VertexId) -> dict[str, Any] | None: ...
+    def add_edge(self, from_id: VertexId, to_id: VertexId,
+                 label: str, properties: dict[str, Any] | None = None) -> Edge: ...
+    def get_edges(self, vertex_id: VertexId, direction: str = "out") -> list[Edge]: ...
+    def traverse(self, start_id: VertexId, edge_label: str,
+                 max_depth: int = 2) -> list[VertexId]: ...
+    def traverse_incoming(self, end_id: VertexId, edge_label: str) -> list[VertexId]: ...
+
+# ISemanticIndex - Vector Search Port
+class ISemanticIndex(Protocol):
+    """Semantic similarity search for both domains."""
+    def index(self, id: VertexId, text: str, metadata: dict[str, Any]) -> None: ...
+    def search(self, query: str, top_k: int = 5,
+               filters: dict[str, Any] | None = None) -> list[tuple[VertexId, float]]: ...
+    def reindex(self, items: list[tuple[VertexId, str, dict]]) -> None: ...
+    def delete(self, id: VertexId) -> None: ...
+
+# IRDFSerializer - RDF Export Port
+class IRDFSerializer(Protocol):
+    """RDF serialization for standards compliance."""
+    def to_rdf(self, entity: Vertex) -> Graph: ...
+    def serialize(self, format: str = "turtle") -> str: ...
+    def to_jsonld(self, entity: Vertex, context: dict | None = None) -> str: ...
+
+# IUnitOfWork - Transaction Port
+class IUnitOfWork(Protocol):
+    """Transactional unit of work pattern."""
+    def __enter__(self) -> "IUnitOfWork": ...
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...
+```
+
+### 5.2 Work Tracker Ports
+
+Domain-specific ports for Work Tracker context:
+
+```python
+# IWorkItemRepository - Persistence Port
+class IWorkItemRepository(Protocol):
+    """Repository for WorkItem aggregate persistence."""
+    def save(self, item: WorkItem) -> None: ...
+    def get(self, id: WorkItemId) -> WorkItem | None: ...
+    def get_all(self) -> list[WorkItem]: ...
+    def get_by_status(self, status: Status) -> list[WorkItem]: ...
+    def get_by_parent(self, parent_id: WorkItemId) -> list[WorkItem]: ...
+    def delete(self, id: WorkItemId) -> None: ...
+    def exists(self, id: WorkItemId) -> bool: ...
+    def next_id(self) -> WorkItemId: ...
+
+# IProjectRepository - Persistence Port
+class IProjectRepository(Protocol):
+    """Repository for Project aggregate persistence."""
+    def save(self, project: Project) -> None: ...
+    def get(self, id: ProjectId) -> Project | None: ...
+    def get_all(self) -> list[Project]: ...
+
+# ISprintRepository - Persistence Port
+class ISprintRepository(Protocol):
+    """Repository for Sprint aggregate persistence."""
+    def save(self, sprint: Sprint) -> None: ...
+    def get(self, id: SprintId) -> Sprint | None: ...
+    def get_active(self) -> Sprint | None: ...
+```
+
+### 5.3 KM Ports
+
+Domain-specific ports for Knowledge Management context:
+
+```python
+# IKnowledgeRepository - Persistence Port
+class IKnowledgeRepository(ABC):
+    """Repository for KnowledgeItem aggregate persistence."""
+    @abstractmethod
+    def save(self, item: KnowledgeItem) -> None: ...
+    @abstractmethod
+    def find_by_id(self, id: KnowledgeItemId) -> KnowledgeItem | None: ...
+    @abstractmethod
+    def find_by_type(self, km_type: KnowledgeType,
+                     status: KnowledgeStatus | None = None) -> list[KnowledgeItem]: ...
+    @abstractmethod
+    def find_related(self, item_id: KnowledgeItemId,
+                     max_depth: int = 2) -> list[KnowledgeItem]: ...
+    @abstractmethod
+    def next_id(self, km_type: KnowledgeType) -> KnowledgeItemId: ...
+
+# IKnowledgeSearch - Search Port (extends ISemanticIndex)
+class IKnowledgeSearch(Protocol):
+    """Semantic search specialized for knowledge items."""
+    def search_patterns(self, query: str, top_k: int = 5) -> list[tuple[KnowledgeItemId, float]]: ...
+    def search_lessons(self, query: str, top_k: int = 5) -> list[tuple[KnowledgeItemId, float]]: ...
+    def search_assumptions(self, query: str, top_k: int = 5) -> list[tuple[KnowledgeItemId, float]]: ...
+    def find_similar(self, item_id: KnowledgeItemId, top_k: int = 5) -> list[tuple[KnowledgeItemId, float]]: ...
+```
+
+### 5.4 Port Hierarchy
+
+```mermaid
+classDiagram
+    class Protocol {
+        <<interface>>
+    }
+
+    class IEventStore {
+        <<interface>>
+        +append(aggregate_id, events)
+        +get_events(aggregate_id)
+        +get_all_events()
+    }
+
+    class IEventDispatcher {
+        <<interface>>
+        +dispatch(event)
+        +subscribe(event_type, handler)
+    }
+
+    class IGraphStore {
+        <<interface>>
+        +add_vertex(id, label, properties)
+        +add_edge(from_id, to_id, label)
+        +traverse(start_id, edge_label, max_depth)
+    }
+
+    class ISemanticIndex {
+        <<interface>>
+        +index(id, text, metadata)
+        +search(query, top_k, filters)
+    }
+
+    class IRepository~T~ {
+        <<interface>>
+        +save(entity: T)
+        +get(id) T
+        +delete(id)
+    }
+
+    class IWorkItemRepository {
+        <<interface>>
+        +get_by_status(status)
+        +get_by_parent(parent_id)
+        +next_id()
+    }
+
+    class IKnowledgeRepository {
+        <<interface>>
+        +find_by_type(km_type, status)
+        +find_related(item_id, max_depth)
+        +next_id(km_type)
+    }
+
+    class IKnowledgeSearch {
+        <<interface>>
+        +search_patterns(query, top_k)
+        +search_lessons(query, top_k)
+        +find_similar(item_id, top_k)
+    }
+
+    Protocol <|-- IEventStore
+    Protocol <|-- IEventDispatcher
+    Protocol <|-- IGraphStore
+    Protocol <|-- ISemanticIndex
+    Protocol <|-- IRepository
+
+    IRepository <|-- IWorkItemRepository
+    IRepository <|-- IKnowledgeRepository
+    ISemanticIndex <|-- IKnowledgeSearch
+```
+
+---
+
+## 6. Unified Use Case Model
+
+### 6.1 Work Tracker Commands
+
+| Command | Handler | Preconditions | Postconditions | Events |
+|---------|---------|---------------|----------------|--------|
+| `CreateWorkItemCommand` | `CreateWorkItemHandler` | Valid title (1-200), valid type | Item exists, status=PENDING | WorkItemCreated |
+| `UpdateWorkItemCommand` | `UpdateWorkItemHandler` | Item exists, not COMPLETED | Fields updated | WorkItemUpdated |
+| `StartWorkItemCommand` | `StartWorkItemHandler` | Status=PENDING | Status=IN_PROGRESS | WorkItemStarted |
+| `BlockWorkItemCommand` | `BlockWorkItemHandler` | Status=IN_PROGRESS, reason provided | Status=BLOCKED | WorkItemBlocked |
+| `UnblockWorkItemCommand` | `UnblockWorkItemHandler` | Status=BLOCKED | Status=IN_PROGRESS | WorkItemUnblocked |
+| `CompleteWorkItemCommand` | `CompleteWorkItemHandler` | Status=IN_PROGRESS | Status=COMPLETED | WorkItemCompleted |
+| `ReopenWorkItemCommand` | `ReopenWorkItemHandler` | Status=COMPLETED | Status=PENDING | WorkItemReopened |
+| `AddNoteCommand` | `AddNoteHandler` | Item exists | Note added | NoteAdded |
+| `AddTagCommand` | `AddTagHandler` | Item exists, tag not present | Tag added | TagAdded |
+
+**Command Signatures:**
+
+```python
+@dataclass
+class CreateWorkItemCommand:
+    title: str
+    description: str = ""
+    type: str = "task"
+    priority: str = "medium"
+    parent_id: str | None = None
+    tags: list[str] = field(default_factory=list)
+
+@dataclass
+class CompleteWorkItemCommand:
+    id: str
+    notes: str | None = None
+```
+
+### 6.2 Work Tracker Queries
+
+| Query | Handler | Parameters | Returns |
+|-------|---------|------------|---------|
+| `GetWorkItemQuery` | `GetWorkItemHandler` | id: str | WorkItemDTO | None |
+| `ListWorkItemsQuery` | `ListWorkItemsHandler` | status[], priority[], type[], parent_id, limit, offset, sort_by | list[WorkItemSummaryDTO] |
+| `SearchWorkItemsQuery` | `SearchWorkItemsHandler` | query: str, include_completed, limit | list[WorkItemSummaryDTO] |
+| `GetWorkTrackerStatsQuery` | `GetStatsHandler` | time_range (optional) | WorkTrackerStatsDTO |
+| `GetEnrichedWorkItemQuery` | `GetEnrichedWorkItemHandler` | id: str | EnrichedWorkItemDTO |
+
+**Query Signatures:**
+
+```python
+@dataclass
+class ListWorkItemsQuery:
+    status: list[str] | None = None
+    priority: list[str] | None = None
+    type: list[str] | None = None
+    parent_id: str | None = None
+    limit: int = 50
+    offset: int = 0
+    sort_by: str = "created_at"
+    sort_order: str = "desc"
+```
+
+### 6.3 KM Commands
+
+| Command | Handler | Preconditions | Postconditions | Events |
+|---------|---------|---------------|----------------|--------|
+| `CaptureKnowledgeCommand` | `CaptureKnowledgeHandler` | Valid title, content, km_type | Item created, status=DRAFT | KnowledgeItemCreated |
+| `ValidateKnowledgeCommand` | `ValidateKnowledgeHandler` | Status=DRAFT | Status=VALIDATED | KnowledgeItemValidated |
+| `DeprecateKnowledgeCommand` | `DeprecateKnowledgeHandler` | Status != DEPRECATED, reason provided | Status=DEPRECATED | KnowledgeItemDeprecated |
+| `RelateKnowledgeCommand` | `RelateKnowledgeHandler` | Both items exist | Edge created | KnowledgeRelationCreated |
+
+**Command Signatures:**
+
+```python
+@dataclass
+class CaptureKnowledgeCommand:
+    title: str
+    km_type: KnowledgeType
+    content: Pattern | Lesson | Assumption
+    context: str = ""
+    tags: list[str] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)
+    created_by: str = "system:km"
+```
+
+### 6.4 KM Queries
+
+| Query | Handler | Parameters | Returns |
+|-------|---------|------------|---------|
+| `GetKnowledgeItemQuery` | `GetKnowledgeItemHandler` | id: str | KnowledgeItemDTO | None |
+| `SearchKnowledgeQuery` | `SearchKnowledgeHandler` | query: str, km_type, status, top_k | list[KnowledgeSearchResultDTO] |
+| `GetRelatedKnowledgeQuery` | `GetRelatedKnowledgeHandler` | id: str, max_depth | list[KnowledgeItemDTO] |
+| `TraverseKnowledgeGraphQuery` | `TraverseGraphHandler` | start_id, edge_labels, max_depth | GraphTraversalResultDTO |
+| `ExportKnowledgeGraphQuery` | `ExportGraphHandler` | format: turtle | json-ld | str |
+
+### 6.5 Cross-Domain Use Cases
+
+New use cases that integrate Work Tracker and KM:
+
+| Use Case | Input | Output | Description |
+|----------|-------|--------|-------------|
+| `CaptureKnowledgeFromWorkItem` | task_id, AAR responses | KnowledgeItemId | Create Lesson from completed task |
+| `ApplyPatternToWorkItem` | task_id, pattern_id, notes | Edge | Record pattern usage on task |
+| `ValidateAssumptionFromWorkItem` | task_id, assumption_id, result | Edge | Record assumption validation evidence |
+| `SearchKnowledgeForTask` | task_title, context | list[KnowledgeItemDTO] | Find relevant patterns/lessons |
+| `GetEnrichedWorkItem` | task_id | EnrichedWorkItemDTO | WorkItem with related knowledge |
+
+**Cross-Domain Handler Example:**
+
+```python
+class CaptureKnowledgeFromWorkItemHandler:
+    """Cross-domain: Create Lesson from completed WorkItem."""
+
+    def __init__(
+        self,
+        wt_repo: IWorkItemRepository,
+        km_repo: IKnowledgeRepository,
+        graph: IGraphStore,
+        event_dispatcher: IEventDispatcher
+    ):
+        self.wt_repo = wt_repo
+        self.km_repo = km_repo
+        self.graph = graph
+        self.event_dispatcher = event_dispatcher
+
+    def handle(self, command: CaptureKnowledgeFromWorkItemCommand) -> KnowledgeItemId:
+        # Validate work item exists
+        task = self.wt_repo.get(WorkItemId(command.task_id))
+        if not task:
+            raise ValueError(f"Task not found: {command.task_id}")
+
+        # Create lesson
+        lesson_id = self.km_repo.next_id(KnowledgeType.LESSON)
+        lesson_content = Lesson(
+            what_happened=command.what_happened,
+            what_learned=command.what_learned,
+            prevention=command.prevention
+        )
+
+        knowledge_item = KnowledgeItem(
+            id=lesson_id,
+            title=f"Lesson from {task.title}",
+            km_type=KnowledgeType.LESSON,
+            content=lesson_content,
+            evidence_refs=[str(JerryUri.for_task(task.id))]
+        )
+
+        self.km_repo.save(knowledge_item)
+
+        # Create graph edge
+        self.graph.add_edge(
+            from_id=task.id,
+            to_id=lesson_id,
+            label="LEARNED_FROM",
+            properties={"captured_at": datetime.utcnow().isoformat()}
+        )
+
+        # Emit event
+        self.event_dispatcher.dispatch(KnowledgeItemCreated(
+            item_id=str(lesson_id),
+            km_type="LESSON",
+            title=knowledge_item.title,
+            created_by=command.captured_by
+        ))
+
+        return lesson_id
+```
+
+---
+
+## 7. Implementation Priority Matrix
+
+### 7.1 Phase 1: Foundation (Weeks 1-8)
+
+**Goal:** Establish Work Tracker core with shared infrastructure patterns.
+
+| Week | Deliverable | Components | Validates For KM |
+|------|-------------|------------|------------------|
+| 1-2 | Domain entities | WorkItem, WorkItemId, Status, Priority, Note, Tag | Entity patterns, VertexId hierarchy |
+| 3-4 | SQLite repository | SQLiteWorkItemRepository, SQLiteEventStore | IEventStore port pattern |
+| 5-6 | CQRS handlers | CreateWorkItem, UpdateWorkItem, CompleteWorkItem commands/queries | Use case patterns |
+| 7-8 | CLI adapter, BDD tests | CLI commands, pytest-bdd scenarios | Interface layer patterns |
+
+**Exit Criteria:**
+- WorkItem CRUD functional via CLI
+- Event sourcing operational
+- BDD tests passing
+- ~500 LOC domain, ~800 LOC infrastructure
+
+### 7.2 Phase 2: Work Tracker Core + Shared Infrastructure (Weeks 9-16)
+
+**Goal:** Add graph and search infrastructure using Work Tracker as validation.
+
+| Week | Deliverable | Components | Validates For KM |
+|------|-------------|------------|------------------|
+| 9-10 | NetworkX adapter | NetworkXGraphStore implementing IGraphStore | Graph traversal patterns |
+| 11-12 | RDFLib serialization | WorkItem `to_jsonld()`, `to_turtle()` | RDF export patterns |
+| 13-14 | FAISS semantic search | FAISSSemanticIndex for WorkItem search | Vector search patterns |
+| 15-16 | Performance baselines | Query latency metrics, supernode detection | Performance monitoring |
+
+**Exit Criteria:**
+- Graph queries <10ms for typical operations
+- Semantic search functional
+- RDF export produces valid Turtle/JSON-LD
+- Performance baseline documented
+
+### 7.3 Phase 3: KM Integration (Weeks 17-24)
+
+**Goal:** Implement KM entities using validated infrastructure.
+
+| Week | Deliverable | Components | Dependencies |
+|------|-------------|------------|--------------|
+| 17-18 | KM entities | KnowledgeItem, Pattern, Lesson, Assumption | Phase 1 entity patterns |
+| 19-20 | KM repository | FileSystemKnowledgeRepository | Phase 2 graph store |
+| 21-22 | KM CQRS | CaptureKnowledge, ValidateKnowledge, SearchKnowledge | Phase 1 handler patterns |
+| 23-24 | KM CLI/Skill | `jerry knowledge capture`, `jerry knowledge search` | Phase 1 CLI patterns |
+
+**Exit Criteria:**
+- CRUD for all knowledge types
+- Semantic search for knowledge
+- Graph relationships functional
+- BDD tests passing
+
+### 7.4 Phase 4: Advanced Features (Weeks 25-32)
+
+**Goal:** Full cross-domain integration and advanced capabilities.
+
+| Week | Deliverable | Components | Value |
+|------|-------------|------------|-------|
+| 25-26 | Cross-domain events | AARPromptHandler, PatternDetectionHandler | Automatic knowledge capture |
+| 27-28 | Enriched queries | GetEnrichedWorkItem, related knowledge | Context-aware work tracking |
+| 29-30 | HybridRAG | Combined vector + graph retrieval | LLM grounding |
+| 31-32 | SPARQL endpoint | pyoxigraph adapter for SPARQL queries | External integration |
+
+**Exit Criteria:**
+- AAR prompts on task completion
+- Enriched work items show related knowledge
+- Hallucination reduction measurable
+- SPARQL queries functional
+
+---
+
+## 8. Patterns Identified
+
+### 8.1 Cross-Cutting Patterns
+
+Patterns appearing in both Work Tracker and KM domains:
+
+| Pattern | Work Tracker Usage | KM Usage | Implementation |
+|---------|-------------------|----------|----------------|
+| **Strongly-Typed IDs** | WorkItemId (`WORK-001`) | KnowledgeItemId (`PAT-001`) | VertexId base class, frozen dataclass |
+| **State Machine** | Status transitions | KnowledgeStatus lifecycle | `can_transition_to()` validation |
+| **Event Sourcing** | WorkItem reconstitution | KnowledgeItem audit trail | `reconstitute(events)` factory |
+| **CloudEvents** | WorkItemCompleted | KnowledgeItemCreated | Shared event schema |
+| **Repository Pattern** | IWorkItemRepository | IKnowledgeRepository | Generic IRepository<T> base |
+| **Value Objects** | Priority, Tag, Note | Pattern, Lesson, Assumption | Frozen dataclasses |
+
+### 8.2 Domain-Specific Patterns
+
+#### 8.2.1 Work Tracker Patterns
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| **Hierarchical Containment** | Tasks belong to Phases, Phases to Plans | `parent_id` reference, `PART_OF` edge |
+| **Blocking Dependencies** | Tasks can block other tasks | `BLOCKS` edge with reason |
+| **Priority Sorting** | Work items sortable by importance | Priority enum with integer values |
+| **Session Persistence** | State survives Claude Code compaction | SQLite persistence, CLI reload |
+
+#### 8.2.2 KM Patterns
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| **Discriminated Union Content** | One aggregate, three content types | Pattern, Lesson, Assumption in KnowledgeItem |
+| **Validation Lifecycle** | Draft -> Validated -> Deprecated | Status transitions with deprecation reason |
+| **Evidence Linking** | Knowledge grounded in work | `evidence_refs` list of JerryUris |
+| **Semantic Discovery** | Find by meaning, not keywords | FAISS vector search |
+
+### 8.3 Integration Patterns
+
+| Pattern | Description | Implementation |
+|---------|-------------|----------------|
+| **Event-Driven Integration** | Loose coupling via events | WorkItemCompleted triggers CaptureKnowledge |
+| **Graph-Based Relationships** | Cross-aggregate links as edges | IGraphStore.add_edge() |
+| **Enriched Queries** | Base entity + related knowledge | EnrichedWorkItemDTO |
+| **AAR Prompting** | Structured knowledge capture | 3-question protocol on completion |
+| **Bidirectional Traversal** | Query from either direction | `traverse()` + `traverse_incoming()` |
+
+---
+
+## 9. Technology Mapping
+
+### 9.1 NetworkX Usage
+
+**Assessment:** EXCELLENT fit for unified graph (5,500 nodes Year 1)
+
+| Use Case | Work Tracker | KM | NetworkX Feature |
+|----------|--------------|-----|------------------|
+| Hierarchy traversal | Task -> Phase -> Plan | N/A | BFS, `ancestors()` |
+| Blocking analysis | Task blocks Task | N/A | `descendants()`, cycle detection |
+| Knowledge relationships | Task -> Pattern | Pattern -> Pattern | Edge attributes, multi-graph |
+| Path finding | N/A | Related knowledge | `shortest_path()` |
+
+**Configuration:**
+
+```python
+import networkx as nx
+
+# Unified graph for both domains
+class NetworkXGraphStore:
+    def __init__(self):
+        self._graph = nx.MultiDiGraph()  # Directed, allows multiple edges
+
+    def add_vertex(self, id: VertexId, label: str, properties: dict) -> None:
+        self._graph.add_node(str(id), label=label, **properties)
+
+    def add_edge(self, from_id: VertexId, to_id: VertexId,
+                 label: str, properties: dict | None = None) -> Edge:
+        key = self._graph.add_edge(str(from_id), str(to_id),
+                                   label=label, **(properties or {}))
+        return Edge(from_id, to_id, label, properties, key)
+
+    def traverse(self, start_id: VertexId, edge_label: str,
+                 max_depth: int = 2) -> list[VertexId]:
+        results = []
+        for target in nx.bfs_edges(self._graph, str(start_id), depth_limit=max_depth):
+            # Filter by edge label
+            edge_data = self._graph.get_edge_data(target[0], target[1])
+            for key, data in edge_data.items():
+                if data.get("label") == edge_label:
+                    results.append(VertexId(target[1]))
+        return results
+```
+
+**Capacity Projections:**
+
+| Timeframe | Nodes | Edges | Memory | Query Latency |
+|-----------|-------|-------|--------|---------------|
+| Year 1 | 5,500 | 16,500 | ~15MB | <10ms |
+| Year 2 | 15,000 | 45,000 | ~40MB | <20ms |
+| Year 3 | 50,000 | 150,000 | ~130MB | <50ms |
+
+**Migration Path:** If >50K nodes, migrate to igraph (C-based, 10x faster).
+
+### 9.2 FAISS Usage
+
+**Assessment:** GOOD fit for unified semantic search (5,500 vectors Year 1)
+
+| Use Case | Work Tracker | KM | FAISS Configuration |
+|----------|--------------|-----|---------------------|
+| Title search | Find tasks by meaning | Find patterns by problem | IndexFlatL2 (exact) |
+| Description search | Full-text semantic | Content semantic | Metadata filtering |
+| Similar item discovery | Related tasks | Related knowledge | k-NN search |
+
+**Configuration:**
+
+```python
+import faiss
+import numpy as np
+
+class FAISSSemanticIndex:
+    def __init__(self, dimension: int = 1536):
+        self._index = faiss.IndexFlatL2(dimension)
+        self._id_map: dict[int, VertexId] = {}
+        self._metadata: dict[int, dict] = {}
+        self._next_idx = 0
+
+    def index(self, id: VertexId, embedding: np.ndarray, metadata: dict) -> None:
+        self._index.add(embedding.reshape(1, -1))
+        self._id_map[self._next_idx] = id
+        self._metadata[self._next_idx] = metadata
+        self._next_idx += 1
+
+    def search(self, query_embedding: np.ndarray, top_k: int = 5,
+               filters: dict | None = None) -> list[tuple[VertexId, float]]:
+        distances, indices = self._index.search(query_embedding.reshape(1, -1), top_k * 2)
+
+        results = []
+        for dist, idx in zip(distances[0], indices[0]):
+            if idx == -1:
+                continue
+            if filters:
+                meta = self._metadata.get(idx, {})
+                if not self._matches_filters(meta, filters):
+                    continue
+            results.append((self._id_map[idx], float(dist)))
+            if len(results) >= top_k:
+                break
+
+        return results
+```
+
+**Capacity Projections:**
+
+| Timeframe | Vectors | Index Size | Search Latency |
+|-----------|---------|------------|----------------|
+| Year 1 | 5,500 | ~12MB | <50ms |
+| Year 2 | 15,000 | ~35MB | <100ms |
+| Year 3 | 50,000 | ~115MB | <200ms |
+
+**Migration Path:** If >10K vectors, switch to IndexIVFFlat for approximate search.
+
+### 9.3 RDFLib Usage
+
+**Assessment:** EXCELLENT fit for standards compliance
+
+| Use Case | Work Tracker | KM | RDFLib Feature |
+|----------|--------------|-----|----------------|
+| Export to Turtle | WorkItem RDF | KnowledgeItem RDF | `serialize(format="turtle")` |
+| Export to JSON-LD | API responses | Linked Data | `serialize(format="json-ld")` |
+| SHACL validation | Optional | Required | pyshacl integration |
+| Ontology alignment | Jerry ontology | Knowledge ontology | Namespace management |
+
+**Configuration:**
+
+```python
+from rdflib import Graph, Namespace, Literal, URIRef
+from rdflib.namespace import RDF, RDFS, XSD, DC
+
+JERRY = Namespace("https://jerry.framework/ontology/")
+WT = Namespace("https://jerry.framework/ontology/worktracker/")
+KM = Namespace("https://jerry.framework/ontology/knowledge/")
+
+class RDFLibSerializer:
+    def __init__(self):
+        self._graph = Graph()
+        self._graph.bind("jerry", JERRY)
+        self._graph.bind("wt", WT)
+        self._graph.bind("km", KM)
+
+    def workitem_to_rdf(self, item: WorkItem) -> Graph:
+        g = Graph()
+        uri = URIRef(str(item.uri))
+
+        g.add((uri, RDF.type, WT.WorkItem))
+        g.add((uri, JERRY.id, Literal(str(item.id))))
+        g.add((uri, DC.title, Literal(item.title)))
+        g.add((uri, WT.status, Literal(item.status.value)))
+        g.add((uri, WT.priority, Literal(item.priority.name)))
+        g.add((uri, DC.created, Literal(item.created_at, datatype=XSD.dateTime)))
+
+        if item.parent_id:
+            g.add((uri, WT.partOf, URIRef(f"jer:jer:work-tracker:task:{item.parent_id}")))
+
+        return g
+
+    def knowledge_to_rdf(self, item: KnowledgeItem) -> Graph:
+        g = Graph()
+        uri = URIRef(str(item.uri))
+
+        g.add((uri, RDF.type, KM[item.km_type.name]))
+        g.add((uri, JERRY.id, Literal(str(item.id))))
+        g.add((uri, DC.title, Literal(item.title)))
+        g.add((uri, KM.status, Literal(item.status.value)))
+
+        # Content-type specific properties
+        if item.km_type == KnowledgeType.PATTERN:
+            g.add((uri, KM.problem, Literal(item.content.problem)))
+            g.add((uri, KM.solution, Literal(item.content.solution)))
+
+        return g
+```
+
+---
+
+## 10. Synthesis Recommendations
+
+### 10.1 Domain Model Recommendations
+
+1. **Adopt Unified Vertex Base Class**
+   - Both WorkItem and KnowledgeItem extend `Vertex`
+   - Common audit fields: created_at, created_by, modified_at, modified_by
+   - Shared graph integration via VertexId
+
+2. **Implement Shared Event Infrastructure First**
+   - Single IEventStore for both domains
+   - Single IEventDispatcher with subscription model
+   - Event handlers subscribe to cross-domain events
+
+3. **Use Jerry URI as Integration Key**
+   - All cross-aggregate references use JerryUri
+   - URIs are stable identifiers for graph edges
+   - URIs enable RDF serialization
+
+4. **Graph Edges for Cross-Domain Relationships**
+   - Never embed cross-aggregate references
+   - Always use IGraphStore.add_edge()
+   - Properties on edges for metadata (applied_at, notes)
+
+5. **CQRS with Read-Model Enrichment**
+   - Commands operate within aggregate boundaries
+   - Queries can join across domains via graph
+   - EnrichedDTO pattern for comprehensive views
+
+### 10.2 Implementation Order
+
+**Recommended sequence based on risk reduction and dependency management:**
+
+```
+Phase 1 (Foundation)
+├── Week 1-2: WorkItem entity + value objects
+├── Week 3-4: SQLite repository + event store
+├── Week 5-6: CQRS handlers (commands + queries)
+└── Week 7-8: CLI adapter + BDD tests
+
+Phase 2 (Shared Infrastructure)
+├── Week 9-10: NetworkX IGraphStore adapter
+├── Week 11-12: RDFLib IRDFSerializer adapter
+├── Week 13-14: FAISS ISemanticIndex adapter
+└── Week 15-16: Performance baselines
+
+Phase 3 (KM Core)
+├── Week 17-18: KnowledgeItem + Pattern/Lesson/Assumption
+├── Week 19-20: KM repository + graph integration
+├── Week 21-22: KM CQRS handlers
+└── Week 23-24: KM CLI/Skill
+
+Phase 4 (Integration)
+├── Week 25-26: Cross-domain event handlers
+├── Week 27-28: Enriched queries
+├── Week 29-30: HybridRAG implementation
+└── Week 31-32: SPARQL endpoint
+```
+
+### 10.3 Risk Mitigations
+
+| Risk | Mitigation | Detection | Response |
+|------|------------|-----------|----------|
+| **Performance Degradation** | Validate at Work Tracker scale first | Query latency >100ms | Optimize before KM rollout |
+| **Supernode Issue** | Edge count validator | Alert at 100 edges | Apply fanout pattern |
+| **Event Store Scaling** | Measure throughput on WT workload | Events/sec declining | Consider partitioning |
+| **Schema Evolution** | Practice migrations on WT | Breaking changes | Version envelope pattern |
+| **User Adoption** | Track AAR completion rate | <20% after 2 weeks | Simplify prompts |
+| **Graph Query Complexity** | Limit max_depth to 3 | Query timeout | Add caching layer |
+| **Vector Index Drift** | Re-index on content change | Search quality decline | Background reindex job |
+
+---
+
+## References
+
+### Input Documents
+
+| Document | Size | Key Contributions |
+|----------|------|-------------------|
+| `docs/research/work-034-e-001-domain-analysis.md` | 93KB | Complete domain analysis, entity specs, BDD scenarios |
+| `docs/plans/WORK_TRACKER_PLAN.md` | 89KB | Work Tracker domain specification |
+| `docs/decisions/ADR-033-unified-km-architecture.md` | 44KB | KM architecture decisions |
+| `docs/design/work-033-e-002-unified-design.md` | 64KB | KM domain model and ports |
+
+### External References
+
+| Reference | Citation | Relevance |
+|-----------|----------|-----------|
+| Hexagonal Architecture | Cockburn (2005) | Core architectural pattern |
+| Domain-Driven Design | Evans (2003) | Bounded contexts, aggregates |
+| CQRS Pattern | Cosmic Python | Command/query separation |
+| CloudEvents 1.0 | CNCF | Event interoperability |
+| Netflix UDA | Tech Blog | Multi-representation pattern |
+
+---
+
+## Appendix: Complete Entity Specifications
+
+### A.1 WorkItem JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/work-item.json",
+  "title": "WorkItem",
+  "type": "object",
+  "required": ["id", "title", "type", "status", "priority", "created_at", "updated_at"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^WORK-[0-9]+$"},
+    "uri": {"type": "string", "format": "uri"},
+    "title": {"type": "string", "minLength": 1, "maxLength": 200},
+    "description": {"type": "string", "maxLength": 10000, "default": ""},
+    "type": {"type": "string", "enum": ["epic", "feature", "task", "bug", "spike"]},
+    "status": {"type": "string", "enum": ["pending", "in_progress", "blocked", "completed"]},
+    "priority": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+    "parent_id": {"type": ["string", "null"], "pattern": "^WORK-[0-9]+$"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["content", "created_at"],
+        "properties": {
+          "content": {"type": "string", "maxLength": 5000},
+          "created_at": {"type": "string", "format": "date-time"},
+          "author": {"type": "string", "default": "claude"}
+        }
+      }
+    },
+    "tags": {"type": "array", "items": {"type": "string"}}
+  }
+}
+```
+
+### A.2 KnowledgeItem JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/knowledge-item.json",
+  "title": "KnowledgeItem",
+  "type": "object",
+  "required": ["id", "uri", "title", "km_type", "status", "content", "created_at"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^(PAT|LES|ASM)-[0-9]+$"},
+    "uri": {"type": "string", "format": "uri"},
+    "title": {"type": "string", "minLength": 1, "maxLength": 80},
+    "km_type": {"type": "string", "enum": ["PATTERN", "LESSON", "ASSUMPTION"]},
+    "status": {"type": "string", "enum": ["DRAFT", "VALIDATED", "DEPRECATED"]},
+    "content": {
+      "oneOf": [
+        {"$ref": "#/$defs/Pattern"},
+        {"$ref": "#/$defs/Lesson"},
+        {"$ref": "#/$defs/Assumption"}
+      ]
+    },
+    "context": {"type": "string", "default": ""},
+    "tags": {"type": "array", "items": {"type": "string"}},
+    "related_items": {"type": "array", "items": {"type": "string", "pattern": "^(PAT|LES|ASM)-[0-9]+$"}},
+    "evidence_refs": {"type": "array", "items": {"type": "string", "format": "uri"}},
+    "created_at": {"type": "string", "format": "date-time"},
+    "created_by": {"type": "string"},
+    "modified_at": {"type": "string", "format": "date-time"},
+    "modified_by": {"type": "string"},
+    "version": {"type": "string"},
+    "content_hash": {"type": "string"}
+  },
+  "$defs": {
+    "Pattern": {
+      "type": "object",
+      "required": ["context", "problem", "solution", "consequences"],
+      "properties": {
+        "context": {"type": "string"},
+        "problem": {"type": "string"},
+        "solution": {"type": "string"},
+        "consequences": {"type": "string"},
+        "forces": {"type": ["array", "null"], "items": {"type": "string"}},
+        "alternatives": {"type": ["array", "null"], "items": {"type": "string"}}
+      }
+    },
+    "Lesson": {
+      "type": "object",
+      "required": ["what_happened", "what_learned", "prevention"],
+      "properties": {
+        "what_happened": {"type": "string"},
+        "what_learned": {"type": "string"},
+        "prevention": {"type": "string"},
+        "impact": {"type": "string", "default": ""},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1, "default": 1.0}
+      }
+    },
+    "Assumption": {
+      "type": "object",
+      "required": ["statement", "impact_if_wrong", "validation_path"],
+      "properties": {
+        "statement": {"type": "string"},
+        "impact_if_wrong": {"type": "string"},
+        "validation_path": {"type": "string"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1, "default": 0.5},
+        "review_date": {"type": "string", "format": "date"}
+      }
+    }
+  }
+}
+```
+
+### A.3 Edge JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://jerry.framework/schemas/edge.json",
+  "title": "Edge",
+  "type": "object",
+  "required": ["from_id", "to_id", "label", "created_at"],
+  "properties": {
+    "from_id": {"type": "string"},
+    "to_id": {"type": "string"},
+    "label": {
+      "type": "string",
+      "enum": [
+        "PART_OF", "BLOCKS", "DEPENDS_ON",
+        "LEARNED_FROM", "APPLIED_PATTERN", "VALIDATED_ASSUMPTION",
+        "EMERGED_PATTERN", "DEPENDS_ON_ASSUMPTION",
+        "REFERENCES", "SUPERSEDES", "EVIDENCED_BY", "CREATED_BY"
+      ]
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "created_at": {"type": "string", "format": "date-time"}
+  }
+}
+```
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | `docs/synthesis/work-034-e-002-domain-synthesis.md` |
+| **Created** | 2026-01-09 |
+| **Author** | ps-synthesizer v2.0.0 |
+| **Word Count** | ~8,500 words |
+| **Diagrams** | 7 Mermaid |
+| **Tables** | 35+ |
+| **Status** | COMPLETE |
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): All claims traced to domain analysis input
+- P-002 (File Persistence): Synthesis persisted to markdown file
+- P-004 (Reasoning Transparency): Design rationale documented throughout
+- P-010 (Task Tracking): Document supports WORK-034 task
+
+**Next Steps:**
+1. Review synthesis with stakeholders
+2. Create implementation tasks from Phase 1-4 breakdown
+3. Begin Phase 1 foundation implementation

--- a/docs/archive/projects-archive/validation/work-031-e-009-validation-report.md
+++ b/docs/archive/projects-archive/validation/work-031-e-009-validation-report.md
@@ -1,0 +1,773 @@
+# WORK-031 Validation Report
+
+> **Report ID:** work-031-e-009
+> **Date:** 2026-01-08
+> **Agent:** ps-validator (v2.0.0)
+> **Subject:** ADR-031 Knowledge Architecture Decision
+> **Status:** APPROVED
+
+---
+
+## Validation Summary
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| **Evidence-Based** | ✅ PASS | Quantitative evidence from 5 production case studies, unanimous pattern support (5/5 documents) |
+| **Risk Assessment** | ✅ PASS | 5 risks identified with P×I scoring, detailed mitigations, residual risk analysis |
+| **Implementation** | ✅ PASS | 4-phase roadmap with measurable go/no-go gates, rollback paths defined |
+| **Architecture** | ✅ PASS | Preserves zero-dependency core, fits hexagonal architecture, backward compatible |
+| **Constitution** | ✅ PASS | P-001 (citations), P-002 (persistence), P-004 (provenance) all satisfied |
+
+---
+
+## Overall Verdict
+
+**APPROVED**
+
+ADR-031 (Hybrid Property + RDF Architecture) is validated for implementation. The decision is evidence-based, risk-aware, architecturally sound, and constitutionally compliant. All validation criteria met without conditions.
+
+---
+
+## L0: Executive Summary
+
+### What Was Validated
+
+This report validates ADR-031, which proposes a hybrid knowledge architecture for Jerry combining:
+- Property graphs for operational performance (Gremlin)
+- RDF/semantic web for standards compliance (SPARQL, JSON-LD)
+- HybridRAG for LLM grounding (vector + graph retrieval)
+
+The decision scored 22/25 (88%) in the trade-off analysis—highest of all evaluated options.
+
+### Validation Outcome
+
+**ADR-031 passes all validation checks.** The decision is:
+1. **Evidence-based**: 90% hallucination reduction (FalkorDB), 63% faster resolution (LinkedIn), unanimous pattern support across 5 research documents
+2. **Risk-managed**: Top 5 risks identified with mitigation strategies, residual risk acceptable (LOW-MEDIUM)
+3. **Implementable**: Phase 2 (8 weeks), Phase 3 (12 weeks conditional), Phase 4 (optional with triggers)
+4. **Architecturally sound**: Preserves Jerry's hexagonal architecture and zero-dependency core
+5. **Constitutionally compliant**: All claims cited, artifacts persisted, provenance documented
+
+### Key Strengths
+
+- **Quantitative evidence**: Production case studies show 90% hallucination reduction, 300-320% ROI
+- **Unanimous support**: PAT-001 (hybrid architecture) and PAT-002 (four-phase model) supported by all 5 research documents
+- **Risk mitigation**: Critical supernode risk (9/9) has 5-layer mitigation strategy
+- **Reversibility**: High in Phase 2 (JSON-LD optional), can stop at any phase
+- **Production validation**: Netflix UDA pattern deployed at scale
+
+### Areas of Concern (Minor)
+
+1. **Complexity overhead** (RISK-2): 5 serializers to maintain, estimated 20-30% velocity impact
+   - Mitigation: Netflix UDA pattern, automated testing, defer optional serializers to Phase 3
+   - Residual risk: MEDIUM (inherent to multi-representation architecture)
+
+2. **Schema evolution** (RISK-4): Breaking changes could affect traversals
+   - Mitigation: Versioning, migration scripts, changelog (P-030)
+   - Residual risk: MEDIUM (manageable with systematic governance)
+
+**These concerns do not block approval** as mitigations are well-defined and residual risks are acceptable.
+
+---
+
+## L1: Technical Validation
+
+### 1. Evidence-Based Decision (P-011)
+
+#### 1.1 Decision Cites Quantitative Evidence
+
+**Status:** ✅ PASS
+
+**Evidence Found in ADR-031:**
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| **Hallucination reduction** | 90% | FalkorDB GraphRAG case study |
+| **Resolution time improvement** | 63% (40hrs → 15hrs) | LinkedIn knowledge graph case study |
+| **Accuracy improvement** | 49% → 86% | Amazon Finance GraphRAG case study |
+| **ROI** | 300-320% | Production knowledge graph deployments |
+| **JSON-LD adoption** | 70% web adoption | Web Data Commons 2024 |
+| **Schema.org adoption** | 45M+ websites | Schema.org ecosystem |
+| **Decision matrix score** | 22/25 (88%) | Trade-off analysis (work-031-e-007) |
+| **Pattern support** | PAT-001: 5/5, PAT-002: 5/5 | Synthesis (work-031-e-006) |
+
+**Validation:** All quantitative claims are documented with specific sources. No unsupported assertions found.
+
+---
+
+#### 1.2 Sources Are Authoritative
+
+**Status:** ✅ PASS
+
+**Authority Assessment:**
+
+| Source Type | Examples | Authority Level |
+|------------|----------|-----------------|
+| **W3C Standards** | RDF 1.2, SPARQL 1.2, JSON-LD 1.1 | ✅ PRIMARY (International standards body) |
+| **Academic Research** | Microsoft Research GraphRAG, MiniCheck paper | ✅ PRIMARY (Peer-reviewed) |
+| **Production Case Studies** | FalkorDB, LinkedIn, Amazon Finance, Netflix UDA | ✅ PRIMARY (Real-world validation) |
+| **Industry Leaders** | Tim Berners-Lee 5-star model, Neo4j/DataStax best practices | ✅ SECONDARY (Expert opinion) |
+| **Internal Research** | Synthesis (5 documents), Trade-off analysis (ATAM) | ✅ TERTIARY (Derived from primary sources) |
+
+**Validation:** All sources are authoritative. No reliance on unverified claims or speculative sources.
+
+---
+
+#### 1.3 Claims Are Traceable to Research
+
+**Status:** ✅ PASS
+
+**Traceability Verification:**
+
+Spot-check of key claims:
+
+1. **Claim:** "GraphRAG achieves 90% hallucination reduction"
+   - **Trace:** ADR-031 "Context" → References FalkorDB case study → Synthesis work-031-e-006 (PAT-006) → e-005 (Section 5)
+   - **Validation:** ✅ Traceable to primary source
+
+2. **Claim:** "Netflix UDA is production-proven at scale"
+   - **Trace:** ADR-031 "Option 3" → 4/5 documents cite → Synthesis work-031-e-006 (PAT-003) → e-001 (DISC-064)
+   - **Validation:** ✅ Traceable to Netflix public documentation
+
+3. **Claim:** "JSON-LD has 70% web adoption"
+   - **Trace:** ADR-031 "Context" → Synthesis work-031-e-006 (PAT-005) → e-004 (Section 5.1) → Web Data Commons 2024
+   - **Validation:** ✅ Traceable to external measurement
+
+4. **Claim:** "Hybrid architecture scored 22/25 (88%)"
+   - **Trace:** ADR-031 "Decision" → Trade-off analysis work-031-e-007 (Decision Matrix) → ATAM methodology
+   - **Validation:** ✅ Traceable to systematic analysis
+
+**Validation:** All major claims traceable through citation chain to authoritative sources. Provenance documentation complete.
+
+---
+
+### 2. Risk Assessment Complete
+
+#### 2.1 Top Risks Identified
+
+**Status:** ✅ PASS
+
+**Risk Inventory:**
+
+| Risk ID | Description | Probability | Impact | Score | Tier |
+|---------|-------------|-------------|--------|-------|------|
+| **RISK-1** | Supernode degradation (Actor vertex) | HIGH | HIGH | 9/9 | **CRITICAL** |
+| **RISK-2** | Complexity slowing development | MEDIUM | MEDIUM | 4/9 | **MODERATE** |
+| **RISK-3** | Premature Phase 4 migration | LOW | HIGH | 3/9 | **LOW-MODERATE** |
+| **RISK-4** | Schema evolution breaking traversals | MEDIUM | HIGH | 6/9 | **MODERATE-HIGH** |
+| **RISK-5** | Grounding verification false positives | MEDIUM | LOW | 2/9 | **LOW** |
+
+**Coverage Analysis:**
+- ✅ Critical risk (RISK-1) identified and addressed
+- ✅ Technical risks (RISK-2, RISK-4) covered
+- ✅ Process risks (RISK-3) covered
+- ✅ Operational risks (RISK-5) covered
+- ✅ Risk matrix complete (no gaps)
+
+**Validation:** Comprehensive risk identification. Covers architectural (RISK-1, RISK-4), process (RISK-2, RISK-3), and operational (RISK-5) dimensions.
+
+---
+
+#### 2.2 Mitigations Provided
+
+**Status:** ✅ PASS
+
+**Mitigation Quality Assessment:**
+
+**RISK-1 (Supernode) - CRITICAL:**
+- ✅ Mitigation 1: Preventive monitoring (edge count validator, 100/1000 thresholds)
+- ✅ Mitigation 2: Temporal partitioning (time-based edge labels)
+- ✅ Mitigation 3: Hierarchical decomposition (intermediate Actor nodes)
+- ✅ Mitigation 4: Constitutional enforcement (P-031 Supernode Prevention)
+- ✅ Mitigation 5: Quantitative validation (10,000 synthetic tasks test)
+- **Quality:** STRONG (5 layers, preventive + detective controls)
+
+**RISK-2 (Complexity) - MODERATE:**
+- ✅ Mitigation 1: Netflix UDA pattern enforcement
+- ✅ Mitigation 2: Automated round-trip testing
+- ✅ Mitigation 3: Defer optional serializers to Phase 3
+- ✅ Mitigation 4: Contributor documentation (SERIALIZATION_GUIDE.md)
+- **Quality:** MODERATE (process-based, relies on discipline)
+
+**RISK-3 (Premature Phase 4) - LOW-MODERATE:**
+- ✅ Mitigation 1: Explicit trigger conditions (multi-tenant OR >10M entities OR clustering)
+- ✅ Mitigation 2: Quantitative monitoring (entity count, latency alerts)
+- ✅ Mitigation 3: Phase 4 evaluation checklist
+- ✅ Mitigation 4: Constitutional gate (P-032 Phase Gate Compliance)
+- **Quality:** STRONG (quantitative gates prevent premature action)
+
+**RISK-4 (Schema Evolution) - MODERATE-HIGH:**
+- ✅ Mitigation 1: Schema versioning (semantic versioning)
+- ✅ Mitigation 2: Forward migration scripts
+- ✅ Mitigation 3: Rollback migration scripts
+- ✅ Mitigation 4: Schema changelog (P-030 constitutional requirement)
+- ✅ Mitigation 5: Integration tests for traversals
+- **Quality:** STRONG (systematic governance, automated validation)
+
+**RISK-5 (Grounding False Positives) - LOW:**
+- ✅ Mitigation 1: Confidence threshold tuning (0.7 default)
+- ✅ Mitigation 2: Soft warnings (non-blocking)
+- ✅ Mitigation 3: Defer to Phase 3 (optional feature)
+- ✅ Mitigation 4: User feedback loop
+- **Quality:** ADEQUATE (low-impact risk, appropriate controls)
+
+**Validation:** All risks have detailed, actionable mitigations. Critical risk (RISK-1) has strongest controls (5 layers). Mitigation quality proportional to risk severity.
+
+---
+
+#### 2.3 Risk Levels Justified
+
+**Status:** ✅ PASS
+
+**Justification Analysis:**
+
+**RISK-1 (9/9 Critical) - JUSTIFIED:**
+- ✅ Probability HIGH: Synthesis document explicitly rates Actor as HIGH supernode risk
+- ✅ Impact HIGH: O(n) traversal degradation affects all agents, queries slow from 5-10ms to 500ms+
+- ✅ Score calculation: HIGH × HIGH = 9/9 (correct)
+- ✅ Residual risk LOW: 5-layer mitigation strategy reduces to acceptable level
+
+**RISK-2 (4/9 Moderate) - JUSTIFIED:**
+- ✅ Probability MEDIUM: 5 serializers confirmed in Phase 2
+- ✅ Impact MEDIUM: Estimated 20-30% velocity overhead (not catastrophic)
+- ✅ Score calculation: MEDIUM × MEDIUM = 4/9 (correct)
+- ✅ Residual risk MEDIUM: Complexity inherent to multi-representation, managed via process
+
+**RISK-3 (3/9 Low-Moderate) - JUSTIFIED:**
+- ✅ Probability LOW: Phase 4 explicitly marked "optional"
+- ✅ Impact HIGH: Infrastructure costs ($100-1000/month) + migration effort (weeks)
+- ✅ Score calculation: LOW × HIGH = 3/9 (correct)
+- ✅ Residual risk LOW: Quantitative gates prevent premature migration
+
+**RISK-4 (6/9 Moderate-High) - JUSTIFIED:**
+- ✅ Probability MEDIUM: Jerry is evolving system, schema changes inevitable
+- ✅ Impact HIGH: Breaks agent functionality, requires code updates across system
+- ✅ Score calculation: MEDIUM × HIGH = 6/9 (correct)
+- ✅ Residual risk MEDIUM: Can't eliminate evolution, but can manage systematically
+
+**RISK-5 (2/9 Low) - JUSTIFIED:**
+- ✅ Probability MEDIUM: Grounding models have error rates (MiniCheck not perfect)
+- ✅ Impact LOW: Soft warnings, doesn't block functionality
+- ✅ Score calculation: MEDIUM × LOW = 2/9 (correct)
+- ✅ Residual risk LOW: Optional feature, non-blocking warnings
+
+**Validation:** All risk scores justified with specific evidence. Probability and impact assessments grounded in synthesis findings or quantitative data. Residual risk assessment realistic.
+
+---
+
+### 3. Implementation Feasibility
+
+#### 3.1 Phased Approach Defined
+
+**Status:** ✅ PASS
+
+**Phase Structure Analysis:**
+
+| Phase | Duration | Deliverables | Status | Dependencies |
+|-------|----------|--------------|--------|--------------|
+| **Phase 1** | Complete | Property graph, JSON/TOON, Jerry URIs, Work Tracker | ✅ COMPLETE | None |
+| **Phase 2** | 8 weeks | JSON-LD context, RDF serialization, SHACL, Vector RAG, HybridRAG foundation | 🎯 NEXT | Phase 1 complete |
+| **Phase 3** | 12 weeks | SPARQL endpoint, OWL ontology, grounding verification, visualization | 🔮 FUTURE | Phase 2 success criteria |
+| **Phase 4** | TBD | Server-based deployment (Fuseki/Neptune), clustering, >10M entities | 🔮 OPTIONAL | Trigger conditions |
+
+**Phase 2 Breakdown (8 weeks):**
+- Week 1-2: Foundation (JSON-LD context, supernode validator, edge monitoring)
+- Week 3-4: RDF Serialization (pyoxigraph, Turtle/JSON-LD adapters, SHACL shapes)
+- Week 5-6: Vector RAG (docs/ indexing, embeddings, cosine search)
+- Week 7-8: Integration & Testing (benchmarks, schema migration tests, documentation)
+
+**Validation:**
+- ✅ Clear phase boundaries
+- ✅ Deliverables specific and actionable
+- ✅ Dependencies explicitly stated
+- ✅ Time estimates reasonable (8-12 weeks per phase)
+- ✅ Phase 4 clearly marked optional with explicit triggers
+
+---
+
+#### 3.2 Success Criteria Measurable
+
+**Status:** ✅ PASS
+
+**Phase 2 Go/No-Go Gates (Week 8):**
+
+| Criterion | Metric | Target | Measurement Method |
+|-----------|--------|--------|-------------------|
+| **Backward Compatibility** | % existing tests passing | 100% | pytest suite (all Phase 1 tests) |
+| **Performance (Hot Path)** | Query latency P95 | < 50ms | Benchmark suite (property graph queries) |
+| **Performance (Cold Path)** | RDF export latency P95 | < 100ms | Benchmark suite (Turtle, JSON-LD) |
+| **Serialization Correctness** | Round-trip success rate | 100% | Parametrized tests (all serializers) |
+| **Supernode Prevention** | Edge count monitoring | Alerts working | Synthetic test (10,000 tasks) |
+| **Documentation** | Contributor onboarding time | < 4 hours | User time tracking |
+
+**Measurability Assessment:**
+- ✅ All criteria quantitative (percentages, latencies, success rates)
+- ✅ Measurement methods specified (pytest, benchmark suite, time tracking)
+- ✅ Clear pass/fail thresholds
+- ✅ No subjective criteria
+
+**Phase 3 Go/No-Go Gates (Month 7):**
+
+| Criterion | Evidence Required | Measurable? |
+|-----------|------------------|-------------|
+| **Phase 2 Success** | All Phase 2 criteria met | ✅ YES (refer to Phase 2 gates) |
+| **User Validation** | User feedback confirms value | ✅ YES (surveys, usage metrics) |
+| **Use Case Demand** | SPARQL/reasoning required | ✅ YES (feature requests logged) |
+| **HybridRAG Impact** | Hallucination reduction | ✅ YES (baseline vs RAG comparison) |
+
+**Phase 4 Trigger Conditions (Ongoing):**
+
+| Trigger | Threshold | Measurable? |
+|---------|-----------|-------------|
+| Multi-tenant access | User requests | ✅ YES (explicit requests) |
+| Entity count | > 10M | ✅ YES (dashboard monitoring) |
+| Query latency | P95 > 500ms | ✅ YES (performance logs) |
+| Clustering/HA | User SLA requirements | ✅ YES (explicit SLA requests) |
+
+**Validation:** All success criteria measurable. No vague "user satisfaction" or "system quality" criteria. Clear quantitative thresholds with specified measurement methods.
+
+---
+
+#### 3.3 Rollback Path Exists
+
+**Status:** ✅ PASS
+
+**Reversibility Analysis:**
+
+**Phase 2 Reversibility: HIGH**
+- ✅ JSON-LD is optional extension (plain JSON still works)
+- ✅ RDF export is cold path (no performance impact on operations)
+- ✅ Supernode validator can be disabled (warnings only)
+- ✅ Vector embeddings stored separately (can delete without affecting domain model)
+- **Rollback cost:** LOW (remove @context, disable serializers)
+
+**Phase 3 Reversibility: MEDIUM**
+- ✅ SPARQL endpoint is separate service (can shut down without affecting core)
+- ✅ OWL ontology is declarative (no code changes to domain)
+- ✅ Grounding verification is non-blocking (soft warnings)
+- **Rollback cost:** MEDIUM (infrastructure teardown, but no data migration needed)
+
+**Phase 4 Reversibility: LOW**
+- ⚠️ Server-based migration requires data export/import
+- ⚠️ Cloud infrastructure has termination costs
+- ⚠️ Clustering/HA changes operational patterns
+- **Rollback cost:** HIGH (data migration, infrastructure changes)
+
+**Mitigation for Low Phase 4 Reversibility:**
+- ✅ Phase 4 clearly marked OPTIONAL
+- ✅ Trigger conditions require user approval
+- ✅ Evaluation checklist before migration
+- ✅ Cost-benefit analysis required
+
+**Schema Evolution Rollback (RISK-4 Mitigation):**
+- ✅ Every migration has rollback script (documented in Implementation Plan Week 3-4)
+- ✅ Example rollback script provided:
+  ```python
+  # migrations/001_add_blocking_reason_rollback.py
+  def rollback(graph: Graph):
+      for task in graph.V().hasLabel('Task'):
+          task.properties('blocking_reason').drop()
+  ```
+
+**Validation:** Rollback paths defined for all phases. Reversibility HIGH in Phase 2 (critical phase), MEDIUM in Phase 3 (acceptable), LOW in Phase 4 (mitigated by optional status and gates).
+
+---
+
+### 4. Architectural Alignment
+
+#### 4.1 Fits Jerry's Hexagonal Architecture
+
+**Status:** ✅ PASS
+
+**Hexagonal Architecture Principles:**
+
+| Principle | Jerry Implementation | ADR-031 Compliance |
+|-----------|---------------------|-------------------|
+| **Domain has no external dependencies** | Domain layer uses Python stdlib only | ✅ "Zero-Dependency Core: Semantic capabilities in infrastructure layer (pyoxigraph), Domain layer remains pure Python stdlib" (Consequences) |
+| **Ports define contracts** | Repository ports, serialization ports | ✅ "RDF serialization adapters" as infrastructure adapters (Decision) |
+| **Adapters implement ports** | JSON/TOON serializers already exist | ✅ "Netflix UDA: Model Once, Represent Everywhere" - serializers as adapters (Rationale) |
+| **Dependency inversion** | Outer layers depend on inner | ✅ Property graph (domain) → RDF adapters (infrastructure) (Architecture diagram in Decision) |
+
+**Layering Verification:**
+
+```
+ADR-031 Proposed Architecture:
+Domain Model (Property Graph)
+    ├─ Primary Storage: File-based JSON/TOON
+    ├─ Operational Queries: Gremlin traversal (hot path)
+    └─ Serialization Adapters (cold path):        ← INFRASTRUCTURE LAYER
+        ├─ JSON-LD (web integration)
+        ├─ Turtle (human-readable RDF)
+        ├─ GraphSON (TinkerPop export)
+        └─ RDF* (edge properties without reification)
+```
+
+**Validation:**
+- ✅ Domain layer unchanged (Property graph abstractions from Phase 1)
+- ✅ Infrastructure layer contains new capabilities (RDF adapters, pyoxigraph)
+- ✅ Adapters implement serialization contracts
+- ✅ No business logic in adapters (Netflix UDA pattern)
+
+---
+
+#### 4.2 Respects Zero-Dependency Core
+
+**Status:** ✅ PASS
+
+**Zero-Dependency Analysis:**
+
+**Decision Driver #4 (ADR-031):**
+> "Zero-Dependency Core: Domain layer maintains Python stdlib-only constraint"
+
+**Consequences Section (ADR-031):**
+> "Zero-Dependency Core Preserved: Semantic capabilities in infrastructure layer (pyoxigraph), Domain layer remains pure Python stdlib, Embedded databases through Phase 3 ($0 infrastructure)"
+
+**Dependency Placement:**
+
+| Dependency | Layer | Justification | Compliant? |
+|------------|-------|---------------|-----------|
+| **pyoxigraph** | Infrastructure | RDF storage adapter | ✅ YES (not in domain) |
+| **Embedding models** | Infrastructure | Vector RAG adapter | ✅ YES (not in domain) |
+| **MiniCheck** | Infrastructure | Grounding verification (optional) | ✅ YES (Phase 3, optional) |
+| **Flask** | Infrastructure | SPARQL endpoint (Phase 3) | ✅ YES (not in domain) |
+
+**Negative Consequences Section Acknowledgment:**
+> "Dependency Expansion: Issue: pyoxigraph (RDF storage), embedding models (vector RAG), potentially MiniCheck (grounding). Impact: Goes against Jerry's zero-dependency principle (though dependencies in infrastructure layer, not domain). Mitigation: All dependencies optional (infrastructure layer only), embedded deployment avoids server dependencies"
+
+**Validation:**
+- ✅ Zero-dependency principle explicitly listed as decision driver
+- ✅ All new dependencies in infrastructure layer
+- ✅ Domain layer remains Python stdlib only
+- ✅ Trade-off acknowledged (complexity vs capability)
+- ✅ Mitigation: Optional dependencies, embedded deployment
+
+---
+
+#### 4.3 Compatible with Existing Phase 1
+
+**Status:** ✅ PASS
+
+**Backward Compatibility Analysis:**
+
+**Rationale Section (ADR-031):**
+> "Backward Compatible: Jerry's existing Phase 1 property graph foundation remains intact—no throwaway work"
+
+**Consequences Section (ADR-031):**
+> "Incremental Risk Management: Each phase delivers independent value, High reversibility in Phase 2 (JSON-LD optional extension), Can stop at Phase 2 if advanced capabilities not needed"
+
+**Phase 1 Artifacts (from CLAUDE.md and ADR-031):**
+- ✅ Property graph abstractions (Vertex, Edge, VertexProperty)
+- ✅ File-based storage (JSON, TOON)
+- ✅ Jerry URI scheme (SPEC-001)
+- ✅ Work Tracker graph model
+
+**Phase 2 Changes (from Implementation Plan):**
+- ✅ Add JSON-LD context (optional @context field)
+- ✅ Add RDF serialization adapters (export only, non-breaking)
+- ✅ Add supernode validator (monitoring, non-blocking warnings)
+- ✅ Add vector embeddings (stored separately, no domain changes)
+
+**Breaking Change Analysis:**
+- ✅ No changes to domain entity structure
+- ✅ No changes to property graph traversal APIs
+- ✅ No changes to existing JSON/TOON serialization
+- ✅ All Phase 2 capabilities are additive
+
+**Phase 2 Success Criteria (Backward Compatibility):**
+- ✅ "Backward Compatibility: % of existing tests passing = 100% target" (Success Criteria table)
+- ✅ Measurement method: "pytest suite (all Phase 1 tests)"
+
+**Trade-off Analysis Validation (work-031-e-007 SWOT):**
+> "Strengths: Leverages Existing Foundation - Jerry already has property graph abstractions (Vertex, Edge, VertexProperty) ✅, Phase 1 complete—no need to throw away existing work"
+
+**Validation:**
+- ✅ Explicit backward compatibility requirement (100% tests pass)
+- ✅ Phase 1 foundation preserved (property graph, URIs, Work Tracker)
+- ✅ All Phase 2 changes additive (optional extensions)
+- ✅ No throwaway work (builds on existing abstractions)
+
+---
+
+### 5. Constitutional Compliance
+
+#### 5.1 P-001: Truth and Accuracy - Claims Verifiable
+
+**Status:** ✅ PASS
+
+**P-001 (Jerry Constitution):**
+> "P-001: Truth and Accuracy - Agents MUST provide accurate information based on verifiable sources. Claims SHOULD be cited where possible. Confidence levels SHOULD be communicated transparently."
+
+**Citation Analysis:**
+
+**Quantitative Claims:**
+
+| Claim | Citation | Verifiable? |
+|-------|----------|-------------|
+| "90% hallucination reduction" | FalkorDB case study → Synthesis e-006 (PAT-006) → e-005 (Section 5) | ✅ YES |
+| "63% faster resolution (40hrs → 15hrs)" | LinkedIn case study → Synthesis e-006 → e-005 (Section 5) | ✅ YES |
+| "49% → 86% accuracy" | Amazon Finance case study → Synthesis e-006 → e-005 (Section 5) | ✅ YES |
+| "300-320% ROI" | Production KG deployments → Synthesis e-006 | ✅ YES |
+| "70% JSON-LD adoption" | Web Data Commons 2024 → Synthesis e-006 (PAT-005) → e-004 (Section 5.1) | ✅ YES |
+| "45M+ Schema.org websites" | Schema.org ecosystem → Synthesis e-006 (PAT-008) → e-002 (Section 4) | ✅ YES |
+| "22/25 (88%) decision score" | Trade-off analysis work-031-e-007 (Decision Matrix) | ✅ YES |
+
+**Architectural Claims:**
+
+| Claim | Citation | Verifiable? |
+|-------|----------|-------------|
+| "Netflix UDA pattern" | Netflix public documentation → Synthesis e-006 (PAT-003) → e-001 (DISC-064) | ✅ YES |
+| "Unanimous pattern support (5/5)" | Synthesis e-006 (Cross-Reference Matrix) | ✅ YES |
+| "Tim Berners-Lee 5-star model" | Linked Data principles → Synthesis e-006 | ✅ YES |
+
+**References Section:**
+- ✅ Primary Sources documented (synthesis, trade-off analysis)
+- ✅ Research Evidence documented (pattern support, case studies, standards)
+- ✅ Research Methods documented (Braun & Clarke, ATAM, SWOT)
+- ✅ Industry Prior Art documented (Netflix UDA, Microsoft GraphRAG, Neo4j/DataStax)
+
+**Footer Citation:**
+> "Agent: ps-architect (v2.0.0)"
+> "Constitution Compliance: P-001 (all claims cited), P-002 (decision persisted to file)"
+
+**Validation:** All major claims have citation trails. Quantitative data traceable to primary sources. No unsupported assertions.
+
+---
+
+#### 5.2 P-002: Persistence - Artifacts Created
+
+**Status:** ✅ PASS
+
+**P-002 (Jerry Constitution):**
+> "P-002: File Persistence - Agents MUST persist significant outputs to files rather than relying solely on context. Decisions, plans, and knowledge MUST be stored in appropriate docs/ hierarchy."
+
+**Artifacts Created for WORK-031:**
+
+| Artifact | Location | Size | Purpose |
+|----------|----------|------|---------|
+| **Synthesis** | docs/synthesis/work-031-e-006-synthesis.md | 1,142 lines | Cross-document pattern extraction |
+| **Trade-off Analysis** | docs/analysis/work-031-e-007-trade-off-analysis.md | 821 lines | ATAM quality attribute analysis |
+| **ADR** | docs/decisions/ADR-031-knowledge-architecture.md | 956 lines | Architectural decision record |
+| **Validation Report** | docs/validation/work-031-e-009-validation-report.md | This file | Validation of ADR-031 |
+
+**Persistence Structure:**
+- ✅ Synthesis in docs/synthesis/ (knowledge extraction)
+- ✅ Trade-off analysis in docs/analysis/ (decision support)
+- ✅ ADR in docs/decisions/ (architectural decisions)
+- ✅ Validation report in docs/validation/ (quality assurance)
+
+**Cross-References:**
+- ✅ ADR-031 references synthesis and trade-off analysis
+- ✅ Validation report references all three prior documents
+- ✅ Each document includes changelog with agent attribution
+
+**Footer Acknowledgment (ADR-031):**
+> "Constitution Compliance: P-001 (all claims cited), P-002 (decision persisted to file)"
+
+**Validation:** All significant outputs persisted to files. Proper docs/ hierarchy usage. Cross-references enable traceability.
+
+---
+
+#### 5.3 P-004: Provenance - Sources Cited
+
+**Status:** ✅ PASS
+
+**P-004 (Jerry Constitution):**
+> "P-004: Provenance - Agents SHOULD document sources and reasoning chains. Knowledge items SHOULD include metadata about origin, date, and confidence."
+
+**Provenance Documentation in ADR-031:**
+
+**Document Metadata:**
+```markdown
+## Status
+PROPOSED
+
+## Date
+2026-01-08
+
+## Changelog
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-08 | ps-architect agent (v2.0.0) | Initial ADR created from synthesis work-031-e-006 and analysis work-031-e-007 |
+```
+
+**Sources Section (ADR-031):**
+
+1. **Primary Sources**
+   - docs/synthesis/work-031-e-006-synthesis.md (1,142 lines, Braun & Clarke thematic analysis)
+   - docs/analysis/work-031-e-007-trade-off-analysis.md (821 lines, ATAM-inspired analysis)
+
+2. **Research Evidence (via Synthesis)**
+   - Pattern support documented (PAT-001 through PAT-010)
+   - Case studies cited (FalkorDB, LinkedIn, Amazon, Netflix)
+   - Standards referenced (W3C RDF 1.2, SPARQL 1.2, JSON-LD 1.1, Schema.org)
+
+3. **Research Methods**
+   - Braun & Clarke Thematic Analysis (6-phase qualitative method)
+   - ATAM (Architecture Tradeoff Analysis Method, Carnegie Mellon SEI)
+   - SWOT Analysis (strategic planning framework)
+   - Decision Matrix (multi-criteria decision analysis)
+   - Risk Matrix (probability × impact scoring)
+
+4. **Industry Prior Art**
+   - Netflix UDA (Unified Data Architecture)
+   - Microsoft Research GraphRAG
+   - FalkorDB GraphRAG production deployment
+   - Neo4j Graph Modeling best practices
+   - DataStax Graph Best Practices
+
+5. **Jerry Documentation**
+   - CLAUDE.md (Jerry framework root context)
+   - docs/governance/JERRY_CONSTITUTION.md
+   - SPEC-001 (Jerry URI scheme)
+
+**Reasoning Chain Example:**
+```
+Decision: Adopt Hybrid Property + RDF Architecture
+    ↓
+Evidence: Unanimous support across 5 research documents (PAT-001)
+    ↓
+Synthesis: work-031-e-006-synthesis.md analyzed 5 documents
+    ↓
+Research: e-001 (Gremlin), e-002 (Semantics), e-003 (Tech), e-004 (JSON-LD), e-005 (LLM)
+    ↓
+Industry: Netflix UDA, FalkorDB case study, LinkedIn case study
+```
+
+**Footer Provenance:**
+> "Agent: ps-architect (v2.0.0)"
+> "Decision Record Method: Michael Nygard ADR Format"
+> "Decision: Hybrid Property + RDF Architecture (22/25, 88%)"
+
+**Validation:** Complete provenance chain documented. Sources cited in References section. Reasoning methods explicit (Braun & Clarke, ATAM). Agent attribution in footer.
+
+---
+
+## L2: Strategic Assessment
+
+### Architectural Implications Validated
+
+#### 1. Strategic Differentiation via Knowledge Architecture
+
+**Assessment:** ✅ VALIDATED
+
+**Evidence:**
+- ADR-031 positions knowledge architecture as "strategic differentiation" not "infrastructure"
+- Quantitative ROI: 300-320% (production case studies)
+- Measurable impact: 90% hallucination reduction, 63% faster resolution
+- Industry validation: Netflix UDA, FalkorDB, LinkedIn, Amazon deployments
+
+**Strategic Coherence:**
+Jerry's mission is "solve problems while accruing a body of knowledge, wisdom, and experience." ADR-031 directly supports this by:
+1. Accumulating knowledge in structured graph (Work Tracker)
+2. Grounding LLM agents in Jerry's accumulated knowledge (HybridRAG)
+3. Enabling knowledge interoperability (RDF/JSON-LD export)
+
+**Validation:** Decision aligns with Jerry's strategic mission. Knowledge architecture investments have measurable ROI.
+
+---
+
+#### 2. Phased Risk Mitigation via Incremental Delivery
+
+**Assessment:** ✅ VALIDATED
+
+**Risk-Aware Roadmap:**
+
+| Phase | Risk Level | Reversibility | Value Delivery | Strategic Logic |
+|-------|------------|---------------|----------------|----------------|
+| **Phase 1** | Low | N/A | Property graph foundation | Prerequisite capability |
+| **Phase 2** | Low | HIGH | JSON-LD, RDF export, HybridRAG | Immediate LLM grounding value |
+| **Phase 3** | Medium | MEDIUM | SPARQL, reasoning, verification | Advanced capabilities (conditional) |
+| **Phase 4** | High | LOW | Server-based, cloud scale | Only if scale triggers |
+
+**Go/No-Go Gates:**
+- ✅ Phase 2 → Phase 3: Requires user validation + use case demand
+- ✅ Phase 3 → Phase 4: Requires trigger conditions (multi-tenant OR >10M entities OR P95 >500ms OR clustering)
+
+**Validation:** Incremental approach reduces risk. Each phase independently valuable. High-risk Phase 4 clearly marked optional with quantitative triggers.
+
+---
+
+#### 3. Architectural Evolution Without Technical Debt
+
+**Assessment:** ✅ VALIDATED
+
+**Evolution Strategy:**
+
+ADR-031 avoids common anti-patterns:
+- ❌ Anti-pattern: "Big bang" semantic web migration (rewrite everything)
+- ✅ Pattern: Incremental capability addition (property graph → RDF export → SPARQL)
+
+- ❌ Anti-pattern: "Premature optimization" (build for scale not needed)
+- ✅ Pattern: Embedded-first with clear scale triggers (Phase 4 conditions)
+
+- ❌ Anti-pattern: "Technology lock-in" (choose property graph XOR RDF)
+- ✅ Pattern: Netflix UDA (model once, represent everywhere)
+
+**Technical Debt Prevention:**
+- ✅ Backward compatibility requirement (100% tests pass)
+- ✅ Migration scripts with rollback (schema evolution)
+- ✅ Multiple serialization formats (no vendor lock-in)
+- ✅ Constitutional governance (P-030, P-031, P-032)
+
+**Validation:** Architecture evolves without accumulating technical debt. Backward compatibility enforced. Multiple escape hatches (rollback scripts, optional features).
+
+---
+
+#### 4. Semantic Web Pragmatic Turn Timing
+
+**Assessment:** ✅ VALIDATED
+
+**Historical Context Awareness:**
+
+ADR-031 explicitly acknowledges semantic web history:
+> "Context: The Semantic Web has undergone a pragmatic turn in 2024-2025"
+
+**Evidence of Maturity:**
+- JSON-LD: 70% web adoption (vs 3% RDFa) - mainstream, not experimental
+- Schema.org: 45M+ websites - critical mass for interoperability
+- Tooling: Oxigraph (modern Rust/Python, not legacy Java)
+- Use case: LLM grounding (killer app, not academic curiosity)
+
+**Timing Validation:**
+Jerry is adopting semantic web technologies at the right time:
+- ✅ Past the "early adopter" risk phase (70% adoption)
+- ✅ Before the "late majority" commoditization (still differentiator)
+- ✅ Killer app identified (GraphRAG for LLM grounding)
+- ✅ Mature tooling available (embedded options, Python libraries)
+
+**Validation:** Timing is strategically sound. Semantic web adoption now has lower risk (mature standards, tooling) and clearer ROI (GraphRAG case studies).
+
+---
+
+### Conditions for Approval
+
+**None.**
+
+All validation criteria met without conditions. ADR-031 is approved as written.
+
+---
+
+## Sign-off
+
+**Validation Status:** ✅ APPROVED WITHOUT CONDITIONS
+
+**Validated by:** ps-validator (v2.0.0)
+**Date:** 2026-01-08
+**Method:** Systematic checklist validation against 5 constitutional principles
+
+**Recommendation:** Proceed to implementation of Phase 2 (8 weeks) as specified in ADR-031 Implementation Plan.
+
+---
+
+## Changelog
+
+| Version | Date | Agent | Changes |
+|---------|------|-------|---------|
+| 1.0 | 2026-01-08 | ps-validator (v2.0.0) | Initial validation report for ADR-031 |
+
+---
+
+*Validation Method: Constitutional Compliance + Evidence-Based Assessment*
+*Verdict: APPROVED (all checks pass)*
+*Agent: ps-validator (v2.0.0)*
+*Constitution Compliance: P-001 (claims verified), P-002 (report persisted), P-004 (sources documented)*

--- a/docs/archive/projects-archive/validation/work-032-e-009-validation-report.md
+++ b/docs/archive/projects-archive/validation/work-032-e-009-validation-report.md
@@ -1,0 +1,523 @@
+# Validation Report: ADR-032 KM Integration Decision
+
+> **PS ID:** work-032
+> **Entry ID:** e-009
+> **Validator:** ps-validator v2.0.0
+> **Date:** 2026-01-09
+> **Document Under Review:** `docs/decisions/ADR-032-km-integration.md`
+
+---
+
+## L0: Validation Summary
+
+| Validation Check | Status | Score | Notes |
+|-----------------|--------|-------|-------|
+| **Evidence-Based (P-011)** | ✅ PASS | 5/5 | Extensive quantitative evidence from 358KB research, 71+ citations |
+| **Risk Assessment** | ✅ PASS | 5/5 | 5 major risks identified with severity calculations, mitigations, triggers |
+| **Implementation Feasibility** | ✅ PASS | 5/5 | 4-phase plan with clear deliverables, effort estimates, success criteria |
+| **Architectural Alignment** | ✅ PASS | 5/5 | Perfect hexagonal architecture fit, domain isolation preserved |
+| **Constitutional Compliance** | ✅ PASS | 5/5 | P-001, P-002, P-004 satisfied; P-003, P-020, P-022 addressed |
+| **Overall Quality** | ✅ EXCELLENT | 25/25 | Exceeds expectations on all dimensions |
+
+### Overall Verdict
+
+**APPROVED WITH CONDITIONS**
+
+**Conditions for Approval:**
+1. **Quarterly Progress Tracking**: Implementation progress MUST be reviewed quarterly against the 20% dev time threshold (Risk #5 trigger)
+2. **Phase Gate Enforcement**: Each phase MUST meet success criteria before proceeding to next phase
+3. **Adoption Metrics Monitoring**: If adoption <20% by Q2 2026, trigger documented off-ramp protocol
+
+**Confidence Level:** 95% (Very High)
+
+**Rationale:** ADR-032 is an exemplary architectural decision document that demonstrates exceptional thoroughness, evidence-based reasoning, and Jerry framework alignment. The conditions are standard governance checkpoints, not remediation requirements.
+
+---
+
+## L1: Detailed Validation Analysis
+
+### 1. Evidence-Based Decision Making (P-011)
+
+**Constitutional Principle:**
+> "Agents SHALL make decisions based on evidence, not assumptions. This requires: Research before implementation, Citations from authoritative sources, Documentation of decision rationale."
+
+**Findings:**
+
+✅ **PASS** - Exceptional compliance
+
+**Evidence Quality:**
+- **Research Foundation:** 358KB synthesis across 5 documents, 71+ citations
+- **Quantitative Scoring:**
+  - Decision Matrix: 8.5/10 for Lightweight KM (15% higher than alternatives)
+  - SWOT Analysis: 8.2/10
+  - Quality Attributes: 4.37/7
+- **Industry Validation:** Library download statistics (14M+/week), production usage data
+- **Comparative Analysis:** 4 options evaluated against 9 weighted criteria
+- **Confidence Quantification:** 85% confidence level with explicit basis
+
+**Citation Quality:**
+- Primary research documents (7 synthesis files)
+- Industry standards (ISO 30401:2018, RDF/SPARQL)
+- Technical documentation (NetworkX, RDFLib, FAISS)
+- Jerry governance (Constitution, Coding Standards)
+- Prior art (Anthropic, OpenAI, Hexagonal Architecture)
+
+**Decision Rationale:**
+- 7 explicit rationale points with evidence citations
+- Convergent evidence across multiple evaluation methods
+- Clear superiority in weighted decision matrix
+- Industry validation from comprehensive research
+
+**Score:** 5/5 (Exemplary)
+
+---
+
+### 2. Risk Assessment
+
+**Requirement:** Risks identified with mitigations, triggers, and contingencies.
+
+**Findings:**
+
+✅ **PASS** - Comprehensive risk management
+
+**Risk Coverage:**
+
+| Risk | Severity | Analysis Quality | Mitigation Quality |
+|------|----------|------------------|-------------------|
+| **#1: Corpus Growth Exceeds Capacity** | HIGH (4.8/10) | ✅ Quantified (P=60%, I=8) | ✅ Port/adapter swap, quarterly monitoring |
+| **#2: Dependency Abandonment** | MEDIUM (1.4/10) | ✅ Quantified (P=20%, I=7) | ✅ Version pinning, health checks, hexagonal isolation |
+| **#3: Implementation Complexity** | MEDIUM (2.0/10) | ✅ Quantified (P=40%, I=5) | ✅ Phased rollout, MVP in 1 month |
+| **#4: User Adoption Failure** | MEDIUM (2.0/10) | ✅ Quantified (P=50%, I=4) | ✅ Lightweight AAR, value demonstration |
+| **#5: Over-Engineering** | MEDIUM (1.8/10) | ✅ Quantified (P=30%, I=6) | ✅ Phase gates, YAGNI, quarterly ROI review |
+
+**Risk Management Strengths:**
+- Probabilistic severity scoring (Probability × Impact)
+- Each risk has trigger conditions (measurable thresholds)
+- Each risk has contingency plans (specific actions)
+- Risks ranked by severity score
+- Both technical and organizational risks addressed
+
+**Rollback Plan:**
+- Clear trigger conditions (adoption <20% AND ROI unmeasurable AND high maintenance)
+- Defined rollback steps (6-step process)
+- Data preservation strategy (RDF export, filesystem source of truth)
+- Cost quantification (Low due to hexagonal architecture)
+
+**Score:** 5/5 (Comprehensive)
+
+---
+
+### 3. Implementation Feasibility
+
+**Requirement:** Phased approach with clear deliverables and success criteria.
+
+**Findings:**
+
+✅ **PASS** - Exceptionally well-structured implementation plan
+
+**Phase Structure:**
+
+| Phase | Timeline | Effort | Deliverables | Success Criteria | Risk Level |
+|-------|----------|--------|--------------|-----------------|------------|
+| **Phase 1: Foundation** | Q1 2026 (Weeks 1-4) | 20-30 hours | Port definitions, adapters, basic operations | 5 measurable criteria | Low |
+| **Phase 2: Integration** | Q2 2026 (Weeks 5-10) | 30-40 hours | Automated indexing, entity extraction, CLI | 5 measurable criteria | Medium |
+| **Phase 3: AI Integration** | Q3 2026 (Weeks 11-16) | 20-30 hours | RAG implementation, agent integration | 5 measurable criteria | Low |
+| **Phase 4: Optimization** | Q4 2026+ (Triggered) | TBD | Performance tuning, advanced features | Trigger-based | Variable |
+
+**Total Effort:** 70-100 hours over 3 phases (Phase 4 conditional)
+
+**Implementation Strengths:**
+- Clear phase gates (success criteria must be met before proceeding)
+- Incremental value delivery (Phase 2 = first tangible benefits)
+- Risk-appropriate effort allocation (higher risk phases have more time)
+- Trigger-based optimization (YAGNI principle applied)
+- Specific file paths and CLI commands provided
+
+**Success Metrics:**
+
+**Quantitative (Quarterly Measurement):**
+- Knowledge graph size targets (500+ nodes by Q2, 1000+ by Q4)
+- Query performance thresholds (<500ms graph, <2s semantic)
+- Adoption targets (50% of work items by Q2)
+- Coverage targets (80% of docs/ indexed by Q3)
+
+**Qualitative (User/Agent Feedback):**
+- Agent reasoning improvement
+- Faster discovery of related work
+- Measurable knowledge reuse
+- SECI spiral demonstration
+
+**ROI Targets:**
+- 10-20% time saved finding information
+- 15-25% reduced duplicate work
+- Qualitative decision quality improvement
+
+**Governance:**
+- Quarterly assessment framework (Jan/Apr/Jul/Oct)
+- Off-ramp conditions defined (adoption, maintenance burden, performance)
+- Alignment checks against P-002, P-003, P-020, P-022
+
+**Score:** 5/5 (Exemplary)
+
+---
+
+### 4. Architectural Alignment
+
+**Requirement:** Fits Jerry's hexagonal architecture with zero-dependency domain.
+
+**Findings:**
+
+✅ **PASS** - Perfect hexagonal architecture compliance
+
+**Hexagonal Architecture Adherence:**
+
+**Domain Layer (Zero Dependencies):**
+```python
+# Port definitions (contracts only, no implementations)
+src/domain/ports/graph_port.py          # Graph operations interface
+src/domain/ports/knowledge_port.py      # Semantic/RDF operations interface
+src/domain/ports/vector_store_port.py   # Vector search interface
+```
+- ✅ Pure Python abstractions
+- ✅ No external library imports
+- ✅ Dependency inversion principle applied
+
+**Infrastructure Layer (Adapter Implementations):**
+```python
+# Adapters implement domain ports
+src/infrastructure/graph/networkx_adapter.py      # NetworkX implementation
+src/infrastructure/knowledge/rdflib_adapter.py    # RDFLib implementation
+src/infrastructure/embeddings/faiss_adapter.py    # FAISS implementation
+```
+- ✅ External dependencies isolated to infrastructure
+- ✅ Swappable implementations (NetworkX → igraph → Neo4j)
+- ✅ Adapter pattern correctly applied
+
+**Application Layer (Use Cases):**
+```python
+# CQRS pattern maintained
+src/application/commands/build_knowledge_graph.py  # Write operation
+src/application/queries/find_related_docs.py       # Read operation
+src/application/queries/semantic_search.py         # Read operation
+```
+- ✅ CQRS separation preserved
+- ✅ Use cases orchestrate domain via ports
+
+**Interface Layer (Primary Adapters):**
+```bash
+# CLI integration
+jerry knowledge graph --query "find related to X"
+jerry knowledge search "semantic query text"
+```
+- ✅ Clean user interface
+- ✅ No architecture leakage
+
+**Architecture Principles Preserved:**
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| **Dependency Inversion** | ✅ | Outer layers depend on inner ports |
+| **Zero-Dependency Domain** | ✅ | Domain ports have no imports |
+| **Swappable Adapters** | ✅ | Migration paths defined (NetworkX → igraph → Neo4j) |
+| **Local-First** | ✅ | Filesystem remains source of truth |
+| **Port/Adapter Pattern** | ✅ | Correct implementation described |
+
+**Constitutional Alignment:**
+- **P-002 (File Persistence):** Filesystem remains source of truth, graph/vector as indices
+- **P-003 (No Recursive Subagents):** ReAct uses tools, not nested agents
+- **Hexagonal Architecture:** No compromise to framework design
+
+**Score:** 5/5 (Perfect Alignment)
+
+---
+
+### 5. Constitutional Compliance
+
+**Requirement:** Satisfies P-001 (Truth), P-002 (Persistence), P-004 (Provenance).
+
+**Findings:**
+
+✅ **PASS** - Full constitutional compliance with bonus principles
+
+**P-001: Truth and Accuracy**
+
+**Evidence:**
+- ✅ Extensive research citations (358KB, 71+ citations)
+- ✅ Confidence level explicitly stated (85%)
+- ✅ Uncertainty acknowledged (performance limits, learning curve)
+- ✅ Sources distinguished (primary research vs. industry standards)
+- ✅ Multiple evaluation methods for convergent validation
+
+**Compliance Score:** 5/5
+
+---
+
+**P-002: File Persistence**
+
+**Evidence:**
+- ✅ ADR itself is a persistent file
+- ✅ Filesystem designated as source of truth
+- ✅ Graph/vector as derived indices (can be rebuilt from files)
+- ✅ RDF export enables portability
+- ✅ Rollback preserves filesystem (no data loss)
+- ✅ Explicit alignment check in document (line 455)
+
+**Compliance Score:** 5/5
+
+---
+
+**P-004: Explicit Provenance**
+
+**Evidence:**
+- ✅ Comprehensive references section (15 sources)
+- ✅ Primary research documents cited with file paths
+- ✅ Industry standards referenced (ISO 30401, RDF/SPARQL)
+- ✅ Technical documentation linked (NetworkX, RDFLib, FAISS)
+- ✅ Jerry governance cited (Constitution, Coding Standards)
+- ✅ Decision rationale documented (7 explicit points)
+- ✅ Approval chain included (Author, Reviewer, Approver)
+
+**Compliance Score:** 5/5
+
+---
+
+**Bonus Constitutional Principles Addressed:**
+
+**P-003: No Recursive Subagents**
+- ✅ Explicitly noted: "ReAct uses tools, not nested agents" (line 456)
+- ✅ No agent nesting in proposed architecture
+
+**P-011: Evidence-Based Decisions**
+- ✅ Quantitative scoring across 3 evaluation methods
+- ✅ Research synthesis as foundation
+- ✅ Industry validation data provided
+
+**P-020: User Authority**
+- ✅ Approval chain includes user approval requirement
+- ✅ Quarterly governance includes user review
+- ✅ Off-ramps enable user-directed course changes
+- ✅ Explicit alignment check (line 457)
+
+**P-022: No Deception**
+- ✅ Confidence level stated (85%)
+- ✅ Weaknesses and compromises listed
+- ✅ Risks quantified with severity scores
+- ✅ Implementation effort honestly estimated
+- ✅ Explicit alignment check: "Always cite sources, expose uncertainty" (line 458)
+
+**Overall Constitutional Compliance Score:** 5/5 (Exemplary)
+
+---
+
+## L2: Contextual Analysis
+
+### Document Quality Assessment
+
+**Strengths:**
+
+1. **Research Rigor:** 358KB synthesis across 71+ citations demonstrates exceptional thoroughness
+2. **Multi-Method Evaluation:** Decision Matrix + SWOT + Quality Attributes provides convergent validation
+3. **Risk Management:** Probabilistic severity scoring with triggers and contingencies
+4. **Architectural Fidelity:** Perfect hexagonal architecture alignment without compromise
+5. **Implementation Detail:** Specific file paths, CLI commands, success criteria
+6. **Governance Framework:** Quarterly reviews, off-ramps, rollback plans
+7. **Constitutional Awareness:** Explicit alignment checks against Jerry principles
+
+**Minor Observations:**
+
+1. **Implementation Effort:** 70-100 hours is substantial but appropriately phased
+2. **Learning Curve:** Graph concepts, RDF, embeddings acknowledged as challenge
+3. **Performance Limits:** NetworkX (<10K nodes), FAISS (CPU-only) clearly stated
+4. **Memory Overhead:** In-memory structures may constrain scalability
+
+**None of these are deficiencies—they are transparent trade-offs with mitigations.**
+
+---
+
+### Comparison to Industry Standards
+
+**ADR Format Compliance:**
+- ✅ Status clearly marked (PROPOSED)
+- ✅ Context section explains problem and drivers
+- ✅ Options evaluated with pros/cons
+- ✅ Decision stated with rationale
+- ✅ Consequences analyzed (positive and negative)
+- ✅ References provided
+
+**Above Industry Standard:**
+- Quantitative scoring across multiple methods
+- Probabilistic risk assessment
+- Phased implementation with success metrics
+- Constitutional alignment checks
+- Rollback and migration planning
+
+---
+
+### Recommended Conditions for Approval
+
+1. **Quarterly Progress Tracking**
+   - **Trigger:** If KM work >20% of total dev time in any quarter (Risk #5)
+   - **Action:** Freeze feature development, focus on utilization
+   - **Responsibility:** User to review quarterly assessment reports
+
+2. **Phase Gate Enforcement**
+   - **Requirement:** Each phase MUST meet success criteria before proceeding
+   - **Example:** Phase 1 success criteria (5 items, lines 325-330) must be verified
+   - **Responsibility:** ps-validator to review phase completion reports
+
+3. **Adoption Metrics Monitoring**
+   - **Trigger:** If adoption <20% by Q2 2026
+   - **Action:** Simplify protocols or defer Phase 3 (per line 449)
+   - **Responsibility:** User to assess adoption via usage logs
+
+4. **Constitutional Compliance Audits**
+   - **Frequency:** Quarterly (aligned with governance reviews)
+   - **Focus:** P-002 (filesystem source of truth), P-003 (no agent nesting)
+   - **Responsibility:** ps-validator or security-auditor agent
+
+---
+
+### Confidence Assessment
+
+**Validator Confidence:** 95% (Very High)
+
+**Basis for Confidence:**
+- All 5 validation checks passed with maximum scores (25/25)
+- Evidence quality exceeds typical ADR standards
+- Risk management is comprehensive and realistic
+- Architectural alignment is perfect
+- Constitutional compliance demonstrated across 6 principles
+- Industry validation from extensive research
+- Clear governance and exit strategies
+
+**Remaining 5% Uncertainty:**
+- Execution risk (implementation effort is estimate)
+- Adoption risk (user behavior unpredictable)
+- Library evolution risk (dependencies may change)
+
+**All uncertainties have documented mitigations and contingencies.**
+
+---
+
+## L3: Recommendations
+
+### Approval Recommendation
+
+**APPROVED WITH CONDITIONS**
+
+This ADR represents exceptional quality in architectural decision documentation. It exceeds Jerry framework requirements on all validation dimensions.
+
+### Recommended Next Steps
+
+1. **User Review**
+   - Review this validation report
+   - Approve ADR-032 or provide feedback
+   - Confirm acceptance of quarterly governance commitments
+
+2. **Implementation Planning**
+   - Create PLAN file for Phase 1 implementation
+   - Set up quarterly review calendar (Jan/Apr/Jul/Oct)
+   - Establish baseline metrics (current knowledge discovery time)
+
+3. **Governance Setup**
+   - Create tracking dashboard for success metrics
+   - Define log format for adoption measurement
+   - Schedule first quarterly review (April 2026)
+
+4. **Dependency Management**
+   - Pin library versions per specification
+   - Set up quarterly dependency health checks
+   - Document version upgrade criteria
+
+### Post-Approval Actions
+
+**For ps-architect (ADR Author):**
+- Update ADR-032 status from PROPOSED → APPROVED
+- Document approval date and validator
+- Create Phase 1 PLAN file
+
+**For User:**
+- Review and approve ADR-032
+- Authorize Phase 1 commencement
+- Confirm quarterly review schedule
+
+**For ps-validator (This Agent):**
+- Monitor Phase 1 implementation progress
+- Review Phase 1 completion report against success criteria
+- Conduct first quarterly governance review (April 2026)
+
+---
+
+## Appendix A: Validation Methodology
+
+**Framework:** Jerry Constitution v1.0 + ADR Best Practices
+
+**Validation Criteria:**
+1. Evidence-Based (P-011): Quantitative evidence, citations, decision rationale
+2. Risk Assessment: Risks identified with severity, mitigations, triggers, contingencies
+3. Implementation Feasibility: Phased approach, deliverables, success criteria, effort estimates
+4. Architectural Alignment: Hexagonal architecture, zero-dependency domain, port/adapter pattern
+5. Constitutional Compliance: P-001, P-002, P-004 (plus bonus principles)
+
+**Scoring Scale:**
+- 5/5: Exemplary (exceeds expectations)
+- 4/5: Strong (meets all requirements with minor gaps)
+- 3/5: Adequate (meets requirements)
+- 2/5: Weak (partial compliance, needs revision)
+- 1/5: Failing (major deficiencies, reject)
+
+**Verdict Criteria:**
+- **APPROVED:** All checks ≥4/5, no critical gaps
+- **APPROVED WITH CONDITIONS:** All checks ≥4/5, standard governance checkpoints
+- **CONDITIONAL APPROVAL:** Checks 3-4/5, specific revisions required
+- **REJECTED:** Any check <3/5, fundamental issues
+
+---
+
+## Appendix B: Document Metadata
+
+**ADR Under Review:**
+- **File:** `/home/user/jerry/docs/decisions/ADR-032-km-integration.md`
+- **Status:** PROPOSED (Awaiting approval)
+- **Author:** ps-architect v2.0.0
+- **Date:** 2026-01-09
+- **Size:** 27KB (549 lines)
+
+**Validation Report:**
+- **File:** `/home/user/jerry/docs/validation/work-032-e-009-validation-report.md`
+- **Validator:** ps-validator v2.0.0
+- **Date:** 2026-01-09
+- **Confidence:** 95% (Very High)
+
+**Related Documents:**
+- `docs/synthesis/work-032-e-006-km-synthesis.md` (37KB)
+- `docs/analysis/work-032-e-007-trade-off-analysis.md` (29KB)
+- `docs/governance/JERRY_CONSTITUTION.md` (Constitutional principles)
+
+---
+
+## Appendix C: Audit Trail
+
+**Validation Process:**
+1. Read ADR-032 (549 lines analyzed)
+2. Read Jerry Constitution v1.0 (339 lines)
+3. Evaluate Evidence-Based criteria (P-011)
+4. Evaluate Risk Assessment completeness
+5. Evaluate Implementation Feasibility
+6. Evaluate Architectural Alignment
+7. Evaluate Constitutional Compliance (6 principles)
+8. Calculate scores and determine verdict
+9. Generate validation report with recommendations
+
+**Time to Validation:** ~15 minutes (thorough review)
+
+**Validator Signature:** ps-validator v2.0.0 (Agent ID: work-032-e-009)
+
+---
+
+**END OF VALIDATION REPORT**
+
+*Classification: Governance*
+*Status: Final*
+*Confidence: 95% (Very High)*
+*Verdict: APPROVED WITH CONDITIONS*

--- a/docs/archive/projects-archive/validation/work-033-e-005-validation-report.md
+++ b/docs/archive/projects-archive/validation/work-033-e-005-validation-report.md
@@ -1,0 +1,227 @@
+# WORK-033 Validation Report (e-005)
+
+**PS ID:** work-033
+**Entry ID:** e-005
+**Topic:** ADR-033 Validation Report
+**Type:** Validation Document
+**Date:** 2026-01-09
+**Validator:** ps-validator v2.0.0
+**Status:** COMPLETE
+
+---
+
+## Validation Summary
+
+| Field | Value |
+|-------|-------|
+| **ADR** | ADR-033-unified-km-architecture.md |
+| **Verdict** | APPROVED |
+| **Score** | 25/25 (100%) |
+| **Date** | 2026-01-09 |
+| **Validator** | ps-validator v2.0.0 |
+
+---
+
+## Executive Assessment
+
+ADR-033 represents an exceptionally comprehensive and well-structured architectural decision record that successfully unifies two major prior decisions (ADR-031 and ADR-032) into a cohesive knowledge management architecture for Jerry. The document demonstrates outstanding quality across all validation dimensions, earning a perfect score of 25/25 (100%).
+
+The ADR excels in several key areas: (1) thorough metadata and cross-referencing to related decisions; (2) a clear executive summary that distills complex technical concepts into accessible language; (3) comprehensive technical architecture with complete domain models, ports, adapters, and CQRS patterns; (4) a detailed four-phase implementation roadmap with explicit go/no-go gates; and (5) robust risk management with quantified risk scores and mitigation strategies.
+
+The document demonstrates exceptional alignment with Jerry's constitutional principles, particularly P-001 (Truth and Accuracy) through extensive citation of 71+ sources, P-002 (File Persistence) through the filesystem-as-source-of-truth architecture, and P-004 (Explicit Provenance) through documented rationale at multiple levels (L0, L1, L2). The hexagonal architecture compliance is exemplary, with clean separation between domain layer (zero dependencies), infrastructure layer (adapters), and application layer (use cases).
+
+---
+
+## Detailed Checklist Results
+
+### 1. ADR Completeness (10/10)
+
+| Item | Score | Finding |
+|------|-------|---------|
+| **Metadata complete** | 2/2 | Excellent. All required fields present: Status (PROPOSED), Date (2026-01-09), Deciders (ps-architect v2.0.0, User pending approval), Technical Story (WORK-033), Related ADRs (ADR-031, ADR-032), Supersedes (None). |
+| **Executive summary present and clear** | 2/2 | Outstanding. The executive summary provides: (1) context about Jerry's mission; (2) summary of ADR-031 and ADR-032 with scores; (3) key finding of 95% compatibility; (4) decision outcome (Phased Implementation at 92%); (5) quantified ROI projection (186% over 5 years). Written in accessible language suitable for non-technical stakeholders. |
+| **Context and problem statement thorough** | 2/2 | Comprehensive. Document articulates five specific challenges: (1) Context Rot; (2) Knowledge Fragmentation; (3) Discovery Limitations; (4) LLM Hallucination; (5) Interoperability Gaps. Each challenge is explained with impact. Prior work from WORK-031 and WORK-032 is extensively documented. Constraints table explicitly maps requirements to sources (Jerry Constitution, Hexagonal Architecture, Phase 1 Foundation, Privacy/Cost). |
+| **Decision outcome clearly stated** | 2/2 | Excellent. "Phased Implementation strategy is selected" is unambiguous. Rationale enumerated: (1) Decision Matrix Winner 4.6/5; (2) Wins 4 of 5 criteria; (3) Robust to weight changes; (4) Industry validation; (5) Highest ROI. The decision drivers table provides weighted ranking (Critical 70%, Important 30%) with clear rationale for each driver. |
+| **Consequences documented** | 2/2 | Thorough. Positive consequences organized by timeframe (Immediate/Phase 2, Medium-Term/Phase 3, Long-Term/Year 1-5). Negative consequences documented in trade-off table with Impact and Mitigation columns. Five specific trade-offs identified: dependency expansion, learning curve, architectural complexity, performance limits, longer timeline. |
+
+### 2. Technical Architecture (5/5)
+
+| Item | Score | Finding |
+|------|-------|---------|
+| **Domain model defined (KnowledgeItem AR)** | 1/1 | Complete. KnowledgeItem aggregate root fully specified with Mermaid class diagram. Includes: KnowledgeItemId (value object with PAT/LES/ASM prefix validation), KnowledgeType enum, KnowledgeStatus enum (DRAFT/VALIDATED/DEPRECATED), Pattern/Lesson/Assumption value objects. Inheritance from Vertex/EntityBase documented. Methods defined: validate(), deprecate(reason), add_evidence(uri), relate_to(other). |
+| **Ports defined** | 1/1 | Complete. Four primary ports specified with full Python interface signatures: IKnowledgeRepository (save, find_by_id, find_by_type, find_related), ISemanticIndex (index, search, reindex), IGraphStore (add_vertex, add_edge, traverse, export_rdf), IRDFSerializer (to_turtle, to_jsonld, validate_shacl). All ports follow ABC pattern with @abstractmethod decorators. |
+| **Adapters specified** | 1/1 | Complete. Six adapters mapped to ports with library versions: FileSystemAdapter (Python stdlib), NetworkXAdapter (NetworkX 3.2.1), FAISSAdapter (FAISS 1.7.4), RDFLibAdapter (RDFLib 7.0.0), PyoxigraphAdapter (pyoxigraph, Phase 3). Adapter architecture diagram shows relationship between ports and adapters. Dependency installation commands provided. |
+| **Use cases listed (CQRS)** | 1/1 | Complete. Commands documented: CaptureKnowledgeCommand, ValidateKnowledgeCommand, DeprecateKnowledgeCommand, RelateKnowledgeCommand with corresponding handlers. Queries documented: SearchKnowledgeQuery, GetRelatedKnowledgeQuery, TraverseKnowledgeGraphQuery, ExportKnowledgeGraphQuery with handlers. CQRS pattern explicitly referenced. |
+| **Domain events defined (CloudEvents 1.0)** | 1/1 | Complete. Four events specified with CloudEvents 1.0 type URIs: KnowledgeItemCreated (jer:jer:knowledge:facts/KnowledgeItemCreated), KnowledgeItemValidated, KnowledgeItemDeprecated, KnowledgeRelationCreated. Event schema example provided with specversion, type, source, subject, time, and data fields. |
+
+### 3. Implementation Roadmap (5/5)
+
+| Item | Score | Finding |
+|------|-------|---------|
+| **Phase 2 breakdown with timeline** | 1/1 | Excellent. Phase 2 decomposed into four 2-week sprints: Week 1-2 (Foundation/Protocols), Week 3-4 (RDF Serialization), Week 5-6 (Graph Layer/Entity Extraction), Week 7-8 (Vector RAG/Integration Testing). Each sprint has WORK-031 contributions, WORK-032 contributions, and Integration deliverables. Effort estimates per sprint (20-25, 15-20, 20-25, 15-20 hours). Total: 70-100 hours over 8 weeks (Q1 2026). |
+| **Success criteria defined** | 1/1 | Comprehensive. Success criteria table for Phase 2 go/no-go gate includes 8 metrics: Backward Compatibility (100%), Hot Path Performance (<50ms P95), Cold Path Performance (<100ms P95), Vector Search (<2s), Serialization (100% round-trip), Supernode Prevention (alerts working), Documentation (<4 hours onboarding), User Validation (positive feedback). Each metric has target and measurement method. |
+| **Go/no-go gates specified** | 1/1 | Complete. Phase 2 Go/No-Go Gate at Week 8 with explicit "Proceed to Phase 3 ONLY if ALL criteria met" statement. "If ANY criterion fails: Pause Phase 3, address issues, re-evaluate" instruction provided. Phase 3 Go/No-Go Gate at Month 7 with both proceed and do-not-proceed conditions. |
+| **Phase 3 trigger conditions clear** | 1/1 | Complete. Phase 3 triggers explicitly listed: Phase 2 go/no-go criteria met, user validation confirms semantic layer value, use case demand for SPARQL or reasoning (not theoretical), HybridRAG demonstrates measurable hallucination reduction. Do NOT proceed conditions: hot path degraded >100ms, maintenance overhead >30%, no external integration use cases, user satisfied with Phase 2 alone. |
+| **Phase 4 trigger thresholds documented** | 1/1 | Complete. Phase 4 trigger conditions explicitly quantified: multi-tenant SaaS offering required, >10M entities in production (currently thousands), P95 query latency >500ms (currently <50ms), clustering/HA required for uptime SLA. "Do NOT proceed unless one trigger met" statement. Evaluation options table (Fuseki, Neptune, igraph, Stay Embedded) with cost implications. Quarterly review governance specified. |
+
+### 4. Risk Management (3/3)
+
+| Item | Score | Finding |
+|------|-------|---------|
+| **Risk register present** | 1/1 | Complete. 10-risk register with quantified scoring: RISK-1 (Corpus Growth, 4.8/10), RISK-2 (Supernode, 5.6/10 CRITICAL), RISK-3 (Architectural Complexity, 3.0/10), RISK-4 (Schema Evolution, 3.5/10), RISK-5 (User Adoption, 2.0/10), RISK-6 (Over-Engineering, 1.8/10), RISK-7 (Dependency Abandonment, 1.4/10), RISK-8 (Implementation Delays, 2.0/10), RISK-9 (Premature Phase 4, 0.8/10), RISK-10 (Grounding False Positives, 1.2/10). Risk score calculation formula provided (Probability % x Impact / 10). |
+| **Mitigation strategies documented** | 1/1 | Excellent. Top 3 risks (RISK-1, RISK-2, RISK-6) have detailed mitigation sections with 4-5 specific strategies each. RISK-2 (Supernode) mitigations: temporal partitioning, hierarchical decomposition, edge count validator (100/1000 thresholds), constitutional enforcement (P-031), quantitative testing (10,000 tasks). Contingency plans with effort estimates (e.g., "Budget 1 week for schema migration"). |
+| **Residual risk assessment** | 1/1 | Complete. Residual risk column in risk register: RISK-1 (2.4), RISK-2 (1.4), RISK-3 (3.0), RISK-4 (3.5), RISK-5 (2.0), RISK-6 (1.8), RISK-7 (1.4), RISK-8 (2.0), RISK-9 (0.8), RISK-10 (1.2). Risk Heat Map ASCII visualization with RED/YELLOW/GREEN zones. "Overall Risk Profile: MODERATE (acceptable with active risk management)" assessment. Mitigation strength ratings (STRONG/MEDIUM) per risk. |
+
+### 5. Compliance (2/2)
+
+| Item | Score | Finding |
+|------|-------|---------|
+| **Jerry Constitution alignment** | 1/1 | Excellent. Constitution alignment table maps 5 existing principles: P-001 (Truth/Accuracy, REINFORCED via grounding verification), P-002 (File Persistence, REINFORCED), P-003 (No Recursive Subagents, COMPLIANT), P-020 (User Authority, COMPLIANT via phase gates), P-022 (No Deception, REINFORCED via citations). Three new constitutional principles proposed: P-030 (Schema Evolution Governance, Hard), P-031 (Supernode Prevention, Medium), P-032 (Phase Gate Compliance, Medium). Each new principle includes full text, rationale, and enforcement level. |
+| **Hexagonal architecture compliance** | 1/1 | Complete. Four-layer architecture explicitly documented: (1) Domain Layer (Zero Dependencies) with entities and ports; (2) Application Layer (Depends on Domain) with commands and queries; (3) Infrastructure Layer (Implements Ports) with adapters; (4) Interface Layer (Invokes Application) with CLI and skills. "Pure business logic, Python stdlib only" constraint for domain layer. Adapter swappability via ports emphasized. Mermaid diagram shows port-adapter relationships with dependency arrows. |
+
+---
+
+## Strengths
+
+- **Exceptional comprehensiveness**: At 44KB and ~8,500 words, the ADR provides exhaustive coverage without sacrificing readability through effective L0/L1/L2 layering.
+
+- **Strong evidence base**: Integration analysis from WORK-033 e-001 (72KB), unified design from e-002 (64KB), and trade-off analysis from e-003 (66KB) provide 200+ KB of supporting documentation with 71+ citations.
+
+- **Quantified decision-making**: Decision matrix scores (4.6/5, 92% for Phased), sensitivity analysis across 3 scenarios, ROI projections (186% over 5 years), and risk scores (probability x impact formula) demonstrate rigorous analytical approach.
+
+- **Clear implementation path**: 8-week Phase 2 roadmap with 4 sprints, effort estimates (70-100 hours), and explicit deliverable checklists provide actionable implementation guidance.
+
+- **Industry validation**: Netflix UDA pattern, FalkorDB case study (90% hallucination reduction), LinkedIn example (63% faster resolution), JSON-LD adoption statistics (70% web adoption), and Schema.org integration (45M+ websites) ground the architecture in proven approaches.
+
+- **Constitutional integration**: Reinforcement of existing principles (P-001, P-002, P-022) plus three new principle proposals (P-030, P-031, P-032) demonstrate governance maturity.
+
+- **Risk transparency**: 10-risk register with residual risk tracking, contingency plans with effort estimates, and explicit migration paths (NetworkX -> igraph, FAISS -> Qdrant) show realistic risk management.
+
+- **Technology specificity**: Library versions pinned (NetworkX 3.2.1, RDFLib 7.0.0, FAISS 1.7.4), installation commands provided, and adapter implementations specified by phase.
+
+---
+
+## Weaknesses
+
+- **None identified**: The ADR meets or exceeds all validation criteria. Minor observations noted below are enhancement opportunities rather than gaps.
+
+- **Enhancement opportunity**: The Success Metrics section could benefit from baseline measurement methodology for qualitative metrics like "Agent Reasoning" and "Faster Discovery" that rely on user surveys.
+
+- **Enhancement opportunity**: The Contributor Onboarding target (<4 hours) could specify onboarding path or curriculum outline.
+
+- **Enhancement opportunity**: The decision to propose three new constitutional principles (P-030, P-031, P-032) could reference the amendment process from Article VII of the Jerry Constitution.
+
+---
+
+## Conditions (if APPROVED WITH CONDITIONS)
+
+Not applicable. Verdict is APPROVED without conditions.
+
+---
+
+## Recommendations
+
+1. **Begin Phase 2 implementation**: Given the 100% validation score and APPROVED verdict, recommend immediate commencement of Week 1-2 activities (ports, JSON-LD contexts, AAR templates, supernode validator).
+
+2. **Formalize constitutional amendments**: The three proposed principles (P-030, P-031, P-032) should be processed through the amendment procedure in Article VII of the Jerry Constitution.
+
+3. **Establish baseline measurements**: Before Phase 2 completion, establish baseline metrics for qualitative success criteria (time finding information, duplicate work rate, agent reasoning quality) to enable meaningful Phase 2/Phase 3 comparison.
+
+4. **Create implementation tracking**: Generate a PLAN file (e.g., `PLAN-WORK-033-phase-2-implementation.md`) to track the 8-week Phase 2 roadmap deliverables.
+
+5. **Schedule Phase 2 go/no-go review**: Calendar the Week 8 go/no-go gate review (approximately 2026-02-28) with the 8-metric success criteria checklist.
+
+---
+
+## Evidence Citations
+
+| Section | Source Document | Location |
+|---------|-----------------|----------|
+| Executive Summary | ADR-033 | Lines 16-28 |
+| Context and Problem Statement | ADR-033 | Lines 31-86 |
+| Decision Drivers | ADR-033 | Lines 89-112 |
+| Considered Options | ADR-033 | Lines 115-181 |
+| Decision Outcome | ADR-033 | Lines 184-228 |
+| Technical Architecture | ADR-033 | Lines 231-552 |
+| Implementation Roadmap | ADR-033 | Lines 555-776 |
+| Risk Management | ADR-033 | Lines 779-837 |
+| Compliance | ADR-033 | Lines 840-905 |
+| Success Metrics | ADR-033 | Lines 908-939 |
+| 95% Compatibility Finding | Integration Analysis (e-001) | Lines 17-28 |
+| Decision Matrix Scoring | Trade-off Analysis (e-003) | Lines 251-337 |
+| Domain Model Specification | Unified Design (e-002) | Lines 152-437 |
+| Hexagonal Architecture | Unified Design (e-002) | Lines 1166-1258 |
+| Constitutional Principles | Jerry Constitution | Articles I-IV |
+
+---
+
+## Verdict Justification
+
+**APPROVED**
+
+ADR-033-unified-km-architecture.md earns an APPROVED verdict with a perfect score of 25/25 (100%) based on the following justification:
+
+### Completeness Assessment
+
+The ADR satisfies all 25 validation checklist items across five categories:
+- **ADR Completeness (10/10)**: All metadata, executive summary, context, decision outcome, and consequences are thoroughly documented.
+- **Technical Architecture (5/5)**: KnowledgeItem aggregate root, four ports, six adapters, CQRS use cases, and CloudEvents 1.0 domain events are fully specified.
+- **Implementation Roadmap (5/5)**: Phase 2 breakdown, success criteria, go/no-go gates, Phase 3 triggers, and Phase 4 thresholds are explicitly defined.
+- **Risk Management (3/3)**: 10-risk register with quantified scores, mitigation strategies, and residual risk assessment.
+- **Compliance (2/2)**: Jerry Constitution alignment and hexagonal architecture compliance demonstrated.
+
+### Quality Assessment
+
+The ADR demonstrates exceptional quality through:
+- **Evidence-based reasoning**: 71+ citations from industry sources, case studies, and prior Jerry research.
+- **Quantitative rigor**: Decision matrix, sensitivity analysis, ROI projections, risk scoring.
+- **Actionable specificity**: Library versions, effort estimates, timeline, success criteria with thresholds.
+- **Architectural coherence**: Netflix UDA pattern, hexagonal architecture, CQRS, CloudEvents integration.
+
+### Risk Assessment
+
+The overall risk profile is MODERATE (acceptable) with strong mitigations:
+- Two critical risks (RISK-1, RISK-2) have residual risk reduced by 50%+ through defined mitigations.
+- Port/adapter pattern enables migration paths without domain layer changes.
+- Phase gates provide explicit stop points to prevent over-engineering.
+
+### Alignment Assessment
+
+The ADR reinforces Jerry's constitutional principles (P-001, P-002, P-022) and proposes three governance extensions (P-030, P-031, P-032) that strengthen the framework.
+
+### Conclusion
+
+ADR-033 represents a model architectural decision record that successfully unifies WORK-031 and WORK-032 into a coherent, implementable, and well-governed knowledge management architecture. The document is ready for user approval and Phase 2 implementation.
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | WORK-033-e-005 |
+| **File Path** | `docs/validation/work-033-e-005-validation-report.md` |
+| **Date Created** | 2026-01-09 |
+| **Validator** | ps-validator v2.0.0 |
+| **Word Count** | ~2,800 words |
+| **Validation Method** | 25-point checklist against ADR, supporting documents, and Jerry Constitution |
+
+---
+
+## Constitution Compliance
+
+This validation report complies with Jerry Constitution principles:
+
+| Principle | Compliance | Evidence |
+|-----------|------------|----------|
+| **P-001 (Truth and Accuracy)** | COMPLIANT | All findings cited to specific line numbers in source documents. |
+| **P-002 (File Persistence)** | COMPLIANT | Validation persisted to `docs/validation/work-033-e-005-validation-report.md`. |
+| **P-004 (Explicit Provenance)** | COMPLIANT | Evidence Citations section provides full traceability. |
+| **P-010 (Task Tracking Integrity)** | COMPLIANT | WORK-033 Step 4 deliverable completed. |
+| **P-022 (No Deception)** | COMPLIANT | Perfect score awarded based on objective checklist evaluation. |
+
+---
+
+*Validation Report Complete*
+*ps-validator v2.0.0*
+*2026-01-09*

--- a/docs/archive/projects-archive/validation/work-034-e-006-validation-report.md
+++ b/docs/archive/projects-archive/validation/work-034-e-006-validation-report.md
@@ -1,0 +1,463 @@
+# WORK-034 Validation Report: Unified Work Tracker + Knowledge Management
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **PS ID** | work-034 |
+| **Entry ID** | e-006 |
+| **Date** | 2026-01-09 |
+| **Author** | ps-validator v2.0.0 |
+| **Artifacts Validated** | 5 |
+| **Total Size** | 331KB (actual) vs ~332KB (expected) |
+| **Status** | **APPROVED** |
+
+---
+
+## Executive Summary
+
+**VERDICT: APPROVED**
+
+This validation report certifies that all five WORK-034 artifacts meet the required quality standards for proceeding to implementation (WORK-035). The comprehensive analysis covered domain analysis (93KB), domain synthesis (54KB), unified design (87KB), trade-off analysis (39KB), and the Architecture Decision Record (59KB).
+
+**Key Findings:**
+
+- **Pass Rate**: 47/50 criteria passed (94%)
+- **Critical Issues**: 0
+- **Major Issues**: 1 (minor inconsistency in event type naming)
+- **Minor Issues**: 2 (documentation improvements recommended)
+
+**Recommendation**: Proceed to WORK-035 implementation. The artifacts form a cohesive, well-documented foundation for the unified Work Tracker and Knowledge Management system.
+
+---
+
+## 1. Artifact-by-Artifact Validation
+
+### 1.1 Artifact: Domain Analysis (e-001)
+
+**File**: `docs/research/work-034-e-001-domain-analysis.md`
+**Size**: 92,825 bytes (93KB) - Target: 60-80KB (slightly over, acceptable)
+**Status**: **PASS**
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| File exists | PASS | Verified |
+| Metadata section present | PASS | Lines 3-14, all required fields |
+| Executive Summary | PASS | Comprehensive, covers key findings |
+| Work Tracker Domain Analysis | PASS | Sections 1.1-1.6 fully documented |
+| KM Domain Analysis | PASS | Sections 2.1-2.6 fully documented |
+| Synergy Analysis | PASS | Section 3 with shared patterns |
+| Integration Points | PASS | Section 4 with event handlers |
+| Technology Stack Validation | PASS | NetworkX, FAISS, RDFLib assessed |
+| BDD Scenarios | PASS | Included for both domains |
+| Mermaid Diagrams | PASS | Multiple valid diagrams |
+
+**Quality Assessment:**
+
+| Criterion | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Completeness | 9 | Comprehensive coverage of both domains |
+| Technical Accuracy | 9 | Correct Hexagonal Architecture patterns |
+| Clarity | 8 | Well-structured with clear headings |
+| Actionability | 9 | Clear gap analysis and recommendations |
+
+---
+
+### 1.2 Artifact: Domain Synthesis (e-002)
+
+**File**: `docs/synthesis/work-034-e-002-domain-synthesis.md`
+**Size**: 54,270 bytes (54KB) - Target: 30-50KB (within range)
+**Status**: **PASS**
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| File exists | PASS | Verified |
+| Metadata section present | PASS | Lines 3-13, all required fields |
+| Input reference | PASS | References e-001 domain analysis |
+| Unified Domain Model | PASS | Section 1 with bounded contexts |
+| Unified Aggregate Roots | PASS | Section 2 with WorkItem and KnowledgeItem |
+| Unified Entity Model | PASS | Section 3 with complete hierarchy |
+| Unified Event Model | PASS | Section 4 with CloudEvents compliance |
+| Unified Port Model | PASS | Section 5 with all port definitions |
+| Unified Use Case Model | PASS | Section 6 with CQRS operations |
+| Implementation Priority Matrix | PASS | Section 7 with four phases |
+| Mermaid Diagrams | PASS | 7 diagrams as stated |
+| JSON Schemas | PASS | WorkItem, KnowledgeItem, Edge schemas |
+
+**Quality Assessment:**
+
+| Criterion | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Synthesis Quality | 9 | Effectively merges both domains |
+| Traceability | 9 | Clear references to e-001 |
+| Consistency | 8 | Minor naming variations (see issues) |
+| Completeness | 9 | All required sections present |
+
+---
+
+### 1.3 Artifact: Unified Design (e-003)
+
+**File**: `docs/design/work-034-e-003-unified-design.md`
+**Size**: 86,903 bytes (87KB) - Target: 60-80KB (slightly over, acceptable)
+**Status**: **PASS**
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| File exists | PASS | Verified |
+| Metadata section present | PASS | Lines 3-15, all required fields |
+| 5W1H Analysis | PASS | Section 1 with comprehensive breakdown |
+| Bounded Context Diagram | PASS | Section 2 with Mermaid diagram |
+| Package Diagram | PASS | Section 3 with Hexagonal layout |
+| Domain Model - Class Diagrams | PASS | Section 4 with 4 detailed diagrams |
+| Port Definitions | PASS | Section 5 with 6 port interfaces |
+| CQRS Operations Catalog | PASS | Sections 6-7 with commands/queries |
+| Event Catalog | PASS | Section 8 with CloudEvents |
+| BDD Scenarios | PASS | Section 9 with Given/When/Then |
+| Performance Requirements | PASS | Specified P95 latency targets |
+| Technology Stack | PASS | NetworkX, FAISS, RDFLib, SQLite |
+
+**Quality Assessment:**
+
+| Criterion | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Technical Depth | 10 | Exceptional detail in port definitions |
+| Architecture Quality | 9 | Clean Hexagonal Architecture |
+| Implementability | 9 | Clear specifications for developers |
+| Consistency with e-002 | 9 | Properly extends synthesis |
+
+---
+
+### 1.4 Artifact: Trade-off Analysis (e-004)
+
+**File**: `docs/analysis/work-034-e-004-tradeoff-analysis.md`
+**Size**: 38,819 bytes (39KB) - Target: 30-50KB (within range)
+**Status**: **PASS**
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| File exists | PASS | Verified |
+| Metadata section present | PASS | Lines 3-14, all required fields |
+| Evaluation Framework | PASS | Section 1.2 with weighted scoring |
+| Architecture Trade-offs | PASS | Section 2 with 4 major decisions |
+| Technology Trade-offs | PASS | Section 3 with 4 technology choices |
+| Implementation Trade-offs | PASS | Section 4 with 3 strategy decisions |
+| Risk-Benefit Analysis | PASS | Section 5 with quantified risks |
+| Decision Matrix | PASS | Section 6 with 11 decisions |
+| Sensitivity Analysis | PASS | Section 7 with 4 scenarios |
+| Quantified Scores | PASS | All decisions have weighted scores |
+| Open Questions | PASS | Section 9 with 10 questions |
+
+**Quality Assessment:**
+
+| Criterion | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Analytical Rigor | 10 | Exceptional quantified analysis |
+| Decision Rationale | 9 | Clear justification for each choice |
+| Risk Assessment | 9 | Comprehensive risk register |
+| Objectivity | 9 | Balanced consideration of alternatives |
+
+---
+
+### 1.5 Artifact: ADR-034 (e-005)
+
+**File**: `docs/decisions/ADR-034-unified-wt-km-implementation.md`
+**Size**: 58,682 bytes (59KB) - Target: 40-60KB (within range)
+**Status**: **PASS**
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| File exists | PASS | Verified |
+| ADR Format | PASS | Standard ADR sections present |
+| Metadata section present | PASS | Lines 3-15 with PS ID, Entry ID |
+| Context section | PASS | Section 1 with problem statement |
+| Decision section | PASS | Section 2 with architecture choices |
+| Rationale section | PASS | Section 3 with trade-off references |
+| Consequences section | PASS | Section 4 with positive/negative |
+| Implementation Plan | PASS | Section 5 with 4 phases, 32 weeks |
+| Technical Specifications | PASS | Section 6 with domain model summary |
+| Validation Criteria | PASS | Section 7 with acceptance tests |
+| Alternatives Considered | PASS | Section 8 with 6 alternatives |
+| References | PASS | Section 9 with all input documents |
+| Appendices | PASS | A-H with schemas, diagrams, benchmarks |
+
+**Quality Assessment:**
+
+| Criterion | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Completeness | 10 | All ADR sections thoroughly documented |
+| Traceability | 10 | References all 4 input documents |
+| Decision Clarity | 9 | Clear recommendations with scores |
+| Implementation Guidance | 10 | Detailed 32-week plan with deliverables |
+
+---
+
+## 2. Cross-Artifact Consistency Matrix
+
+### 2.1 Domain Model Consistency
+
+| Element | e-001 | e-002 | e-003 | e-004 | ADR | Status |
+|---------|-------|-------|-------|-------|-----|--------|
+| Task Aggregate | Y | Y | Y | - | Y | PASS |
+| Phase Aggregate | Y | Y | Y | - | Y | PASS |
+| Plan Aggregate | Y | Y | Y | - | Y | PASS |
+| KnowledgeItem Aggregate | Y | Y | Y | - | Y | PASS |
+| Pattern Value Object | Y | Y | Y | - | Y | PASS |
+| Lesson Value Object | Y | Y | Y | - | Y | PASS |
+| Assumption Value Object | Y | Y | Y | - | Y | PASS |
+| VertexId Base Class | Y | Y | Y | - | Y | PASS |
+| JerryUri | Y | Y | Y | - | Y | PASS |
+
+### 2.2 Technology Stack Consistency
+
+| Technology | e-001 | e-002 | e-003 | e-004 | ADR | Status |
+|------------|-------|-------|-------|-------|-----|--------|
+| NetworkX 3.2.1 | Y | Y | Y | Y | Y | PASS |
+| FAISS 1.7.4 | Y | Y | Y | Y | Y | PASS |
+| RDFLib 7.0.0 | Y | Y | Y | Y | Y | PASS |
+| SQLite 3.x | Y | Y | Y | Y | Y | PASS |
+| Python 3.11+ | Y | Y | Y | Y | Y | PASS |
+
+### 2.3 Port Definitions Consistency
+
+| Port | e-002 | e-003 | ADR | Status |
+|------|-------|-------|-----|--------|
+| IWorkItemRepository | Y | Y | Y | PASS |
+| IKnowledgeRepository | Y | Y | Y | PASS |
+| IGraphStore | Y | Y | Y | PASS |
+| ISemanticIndex | Y | Y | Y | PASS |
+| IEventStore | Y | Y | Y | PASS |
+| IRDFSerializer | Y | Y | Y | PASS |
+| IEventDispatcher | Y | Y | Y | PASS |
+| IUnitOfWork | Y | Y | - | PASS (optional in ADR) |
+
+### 2.4 Event Types Consistency
+
+| Event | e-001 | e-002 | e-003 | ADR | Status |
+|-------|-------|-------|-------|-----|--------|
+| TaskCreated | Y | Y | Y | Y | PASS |
+| TaskCompleted | Y | Y | Y | Y | PASS |
+| TaskStarted | Y | Y | Y | Y | PASS |
+| TaskBlocked | Y | Y | Y | Y | PASS |
+| KnowledgeItemCreated | Y | Y | Y | Y | PASS |
+| KnowledgeItemValidated | Y | Y | Y | Y | PASS |
+| KnowledgeItemDeprecated | Y | Y | Y | Y | PASS |
+| LessonMaterialized | - | Y | Y | Y | PASS |
+| PatternDiscovered | - | Y | Y | Y | PASS |
+
+### 2.5 Phase Timeline Consistency
+
+| Phase | e-002 | e-003 | ADR | Status |
+|-------|-------|-------|-----|--------|
+| Phase 1: Foundation | Weeks 1-8 | Weeks 1-8 | Weeks 1-8 | PASS |
+| Phase 2: Infrastructure | Weeks 9-16 | Weeks 9-16 | Weeks 9-16 | PASS |
+| Phase 3: KM Integration | Weeks 17-24 | Weeks 17-24 | Weeks 17-24 | PASS |
+| Phase 4: Advanced Features | Weeks 25-32 | Weeks 25-32 | Weeks 25-32 | PASS |
+| Total Duration | 32 weeks | 32 weeks | 32 weeks | PASS |
+
+---
+
+## 3. Quality Checks
+
+### 3.1 Mermaid Diagram Validation
+
+| Artifact | Diagrams | Validated | Status |
+|----------|----------|-----------|--------|
+| e-001 | 5+ | 5 | PASS |
+| e-002 | 7 | 7 | PASS |
+| e-003 | 8+ | 8 | PASS |
+| e-004 | 3 | 3 | PASS |
+| ADR-034 | 3+ | 3 | PASS |
+
+All Mermaid diagrams use valid syntax and render correctly.
+
+### 3.2 JSON Schema Validation
+
+| Schema | Location | Valid JSON | Status |
+|--------|----------|------------|--------|
+| WorkItem JSON Schema | e-002 Appendix A.1 | PASS | PASS |
+| KnowledgeItem JSON Schema | e-002 Appendix A.2 | PASS | PASS |
+| Edge JSON Schema | e-002 Appendix A.3 | PASS | PASS |
+| Domain Event Schema | e-001 Section 1.4.2 | PASS | PASS |
+| CloudEvents Schema | e-002 Section 4.2 | PASS | PASS |
+
+### 3.3 BDD Scenario Validation
+
+| Domain | e-001 | e-003 | ADR | Format Valid | Status |
+|--------|-------|-------|-----|--------------|--------|
+| Work Tracker | Y | Y | Y | PASS | PASS |
+| Knowledge Management | Y | Y | Y | PASS | PASS |
+| Cross-Domain | - | Y | Y | PASS | PASS |
+
+All BDD scenarios follow Given/When/Then format correctly.
+
+### 3.4 Architecture Compliance
+
+| Principle | e-001 | e-002 | e-003 | ADR | Status |
+|-----------|-------|-------|-------|-----|--------|
+| Hexagonal Architecture | Y | Y | Y | Y | PASS |
+| Zero-dependency domain | Y | Y | Y | Y | PASS |
+| CQRS pattern | Y | Y | Y | Y | PASS |
+| CloudEvents 1.0 | Y | Y | Y | Y | PASS |
+| Python 3.11+ type hints | Y | Y | Y | Y | PASS |
+
+### 3.5 Traceability Checks
+
+| Artifact | References Input Documents | Status |
+|----------|---------------------------|--------|
+| e-002 (Synthesis) | e-001 Domain Analysis | PASS |
+| e-003 (Design) | e-001, e-002 | PASS |
+| e-004 (Trade-off) | e-001, e-002, e-003 | PASS |
+| ADR-034 | e-001, e-002, e-003, e-004 | PASS |
+
+---
+
+## 4. Issues Found
+
+### 4.1 Major Issues
+
+| ID | Severity | Location | Description | Recommendation |
+|----|----------|----------|-------------|----------------|
+| I-001 | Major | e-001 vs e-002 | Minor inconsistency in CloudEvents type naming: e-001 uses `WorkItemCreated` while e-002 uses `jer:jer:knowledge:facts/KnowledgeItemCreated` for KM events but simple names for WT events | Standardize event naming convention in implementation; recommend using simple names for all events |
+
+### 4.2 Minor Issues
+
+| ID | Severity | Location | Description | Recommendation |
+|----|----------|----------|-------------|----------------|
+| I-002 | Minor | e-001 | File size (93KB) exceeds 60-80KB target | Acceptable given comprehensive coverage; no action needed |
+| I-003 | Minor | e-003 | File size (87KB) exceeds 60-80KB target | Acceptable given detailed port definitions; no action needed |
+
+---
+
+## 5. Recommendations
+
+### 5.1 For Implementation (WORK-035)
+
+1. **Event Naming Convention**: Adopt consistent CloudEvents type naming:
+   - Work Tracker: `work-tracker/{EventName}` (e.g., `work-tracker/TaskCompleted`)
+   - Knowledge Management: `knowledge/{EventName}` (e.g., `knowledge/LessonCreated`)
+   - This aligns with ADR-034 Section 6.4 which uses this pattern
+
+2. **Start with Phase 1 Foundation**: Begin with Week 1-2 deliverables as specified:
+   - `src/domain/aggregates/task.py`
+   - `src/domain/value_objects/ids.py`
+   - `src/domain/value_objects/status.py`
+
+3. **Create Implementation Work Items**: Extract from ADR-034 Section 5 the detailed week-by-week deliverables
+
+### 5.2 For Documentation
+
+1. Consider extracting the SQLite schema appendices (ADR-034 Appendix D) into separate schema files when implementing
+
+2. The Performance Benchmarks appendix (ADR-034 Appendix G) provides excellent test targets; incorporate into CI/CD
+
+### 5.3 For Future Validation
+
+1. Create automated schema validation as part of CI pipeline
+2. Add Mermaid diagram linting to prevent syntax errors
+
+---
+
+## 6. Final Verdict
+
+```
+=======================================================================
+                        VALIDATION VERDICT
+=======================================================================
+
+    STATUS:        APPROVED
+
+    PASS RATE:     47/50 (94%)
+
+    CRITICAL ISSUES:  0
+    MAJOR ISSUES:     1 (non-blocking)
+    MINOR ISSUES:     2 (informational)
+
+    RECOMMENDATION:  Proceed to WORK-035 implementation
+
+    The WORK-034 artifacts form a comprehensive, consistent, and
+    technically sound foundation for the unified Work Tracker and
+    Knowledge Management system. All five artifacts meet quality
+    standards and provide sufficient detail for implementation.
+
+=======================================================================
+```
+
+**Signed**: ps-validator v2.0.0
+**Date**: 2026-01-09
+
+---
+
+## Appendix A: Validation Checklist Summary
+
+### A.1 Completeness Checks
+
+| Check | e-001 | e-002 | e-003 | e-004 | ADR |
+|-------|-------|-------|-------|-------|-----|
+| File exists | PASS | PASS | PASS | PASS | PASS |
+| Metadata section | PASS | PASS | PASS | PASS | PASS |
+| Required sections | PASS | PASS | PASS | PASS | PASS |
+| Size within range | WARN | PASS | WARN | PASS | PASS |
+
+### A.2 Consistency Checks
+
+| Check | Status |
+|-------|--------|
+| Domain model consistent | PASS |
+| Technology stack consistent | PASS |
+| Port definitions match | PASS |
+| Event types consistent | PASS (minor naming variance) |
+| Phase timelines consistent | PASS |
+
+### A.3 Quality Checks
+
+| Check | Status |
+|-------|--------|
+| Mermaid diagrams valid | PASS |
+| JSON schemas valid | PASS |
+| BDD scenarios formatted | PASS |
+| Decision rationale documented | PASS |
+| All decisions have scores | PASS |
+
+### A.4 Traceability Checks
+
+| Check | Status |
+|-------|--------|
+| ADR references all inputs | PASS |
+| Trade-off references design | PASS |
+| Design references synthesis | PASS |
+| Synthesis references analysis | PASS |
+
+### A.5 Technical Accuracy Checks
+
+| Check | Status |
+|-------|--------|
+| Hexagonal Architecture followed | PASS |
+| CQRS pattern correct | PASS |
+| CloudEvents 1.0 compliant | PASS |
+| Python 3.11+ type hints | PASS |
+| Domain layer zero dependencies | PASS |
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|-------|-------|
+| **File** | `docs/validation/work-034-e-006-validation-report.md` |
+| **Created** | 2026-01-09 |
+| **Author** | ps-validator v2.0.0 |
+| **Word Count** | ~3,200 words |
+| **Tables** | 30+ |
+| **Status** | COMPLETE |
+
+**Constitution Compliance:**
+- P-001 (Truth and Accuracy): Objective validation with specific evidence
+- P-002 (File Persistence): Report persisted to markdown file
+- P-004 (Reasoning Transparency): Clear pass/fail criteria documented
+- P-010 (Task Tracking): Supports WORK-034 final step
+- P-022 (No Deception): Transparent about minor issues found
+
+**Next Steps:**
+1. Address I-001 event naming convention during implementation
+2. Create WORK-035 implementation tasks from ADR-034 deliverables
+3. Begin Phase 1 foundation work (Weeks 1-8)

--- a/docs/archive/work-026-e-001-jerry-skill-patterns.md
+++ b/docs/archive/work-026-e-001-jerry-skill-patterns.md
@@ -1,0 +1,1375 @@
+# Jerry Skill Pattern Research
+
+> **PS ID:** work-026
+> **Entry ID:** e-001
+> **Topic:** Jerry Skill Architecture Patterns
+> **Date:** 2026-01-30
+> **Researcher:** ps-researcher v2.2.0
+
+---
+
+## L0: Executive Summary (ELI5)
+
+Jerry skills are like specialized teams with well-defined roles and workflows. Each skill (like problem-solving, NASA SE, and orchestration) is a collection of expert agents who work together following proven patterns. The architecture uses three key principles:
+
+1. **Clear Identity** - Every skill and agent knows exactly what they do, like job descriptions
+2. **Structured Workflows** - Step-by-step playbooks and templates ensure consistency
+3. **Constitutional Compliance** - Built-in rules prevent common mistakes (like agents spawning other agents recursively)
+
+Think of it like a professional kitchen: each skill is a station (pastry, grill, salad), each agent is a chef with expertise, and the playbooks are standardized recipes. The SKILL.md is the menu board showing what's available, and templates are the recipe cards ensuring consistent output.
+
+**Key Finding:** All three skills follow the same architectural patterns, making it easy to create new skills by following established conventions.
+
+---
+
+## L1: Technical Analysis (Software Engineer)
+
+### 1. Skill Structure Patterns
+
+#### 1.1 SKILL.md Organization
+
+All three skills follow an identical YAML frontmatter + Markdown content structure:
+
+**Universal YAML Frontmatter Schema:**
+
+```yaml
+---
+name: "{skill-name}"
+description: "{one-line purpose + key capabilities + activation context}"
+version: "X.Y.Z"
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch, WebFetch]
+activation-keywords:
+  - "{keyword-1}"
+  - "{keyword-2}"
+  - "{keyword-N}"
+---
+```
+
+| Skill | Name | Version | Keyword Count |
+|-------|------|---------|---------------|
+| problem-solving | `problem-solving` | 2.1.0 | 16 |
+| nasa-se | `nasa-se` | 1.1.0 | 31 |
+| orchestration | `orchestration` | 2.1.0 | 10 |
+
+**Common Markdown Sections (All Skills):**
+
+| Section | Purpose | Present In |
+|---------|---------|------------|
+| **Document Audience (Triple-Lens)** | L0/L1/L2 reading guide | ✅ All 3 |
+| **Purpose** | Skill mission and capabilities | ✅ All 3 |
+| **When to Use This Skill** | Activation criteria | ✅ All 3 |
+| **Available Agents** | Agent registry table | ✅ All 3 |
+| **Invoking an Agent** | 3 invocation methods | ✅ All 3 |
+| **Orchestration Flow** | Multi-agent coordination | ✅ All 3 |
+| **State Passing Between Agents** | State key registry | ✅ All 3 |
+| **Tool Invocation Examples** | Concrete tool usage | ✅ All 3 |
+| **Mandatory Persistence (P-002)** | File output requirement | ✅ All 3 |
+| **Constitutional Compliance** | Jerry Constitution mapping | ✅ All 3 |
+| **Quick Reference** | Common workflows table | ✅ All 3 |
+| **Agent Details** | Links to agent specs | ✅ All 3 |
+
+**Skill-Specific Sections:**
+
+- **nasa-se:** Disclaimer, NASA Common Technical Processes table, NASA Standards References
+- **orchestration:** Workflow Configuration (workflow IDs, pipeline aliases, dynamic paths)
+
+#### 1.2 Agent Registry Pattern
+
+All skills use a standardized agent registry table:
+
+```markdown
+| Agent | Role | Output Location |
+|-------|------|-----------------|
+| {agent-id} | {role-description} | {output-path} |
+```
+
+**Examples:**
+
+**problem-solving:**
+```markdown
+| Agent | Role | Output Location |
+|-------|------|-----------------|
+| `ps-researcher` | Research Specialist - Gathers information with citations | `docs/research/` |
+| `ps-critic` | Quality Evaluator - Iterative refinement with quality scores | `docs/critiques/` |
+```
+
+**nasa-se:**
+```markdown
+| Agent | Role | NASA Processes | Output Location |
+|-------|------|----------------|-----------------|
+| `nse-requirements` | Requirements Engineer | 1, 2, 11 | `requirements/` |
+| `nse-explorer` | Exploration Engineer (Divergent) | 5, 17 | `exploration/` |
+```
+
+**orchestration:**
+```markdown
+| Agent | Role | Output |
+|-------|------|--------|
+| `orch-planner` | Creates orchestration plan with workflow diagram | `ORCHESTRATION_PLAN.md` |
+| `orch-tracker` | Updates execution state after agent completion | `ORCHESTRATION.yaml`, `ORCHESTRATION_WORKTRACKER.md` |
+```
+
+**Pattern:** Agent IDs use `{skill-prefix}-{specialty}` format (e.g., `ps-researcher`, `nse-requirements`, `orch-planner`).
+
+---
+
+### 2. Agent Definition Patterns
+
+#### 2.1 YAML Frontmatter Structure
+
+**Universal Agent Metadata Schema:**
+
+```yaml
+---
+name: "{agent-id}"
+version: "X.Y.Z"
+description: "{purpose + key features + integration}"
+model: opus | sonnet | haiku  # Model selection based on complexity
+
+# Identity Section (Anthropic best practice)
+identity:
+  role: "{Role Title}"
+  expertise:
+    - "{expertise-1}"
+    - "{expertise-N}"
+  cognitive_mode: "divergent | convergent"
+
+# Persona Section (OpenAI GPT-4.1 guide)
+persona:
+  tone: "{tone}"
+  communication_style: "{style}"
+  audience_level: "adaptive"
+
+# Capabilities Section
+capabilities:
+  allowed_tools: [...]
+  output_formats: [markdown, yaml]
+  forbidden_actions:
+    - "Spawn recursive subagents (P-003)"
+    - "Override user decisions (P-020)"
+    - "Return transient output only (P-002)"
+
+# Guardrails Section (KnowBe4 layered security)
+guardrails:
+  input_validation: {...}
+  output_filtering: {...}
+  fallback_behavior: warn_and_retry
+
+# Output Section
+output:
+  required: true
+  location: "{path-template}"
+  template: "{template-file}"
+  levels: [L0, L1, L2]
+
+# Validation Section
+validation:
+  file_must_exist: true
+  post_completion_checks: [...]
+
+# Constitutional Compliance
+constitution:
+  reference: "docs/governance/JERRY_CONSTITUTION.md"
+  principles_applied: [...]
+
+# Enforcement Tier
+enforcement:
+  tier: "soft | medium | hard"
+  escalation_path: "{escalation-description}"
+
+# Session Context (Agent Handoff) - WI-SAO-002
+session_context:
+  schema: "docs/schemas/session_context.json"
+  schema_version: "1.0.0"
+  input_validation: true
+  output_validation: true
+  on_receive: [...]
+  on_send: [...]
+---
+```
+
+**Observed Variations by Skill:**
+
+| Section | problem-solving | nasa-se | orchestration |
+|---------|----------------|---------|---------------|
+| `identity.nasa_processes` | ❌ | ✅ | ❌ |
+| `identity.belbin_role` | ps-critic only | ❌ | ❌ |
+| `guardrails.requirements_count` | ❌ | nse-requirements | ❌ |
+| `guardrails.dependency_validation` | ❌ | nse-requirements | ❌ |
+| `nasa_standards` | ❌ | ✅ All agents | ❌ |
+| `prior_art` | ✅ All agents | ✅ All agents | ✅ All agents |
+| `orchestration_guidance` | ps-critic only | ❌ | ✅ All agents |
+
+#### 2.2 Agent Identity Specifications
+
+**Common Identity Fields:**
+
+```yaml
+identity:
+  role: "{Role Title}"              # Required - agent's job title
+  expertise: [...]                  # Required - domain specializations
+  cognitive_mode: "divergent | convergent"  # Required - thinking style
+```
+
+**Cognitive Modes:**
+
+| Mode | Agents | Characteristics |
+|------|--------|-----------------|
+| **Divergent** | ps-researcher, nse-explorer | Explore broadly, generate options, discover patterns |
+| **Convergent** | ps-critic, ps-analyst, nse-requirements | Narrow down, evaluate, decide |
+| **Mixed** | orchestration agents | Context-dependent mode switching |
+
+**Example: ps-researcher Identity:**
+
+```yaml
+identity:
+  role: "Research Specialist"
+  expertise:
+    - "Literature review and synthesis"
+    - "Web research and source validation"
+    - "Library/framework documentation (via Context7)"
+    - "Industry best practices analysis"
+  cognitive_mode: "divergent"
+```
+
+**Example: nse-requirements Identity:**
+
+```yaml
+identity:
+  role: "Requirements Engineer"
+  expertise:
+    - "Stakeholder needs elicitation and analysis"
+    - "Technical requirements definition (shall statements)"
+    - "Bidirectional traceability management"
+  cognitive_mode: "convergent"
+  nasa_processes:
+    - "Process 1: Stakeholder Expectations Definition"
+    - "Process 2: Technical Requirements Definition"
+    - "Process 11: Requirements Management"
+```
+
+#### 2.3 Persona Specifications
+
+**Universal Persona Pattern:**
+
+```yaml
+persona:
+  tone: "professional | analytical | consultative"
+  communication_style: "direct | constructive | consultative"
+  audience_level: "adaptive"  # All agents use adaptive L0/L1/L2
+```
+
+**L0/L1/L2 Output Requirement:**
+
+All agents MUST produce output at three levels:
+
+```markdown
+### L0: Executive Summary (ELI5)
+*2-3 paragraphs accessible to non-technical stakeholders.*
+
+### L1: Technical Analysis (Software Engineer)
+*Implementation-focused content with specifics.*
+
+### L2: Architectural Implications (Principal Architect)
+*Strategic perspective with trade-offs.*
+```
+
+**Example from ps-researcher.md:**
+
+```xml
+<persona>
+**Tone:** Professional and thorough - You write with authority backed by evidence.
+
+**Communication Style:** Consultative - You present findings with context and explain significance, not just raw data.
+
+**Audience Adaptation:** You MUST produce output at three levels:
+
+- **L0 (ELI5):** Accessible executive summary. Use analogies. Answer "What does this mean for the project?"
+- **L1 (Software Engineer):** Technical findings with code examples, configuration snippets, and implementation guidance.
+- **L2 (Principal Architect):** Strategic implications, trade-offs, risks, and alignment with existing architecture.
+</persona>
+```
+
+#### 2.4 Capabilities and Guardrails
+
+**Allowed Tools Pattern:**
+
+All agents specify allowed tools with usage patterns:
+
+```yaml
+capabilities:
+  allowed_tools:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash
+    - Task
+    - WebSearch
+    - WebFetch
+    # Skill-specific tools
+    - mcp__context7__resolve-library-id  # ps-researcher only
+    - mcp__context7__query-docs          # ps-researcher only
+```
+
+**Forbidden Actions (Constitutional Compliance):**
+
+Standard forbidden actions across all agents:
+
+```yaml
+capabilities:
+  forbidden_actions:
+    - "Spawn recursive subagents (P-003)"
+    - "Override user decisions (P-020)"
+    - "Return transient output only (P-002)"
+    - "Make claims without citations (P-001, P-011)"  # ps/nse-specific
+    - "Omit mandatory disclaimer (P-043)"             # nse-specific
+```
+
+**Guardrails Pattern:**
+
+```yaml
+guardrails:
+  input_validation:
+    ps_id_format: "^[a-z]+-\\d+(\\.\\d+)?$"
+    entry_id_format: "^e-\\d+$"
+  output_filtering:
+    - no_secrets_in_output
+    - all_claims_must_have_citations
+  fallback_behavior: warn_and_retry
+```
+
+**Advanced Guardrails (nse-requirements):**
+
+```yaml
+guardrails:
+  requirements_count:
+    minimum: 1
+    on_empty:
+      action: reject
+      message: "At least 1 requirement is required..."
+      guidance: [...]
+    maximum_recommended: 100
+    on_exceed:
+      action: warn
+      allow_override: true
+  dependency_validation:
+    circular_dependency_check: true
+    algorithm: "DFS with visited tracking"
+```
+
+#### 2.5 Constitutional Compliance
+
+**Standard Constitutional Compliance Table:**
+
+All agents include a self-critique checklist:
+
+```markdown
+| Principle | Enforcement | Agent Behavior |
+|-----------|-------------|----------------|
+| P-001 (Truth/Accuracy) | Soft | All claims cite sources; uncertainty acknowledged |
+| P-002 (File Persistence) | **Medium** | ALL outputs persisted to files |
+| P-003 (No Recursion) | **Hard** | Task tool spawns single-level agents only |
+| P-004 (Provenance) | Soft | Full citation trail for all findings |
+| P-011 (Evidence-Based) | Soft | Recommendations tied to evidence |
+| P-022 (No Deception) | **Hard** | Transparent about limitations |
+
+**Self-Critique Checklist (Before Response):**
+- [ ] P-001: Are all claims sourced with citations?
+- [ ] P-002: Is output persisted to file?
+- [ ] P-004: Is the methodology documented?
+- [ ] P-011: Are recommendations evidence-based?
+- [ ] P-022: Am I transparent about limitations?
+```
+
+**Skill-Specific Principles:**
+
+- **nasa-se:** P-040 (Traceability), P-041 (V&V Coverage), P-042 (Risk Transparency), P-043 (Disclaimer)
+- **orchestration:** P-010 (Task Tracking)
+
+---
+
+### 3. Orchestration Patterns
+
+#### 3.1 State Passing Mechanisms
+
+**State Key Registry Pattern:**
+
+All skills maintain a state key registry table:
+
+```markdown
+| Agent | Output Key | Provides |
+|-------|------------|----------|
+| {agent-id} | `{agent-id}_output` | {output-summary} |
+```
+
+**problem-solving State Keys:**
+
+| Agent | Output Key | Provides |
+|-------|------------|----------|
+| ps-researcher | `researcher_output` | Research findings, sources |
+| ps-analyst | `analyst_output` | Root cause, recommendations |
+| ps-architect | `architect_output` | Decision, alternatives |
+| ps-critic | `critic_output` | Quality score, improvement areas |
+
+**nasa-se State Keys:**
+
+| Agent | Output Key | Provides |
+|-------|------------|----------|
+| nse-requirements | `requirements_output` | Requirements baseline, traceability |
+| nse-verification | `verification_output` | V&V status, VCRM |
+| nse-risk | `risk_output` | Risk register, mitigation status |
+
+**orchestration State Keys:**
+
+Orchestration uses a different pattern - state is tracked in `ORCHESTRATION.yaml` (SSOT):
+
+```yaml
+workflow:
+  id: "{workflow-id}"
+  status: ACTIVE | PAUSED | COMPLETE | FAILED
+
+pipelines:
+  {pipeline-id}:
+    current_phase: number
+    phases:
+      - agents:
+          - id: "{agent-id}"
+            status: PENDING | IN_PROGRESS | COMPLETE | FAILED
+            artifact: "{path-to-output}"
+```
+
+#### 3.2 Agent Handoff Management
+
+**Session Context Schema (WI-SAO-002):**
+
+All agents validate handoffs using `docs/schemas/session_context.json`:
+
+```yaml
+session_context:
+  schema_version: "1.0.0"
+  session_id: "{uuid}"
+  source_agent:
+    id: "{agent-id}"
+    family: "ps | nse | orch"
+    cognitive_mode: "divergent | convergent"
+    model: "opus | sonnet | haiku"
+  target_agent:
+    id: "{target-agent-id}"
+  payload:
+    key_findings: [...]
+    open_questions: [...]
+    blockers: []
+    confidence: 0.0-1.0
+    artifacts:
+      - path: "{artifact-path}"
+        type: "{artifact-type}"
+        summary: "{one-line-summary}"
+  timestamp: "{ISO-8601}"
+```
+
+**On Receive (Input Validation):**
+
+1. Check `schema_version` matches "1.0.0"
+2. Verify `target_agent.id` matches this agent
+3. Extract `payload.key_findings` for context
+4. Check `payload.blockers` - address before proceeding
+5. Use `payload.artifacts` paths as inputs
+
+**On Send (Output Validation):**
+
+1. Populate `key_findings` from work results
+2. Calculate `confidence` based on source quality
+3. List all `artifacts` with paths
+4. Set `timestamp` to current time
+
+#### 3.3 Sequential Chain Example
+
+**Pattern:** Agent A → Agent B → Agent C (order-dependent)
+
+From problem-solving SKILL.md:
+
+```markdown
+User Request: "I need to understand why our tests are slow and fix it"
+
+1. ps-researcher → Gather data on test execution patterns
+   Output: docs/research/work-024-e-001-test-performance.md
+
+2. ps-analyst → Apply 5 Whys to identify root cause
+   Output: docs/analysis/work-024-e-002-root-cause.md
+
+3. ps-architect → Create ADR for proposed solution
+   Output: docs/decisions/work-024-e-003-adr-test-optimization.md
+
+4. ps-validator → Verify solution meets constraints
+   Output: docs/analysis/work-024-e-004-validation.md
+```
+
+#### 3.4 Cross-Pollinated Pipeline Example
+
+**Pattern:** Two parallel pipelines with sync barriers
+
+From orchestration SKILL.md:
+
+```markdown
+Pipeline A                    Pipeline B
+    │                              │
+    ▼                              ▼
+┌─────────┐                  ┌─────────┐
+│ Phase 1 │                  │ Phase 1 │
+└────┬────┘                  └────┬────┘
+     │                            │
+     └──────────┬─────────────────┘
+                ▼
+        ╔═══════════════╗
+        ║   BARRIER 1   ║  ← Cross-pollination
+        ╚═══════════════╝
+                │
+     ┌──────────┴─────────────────┐
+     │                            │
+     ▼                            ▼
+┌─────────┐                  ┌─────────┐
+│ Phase 2 │                  │ Phase 2 │
+└─────────┘                  └─────────┘
+```
+
+**Barrier Artifact Format:**
+
+```markdown
+# Barrier N: {Direction} Cross-Pollination
+
+> **Source Pipeline:** {pipeline}
+> **Target Pipeline:** {pipeline}
+> **Phase Transition:** {from_phase} -> {to_phase}
+
+## Key Findings
+{extracted findings}
+
+## For Target Pipeline
+{how to use these findings}
+```
+
+#### 3.5 Generator-Critic Loop Example
+
+**Pattern:** Iterative refinement with quality threshold
+
+From ps-critic.md:
+
+```markdown
+Iteration 1:
+  1. Generator (ps-architect) produces design.md
+  2. Orchestrator invokes ps-critic with design.md
+  3. ps-critic returns: score=0.65, threshold_met=false
+  4. Orchestrator: 0.65 < 0.85, iteration=1 < 3 → REVISE
+  5. Orchestrator sends critique to ps-architect
+
+Iteration 2:
+  1. Generator (ps-architect) produces design-v2.md
+  2. Orchestrator invokes ps-critic with design-v2.md
+  3. ps-critic returns: score=0.78, threshold_met=false
+  4. Orchestrator: improvement = 0.78-0.65 = 0.13 > 0.10 → REVISE
+
+Iteration 3:
+  1. Generator (ps-architect) produces design-v3.md
+  2. Orchestrator invokes ps-critic with design-v3.md
+  3. ps-critic returns: score=0.88, threshold_met=true
+  4. Orchestrator: 0.88 >= 0.85 → ACCEPT
+```
+
+**Circuit Breaker Parameters:**
+
+```yaml
+circuit_breaker:
+  max_iterations: 3
+  improvement_threshold: 0.10  # 10% improvement required
+  acceptance_threshold: 0.85   # Score to accept without revision
+  consecutive_no_improvement_limit: 2
+```
+
+---
+
+### 4. Documentation Patterns
+
+#### 4.1 docs/ Structure
+
+**problem-solving:**
+```
+skills/problem-solving/
+└── docs/
+    └── ORCHESTRATION.md
+```
+
+**nasa-se:**
+```
+skills/nasa-se/
+└── docs/
+    ├── NASA-SE-MAPPING.md
+    └── ORCHESTRATION.md
+```
+
+**orchestration:**
+```
+skills/orchestration/
+└── docs/
+    ├── PATTERNS.md
+    └── STATE_SCHEMA.md
+```
+
+**Pattern:** Each skill has a `docs/` directory for supplementary documentation beyond SKILL.md and PLAYBOOK.md.
+
+#### 4.2 PLAYBOOK.md Pattern
+
+**Observed in:** orchestration skill only (v3.1.0)
+
+**Universal YAML Frontmatter:**
+
+```yaml
+---
+name: "{skill}-playbook"
+description: "{step-by-step guidance summary}"
+version: "X.Y.Z"
+skill: "{skill-name}"
+template: PLAYBOOK_TEMPLATE.md v1.0.0
+constitutional_compliance: Jerry Constitution v1.0
+patterns_covered: [...]
+agents_covered: [...]
+---
+```
+
+**Triple-Lens Structure:**
+
+```markdown
+# L0: The Big Picture (ELI5)
+> Metaphors, analogies, decision guides
+
+# L1: How To Use It (Engineer)
+> Executable instructions, commands, file paths
+
+# L2: Architecture & Constraints
+> Anti-patterns, boundaries, invariants, design rationale
+```
+
+**Key Sections:**
+
+1. **Document Overview** - Triple-lens cognitive framework diagram
+2. **L0 Sections:**
+   - What Is Orchestration? (Conductor Metaphor)
+   - Why Does This Matter?
+   - When Do I Use This?
+   - The Cast of Characters (Agent Families)
+3. **L1 Sections:**
+   - Quick Start
+   - Orchestration Patterns
+   - Invocation Methods
+   - Workflow: Cross-Pollinated Pipeline
+   - Agent Reference
+   - Output Locations
+   - Common Scenarios
+   - Tips and Best Practices
+   - Troubleshooting
+4. **L2 Sections:**
+   - Anti-Pattern Catalog
+   - Constraints & Boundaries
+   - Invariants
+   - State Management
+   - Cross-Skill Integration
+   - Design Rationale
+   - Templates Reference
+   - References
+   - Quick Reference Card
+
+**Anti-Pattern Catalog Format:**
+
+```markdown
+### AP-001: Recursive Subagent Spawning
+
++===================================================================+
+| ANTI-PATTERN: Recursive Subagent Spawning                         |
++===================================================================+
+| SYMPTOM:    {what-you-observe}                                    |
+| CAUSE:      {root-cause}                                          |
+| IMPACT:     {consequences}                                        |
+| FIX:        {solution}                                            |
++===================================================================+
+```
+
+#### 4.3 RUNBOOK.md Pattern
+
+**Status:** No RUNBOOK.md files found in any of the three skills.
+
+**Hypothesis:** PLAYBOOK.md serves the combined purpose of both playbook (strategic) and runbook (tactical).
+
+#### 4.4 Template Patterns
+
+**problem-solving Templates:**
+```
+skills/problem-solving/templates/
+└── critique.md
+```
+
+**nasa-se Templates:**
+```
+skills/nasa-se/templates/
+├── alternative-analysis.md
+├── concept-exploration.md
+├── qa-report.md
+├── review-checklists.md
+└── trade-study.md
+```
+
+**orchestration Templates:**
+```
+skills/orchestration/templates/
+├── ORCHESTRATION.template.yaml
+├── ORCHESTRATION_PLAN.template.md
+└── ORCHESTRATION_WORKTRACKER.template.md
+```
+
+**Pattern:** Each skill provides templates for its specific artifact types. NASA SE has the most templates (5), reflecting diverse SE work products.
+
+---
+
+### 5. Quality & Validation Patterns
+
+#### 5.1 Validation Section in Agent Frontmatter
+
+**Universal Validation Schema:**
+
+```yaml
+validation:
+  file_must_exist: true
+  post_completion_checks:
+    - verify_file_created
+    - verify_l0_l1_l2_present
+    - verify_citations_present  # ps/nse-specific
+```
+
+**Skill-Specific Validations:**
+
+**ps-critic:**
+```yaml
+validation:
+  post_completion_checks:
+    - verify_file_created
+    - verify_artifact_linked
+    - verify_l0_l1_l2_present
+    - verify_quality_score_present
+    - verify_improvement_recommendations
+```
+
+**nse-requirements:**
+```yaml
+validation:
+  file_must_exist: true
+  disclaimer_required: true  # NASA-specific
+  post_completion_checks:
+    - verify_file_created
+    - verify_disclaimer_present
+    - verify_l0_l1_l2_present
+    - verify_requirements_have_rationale
+    - verify_traceability_documented
+```
+
+#### 5.2 Quality Mechanisms
+
+**ps-critic Quality Evaluation Framework:**
+
+```yaml
+evaluation_criteria:
+  - name: "Completeness"
+    weight: 0.25
+  - name: "Accuracy"
+    weight: 0.25
+  - name: "Clarity"
+    weight: 0.20
+  - name: "Actionability"
+    weight: 0.15
+  - name: "Alignment"
+    weight: 0.15
+```
+
+**Quality Score Calculation:**
+
+```
+quality_score = Σ(criterion_score × criterion_weight)
+```
+
+**Threshold Interpretation:**
+
+| Score Range | Assessment | Recommendation |
+|-------------|------------|----------------|
+| 0.85 - 1.00 | EXCELLENT | Accept output |
+| 0.70 - 0.84 | GOOD | Accept or minor revision |
+| 0.50 - 0.69 | ACCEPTABLE | Revision recommended |
+| 0.30 - 0.49 | NEEDS_WORK | Revision required |
+| 0.00 - 0.29 | POOR | Major revision required |
+
+**nse-requirements Quality Criteria:**
+
+```markdown
+### Requirements Quality Checklist
+
+- [ ] Complete: All necessary requirements defined
+- [ ] Consistent: No conflicting requirements
+- [ ] Verifiable: Each requirement can be verified
+- [ ] Traceable: Each requirement traced to parent need
+- [ ] Unambiguous: Single interpretation possible
+- [ ] Necessary: Each requirement serves a purpose
+```
+
+#### 5.3 Constitutional Compliance Enforcement
+
+**Enforcement Tier Levels:**
+
+| Tier | Behavior | Example |
+|------|----------|---------|
+| **Soft** | Warn user | P-001 (Truth/Accuracy), P-004 (Provenance) |
+| **Medium** | Block completion | P-002 (File Persistence), P-040 (Traceability) |
+| **Hard** | Reject operation | P-003 (No Recursion), P-022 (No Deception), P-043 (Disclaimer) |
+
+**Example Enforcement (nse-requirements):**
+
+```yaml
+enforcement:
+  tier: "medium"
+  escalation_path: "Warn on missing traces → Block completion without artifact"
+```
+
+---
+
+## L2: Strategic Implications (Principal Architect)
+
+### 1. Cross-Skill Architectural Patterns
+
+#### 1.1 Universal Skill Architecture
+
+**Discovered Pattern:** All three skills share a common architectural blueprint:
+
+```
+{SKILL}/
+├── SKILL.md                    # Interface Definition (SSOT)
+│   ├── YAML Frontmatter        # Metadata
+│   ├── Triple-Lens Audience    # L0/L1/L2 reading guide
+│   ├── Purpose                 # Mission statement
+│   ├── Available Agents        # Agent registry
+│   ├── Invocation Methods      # 3 ways to invoke
+│   ├── Orchestration Flow      # Multi-agent coordination
+│   ├── State Passing           # State key registry
+│   ├── Tool Examples           # Concrete usage
+│   ├── Constitutional          # Jerry Constitution mapping
+│   └── Quick Reference         # Command cheat sheet
+│
+├── PLAYBOOK.md                 # Implementation Guide (Triple-Lens)
+│   ├── L0: Big Picture         # Metaphors, analogies
+│   ├── L1: How To              # Executable instructions
+│   └── L2: Architecture        # Constraints, anti-patterns
+│
+├── agents/                     # Agent Definitions
+│   ├── {prefix}-agent1.md      # XML + Markdown hybrid
+│   │   ├── YAML Frontmatter    # Metadata
+│   │   ├── <agent> XML         # Structured specification
+│   │   └── Markdown Body       # Human-readable docs
+│   └── {prefix}-agentN.md
+│
+├── templates/                  # Output Templates
+│   └── {artifact-type}.md
+│
+└── docs/                       # Supplementary Docs
+    └── {topic}.md
+```
+
+**Implication:** New skills can be scaffolded by copying this structure and customizing content.
+
+#### 1.2 Agent Definition Format Evolution
+
+**Discovery:** Agents use a hybrid XML + Markdown format:
+
+```markdown
+---
+{YAML frontmatter}
+---
+
+<agent>
+
+<identity>...</identity>
+<persona>...</persona>
+<capabilities>...</capabilities>
+<guardrails>...</guardrails>
+<constitutional_compliance>...</constitutional_compliance>
+<invocation_protocol>...</invocation_protocol>
+<output_levels>...</output_levels>
+<state_management>...</state_management>
+
+</agent>
+
+---
+
+# {Agent Name}
+
+{Markdown content for human readers}
+```
+
+**Rationale:**
+- **YAML Frontmatter:** Machine-parseable metadata for tooling
+- **XML Tags:** Structured sections for LLM parsing (Claude excels at XML)
+- **Markdown Body:** Human-readable documentation
+
+**Prior Art:**
+- Anthropic's XML preference documented in [Claude 4 Best Practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
+- XML provides clearer boundaries than Markdown headers for LLM consumption
+
+#### 1.3 L0/L1/L2 Triple-Lens Pattern
+
+**Universal Application:**
+
+| Artifact Type | L0 (ELI5) | L1 (Engineer) | L2 (Architect) |
+|---------------|-----------|---------------|----------------|
+| **SKILL.md** | Purpose, When to Use | Tool Examples, Invocation | Constitutional, State Passing |
+| **PLAYBOOK.md** | Metaphors, Decision Guides | Commands, File Paths | Anti-Patterns, Constraints |
+| **Agent Output** | Executive Summary | Technical Details | Strategic Implications |
+
+**Key Insight:** This isn't just documentation structure - it's a cognitive framework for multi-audience communication.
+
+**Example (orchestration PLAYBOOK.md):**
+
+```
++============================================================================+
+|                       TRIPLE-LENS COGNITIVE FRAMEWORK                       |
++=============================================================================+
+|    L0 (ELI5)          L1 (Engineer)         L2 (Architect)                 |
+|    ----------         -------------         --------------                 |
+|    WHAT & WHY    ->   HOW (commands)   ->   CONSTRAINTS                    |
+|    Metaphors          Invocations           Anti-patterns                  |
+```
+
+### 2. State Management Architecture
+
+#### 2.1 State Passing Mechanisms Comparison
+
+| Skill | State Mechanism | SSOT | Format |
+|-------|----------------|------|--------|
+| **problem-solving** | Output keys in session context | `researcher_output`, `analyst_output` | YAML in session context |
+| **nasa-se** | Output keys in session context | `requirements_output`, `verification_output` | YAML in session context |
+| **orchestration** | ORCHESTRATION.yaml | ORCHESTRATION.yaml | YAML file (persisted) |
+
+**Key Difference:** Orchestration skill uses **file-based state** (`ORCHESTRATION.yaml`) while ps/nse skills use **context-based state** (session context payload).
+
+**Rationale:**
+
+- **ps/nse:** Short-lived agent chains (researcher → analyst → architect)
+  - Context-based state sufficient for <10 agent handoffs
+  - Lightweight, no file I/O overhead
+
+- **orchestration:** Long-lived multi-agent workflows
+  - File-based state required for checkpoint recovery
+  - Survives context compaction
+  - Machine-readable for automation
+
+#### 2.2 Session Context Schema Adoption
+
+**Standard Across All Skills:**
+
+```yaml
+session_context:
+  schema: "docs/schemas/session_context.json"
+  schema_version: "1.0.0"
+  input_validation: true
+  output_validation: true
+```
+
+**Validation Actions:**
+
+1. **On Receive:**
+   - Validate schema version
+   - Verify target agent matches
+   - Extract key findings
+   - Process blockers
+
+2. **On Send:**
+   - Populate key findings
+   - Calculate confidence
+   - List artifacts
+   - Set timestamp
+
+**Implication:** Standardized handoff protocol enables cross-skill agent coordination (e.g., ps-architect → nse-architecture).
+
+### 3. Orchestration Strategy
+
+#### 3.1 P-003 Compliance: No Recursive Subagents
+
+**Constitutional Hard Constraint:**
+
+```
+Maximum ONE level of nesting:
+  MAIN CONTEXT (Orchestrator) → Worker Agent (end)
+
+FORBIDDEN:
+  MAIN CONTEXT → Worker → Sub-Worker → Sub-Sub-Worker
+```
+
+**Enforcement Across Skills:**
+
+- **problem-solving:** Agents use Task tool for single-level delegation only
+- **nasa-se:** Same single-level constraint
+- **orchestration:** Orchestrator coordinates workers directly; workers do NOT spawn others
+
+**Anti-Pattern (orchestration PLAYBOOK.md):**
+
+```
+AP-001: Recursive Subagent Spawning
+
+SYMPTOM:    Agents spawning agents spawning agents...
+CAUSE:      Orchestrator creates subagent which creates another subagent
+IMPACT:     Context window exhausted, untraceable execution
+FIX:        Maximum ONE level of nesting
+```
+
+**Design Rationale:**
+
+- Prevents context explosion
+- Enables checkpointing
+- Maintains traceability
+- Simplifies debugging
+
+#### 3.2 Workflow Patterns Catalog
+
+**Discovered:** orchestration PLAYBOOK.md documents 8 canonical patterns:
+
+| # | Pattern | Cognitive Mode | Use Case |
+|---|---------|---------------|----------|
+| 1 | Single Agent | Depends | Direct task, no coordination |
+| 2 | Sequential Chain | Convergent | Order-dependent state passing |
+| 3 | Fan-Out | Divergent | Parallel independent research |
+| 4 | Fan-In | Convergent | Aggregate multiple outputs |
+| 5 | Cross-Pollinated | Mixed | Bidirectional pipeline exchange |
+| 6 | Divergent-Convergent | Mixed | Explore then converge (diamond) |
+| 7 | Review Gate | Convergent | Quality checkpoint (SRR/PDR/CDR) |
+| 8 | Generator-Critic | Convergent | Iterative refinement loop |
+
+**Pattern Selection Decision Tree:**
+
+```
+START: How many agents?
+       |
+  +----+----+
+  |         |
+  v         v
+ONE       MULTIPLE
+  |         |
+  v         v
+Pattern 1   Dependencies?
+       |
+  +----+----+
+  |         |
+  v         v
+ YES        NO
+  |         |
+  v         v
+Pattern 2   Pattern 3/4
+  |
+  v
+Bidirectional?
+  |
++----+----+
+|         |
+v         v
+YES       NO
+|         |
+v         v
+Pattern 5  Quality gates?
+      |
+ +----+----+
+ |         |
+ v         v
+YES       NO
+ |         |
+ v         v
+P7/P8     P6
+```
+
+**Strategic Insight:** These 8 patterns form a complete pattern language for multi-agent coordination. New workflows compose these patterns.
+
+#### 3.3 Cognitive Mode Matching
+
+**Discovery:** Agent cognitive modes align with workflow patterns:
+
+**Divergent Agents** (Exploration):
+- ps-researcher
+- nse-explorer
+- Used in: Pattern 3 (Fan-Out), Pattern 6 (Divergent phase)
+
+**Convergent Agents** (Decision):
+- ps-critic
+- ps-analyst
+- nse-requirements
+- Used in: Pattern 2 (Sequential), Pattern 4 (Fan-In), Pattern 8 (Generator-Critic)
+
+**Mixed Mode Agents** (Orchestration):
+- orch-planner
+- orch-tracker
+- Used in: Pattern 5 (Cross-Pollinated)
+
+**Implication:** Cognitive mode is a key agent attribute for orchestration planning. Divergent agents should precede convergent agents in workflows.
+
+### 4. Quality & Validation Architecture
+
+#### 4.1 Multi-Layer Validation
+
+**Layer 1: Input Validation (Guardrails)**
+
+```yaml
+guardrails:
+  input_validation:
+    ps_id_format: "^[a-z]+-\\d+(\\.\\d+)?$"
+    entry_id_format: "^e-\\d+$"
+    requirement_id: "^REQ-NSE-[A-Z]{3}-\\d{3}$"  # nse-specific
+  output_filtering:
+    - no_secrets_in_output
+    - all_claims_must_have_citations
+```
+
+**Layer 2: Process Validation (Constitutional)**
+
+```yaml
+constitution:
+  principles_applied:
+    - "P-001: Truth and Accuracy (Soft)"
+    - "P-002: File Persistence (Medium)"
+    - "P-003: No Recursive Subagents (Hard)"
+    - "P-022: No Deception (Hard)"
+```
+
+**Layer 3: Output Validation (Post-Completion)**
+
+```yaml
+validation:
+  post_completion_checks:
+    - verify_file_created
+    - verify_l0_l1_l2_present
+    - verify_citations_present
+```
+
+**Layer 4: Quality Assessment (ps-critic)**
+
+```yaml
+quality_score = Σ(criterion_score × criterion_weight)
+threshold: 0.85
+circuit_breaker:
+  max_iterations: 3
+```
+
+**Implication:** Defense-in-depth validation prevents issues at multiple stages.
+
+#### 4.2 Generator-Critic Pattern
+
+**Discovery:** ps-critic agent implements a complete generator-critic loop framework.
+
+**Circuit Breaker Parameters:**
+
+```yaml
+circuit_breaker:
+  max_iterations: 3
+  improvement_threshold: 0.10  # 10% improvement required
+  acceptance_threshold: 0.85   # Score to accept without revision
+  consecutive_no_improvement_limit: 2
+```
+
+**Decision Logic (MAIN CONTEXT orchestrator):**
+
+```
+IF quality_score >= acceptance_threshold:
+    → ACCEPT (threshold met)
+ELIF iteration >= max_iterations:
+    → ACCEPT_WITH_CAVEATS or ESCALATE_TO_USER
+ELIF (current_score - previous_score) < improvement_threshold AND consecutive_no_improvement >= 2:
+    → ACCEPT_WITH_CAVEATS (no further improvement likely)
+ELSE:
+    → REVISE (send feedback to generator)
+```
+
+**Strategic Value:**
+- Prevents infinite refinement loops
+- Balances quality vs. compute cost
+- Provides escape hatch for diminishing returns
+
+**Prior Art:**
+- [Madaan et al. (2023) Self-Refine](https://arxiv.org/abs/2303.17651)
+- OpenAI Agent Guide - Reflective Loops
+- Anthropic Constitutional AI
+
+### 5. Cross-Skill Integration
+
+#### 5.1 Handoff Matrix
+
+**Discovered Cross-Skill Handoffs:**
+
+```
++---------------+                   +------------------+
+| ps-architect  |------------------>| nse-architecture |
+| (decisions)   |  design handoff   | (trade studies)  |
++---------------+                   +------------------+
+
++---------------+                   +------------------+
+| ps-analyst    |------------------>| nse-risk         |
+| (root cause)  |  risk handoff     | (mitigation)     |
++---------------+                   +------------------+
+
++-----------------+                 +---------------+
+| nse-requirements|---------------->| ps-architect  |
+| (shall stmts)   | decision need   | (ADR)         |
++-----------------+                 +---------------+
+```
+
+**Implication:** Skills are designed to interoperate. The common session context schema enables seamless handoffs.
+
+#### 5.2 Pipeline Alias Configuration
+
+**orchestration Skill Innovation:**
+
+```yaml
+pipelines:
+  pipeline_a:
+    short_alias: "ps"                    # Used in artifact paths
+    skill_source: "problem-solving"       # Originating skill
+
+  pipeline_b:
+    short_alias: "nse"
+    skill_source: "nasa-systems-engineering"
+```
+
+**Alias Resolution Priority:**
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 (Highest) | Workflow Override | User specifies "alpha" |
+| 2 | Skill Default | Skill registers "ps" |
+| 3 (Fallback) | Auto-Derived | Derived from skill name |
+
+**Strategic Value:**
+- Flexible artifact paths
+- Human-readable directory structure
+- No hardcoded pipeline names in templates
+
+### 6. Template & Documentation Architecture
+
+#### 6.1 Template Distribution
+
+**Observed Template Counts:**
+
+| Skill | Template Count | Types |
+|-------|----------------|-------|
+| problem-solving | 1 | critique |
+| nasa-se | 5 | alternative-analysis, concept-exploration, qa-report, review-checklists, trade-study |
+| orchestration | 3 | ORCHESTRATION.yaml, ORCHESTRATION_PLAN.md, ORCHESTRATION_WORKTRACKER.md |
+
+**Pattern:** Template count correlates with artifact type diversity:
+- **problem-solving:** Focused on research/analysis artifacts (shared templates in docs/knowledge/exemplars/templates/)
+- **nasa-se:** Diverse SE work products (requirements, V&V, risk, reviews)
+- **orchestration:** Workflow-specific artifacts (plan, tracker, state)
+
+#### 6.2 PLAYBOOK.md as Comprehensive Guide
+
+**Key Finding:** orchestration PLAYBOOK.md (3.1.0) is the most comprehensive guide observed:
+
+- **Triple-Lens Structure:** L0/L1/L2 throughout
+- **Anti-Pattern Catalog:** 4 documented anti-patterns with ASCII diagrams
+- **Constraints & Boundaries:** Hard vs. Soft constraints table
+- **Invariants Checklist:** 5 invariants that must always be true
+- **Design Rationale:** ADR-style decision documentation
+
+**Strategic Implication:** PLAYBOOK.md should be the gold standard for all skills. problem-solving and nasa-se skills would benefit from similar comprehensive playbooks.
+
+### 7. Risk Assessment & Mitigation
+
+#### 7.1 Identified Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| **Context Rot** | High | High | P-002 (File Persistence), checkpointing |
+| **Recursive Spawning** | High | Medium | P-003 (Hard constraint), agent validation |
+| **State Amnesia** | Medium | Medium | Session context schema, ORCHESTRATION.yaml |
+| **Barrier Bypass** | Medium | Low | Execution queue enforcement |
+| **Quality Degradation** | Medium | Medium | ps-critic circuit breaker |
+
+#### 7.2 Architectural Safeguards
+
+**Defense in Depth:**
+
+1. **Constitutional Layer:** Hard constraints (P-003, P-022, P-043)
+2. **Validation Layer:** Input/output validation
+3. **Quality Layer:** ps-critic iterative refinement
+4. **State Layer:** Persistent checkpoints
+5. **Documentation Layer:** Anti-pattern catalog
+
+### 8. Future Evolution Opportunities
+
+#### 8.1 Potential Skill Enhancements
+
+**Based on Pattern Analysis:**
+
+1. **problem-solving Enhancements:**
+   - Add comprehensive PLAYBOOK.md (similar to orchestration)
+   - Create templates for all agent outputs (not just critique)
+   - Document cross-skill handoff patterns
+
+2. **nasa-se Enhancements:**
+   - Add orchestration-style PLAYBOOK.md with anti-patterns
+   - Expand template coverage (currently missing some agent types)
+   - Document NASA process flow diagrams
+
+3. **orchestration Enhancements:**
+   - Add RUNBOOK.md for operational procedures
+   - Create templates for barrier artifacts
+   - Document failure recovery procedures
+
+#### 8.2 Skill Composition Patterns
+
+**Discovery:** Skills are designed to compose:
+
+```
+Cross-Pollinated Workflow:
+  Pipeline A: problem-solving (divergent exploration)
+  Pipeline B: nasa-se (convergent requirements)
+  Barriers: Knowledge exchange at phase boundaries
+  Synthesis: Combined deliverable
+```
+
+**Opportunity:** Document canonical skill composition patterns:
+- **ps + nse:** Research-driven requirements engineering
+- **ps + orch:** Complex multi-phase problem-solving
+- **nse + orch:** Large-scale systems engineering programs
+
+---
+
+## References
+
+### Skill Artifacts
+
+1. [problem-solving SKILL.md](../../../skills/problem-solving/SKILL.md) - v2.1.0
+2. [nasa-se SKILL.md](../../../skills/nasa-se/SKILL.md) - v1.1.0
+3. [orchestration SKILL.md](../../../skills/orchestration/SKILL.md) - v2.1.0
+4. [orchestration PLAYBOOK.md](../../../skills/orchestration/PLAYBOOK.md) - v3.1.0
+
+### Agent Definitions
+
+1. [ps-researcher.md](../../../skills/problem-solving/agents/ps-researcher.md) - v2.2.0
+2. [ps-critic.md](../../../skills/problem-solving/agents/ps-critic.md) - v2.2.0
+3. [nse-requirements.md](../../../skills/nasa-se/agents/nse-requirements.md) - v2.2.0
+
+### Prior Art
+
+1. Anthropic. (2025). *Claude 4 Best Practices*. https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices
+2. OpenAI. (2024). *A Practical Guide to Building Agents*. https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf
+3. Google. (2025). *Developer's Guide to Multi-Agent Patterns in ADK*. https://developers.googleblog.com/developers-guide-to-multi-agent-patterns-in-adk/
+4. Madaan, A. et al. (2023). *Self-Refine: Iterative Refinement with Self-Feedback*. arXiv:2303.17651
+5. Microsoft. (2025). *AI Agent Orchestration Patterns*. https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns
+6. Anthropic. (2023). *Constitutional AI: Harmlessness from AI Feedback*. https://www.anthropic.com/research/constitutional-ai-harmlessness-from-ai-feedback
+
+---
+
+*Research Artifact: work-026-e-001*
+*Agent: ps-researcher v2.2.0*
+*Date: 2026-01-30*
+*Confidence: 0.95 (High - based on direct analysis of authoritative skill files)*
+*Constitutional Compliance: P-001, P-002, P-004, P-011, P-022*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ strict: true
 exclude_docs: |
   adrs/
   analysis/
+  archive/
   design/
   knowledge/
   research/internal/

--- a/src/domain/markdown_ast/document_type.py
+++ b/src/domain/markdown_ast/document_type.py
@@ -137,6 +137,7 @@ class DocumentTypeDetector:
         ("docs/reviews/**/*.md", DocumentType.KNOWLEDGE_DOCUMENT),
         ("docs/rewrites/**/*.md", DocumentType.KNOWLEDGE_DOCUMENT),
         ("docs/runbooks/*.md", DocumentType.KNOWLEDGE_DOCUMENT),
+        ("docs/archive/**/*.md", DocumentType.KNOWLEDGE_DOCUMENT),
         ("docs/blog/**/*.md", DocumentType.KNOWLEDGE_DOCUMENT),
         ("docs/templates/*.md", DocumentType.TEMPLATE),
         ("docs/*.md", DocumentType.KNOWLEDGE_DOCUMENT),


### PR DESCRIPTION
## Summary

- Extracts 51 historical research artifacts from orphan branch `feat/009-prepare-for-release` into `docs/archive/`
- ADR-031 through ADR-034 (knowledge architecture, KM integration, unified KM architecture, WTK implementation)
- 20+ research documents covering graph data modeling, LLM behavioral governance, polyglot architecture, PS agent refactoring, technology stack analysis, Python KM SDKs, domain analysis
- Trade-off analyses, unified design documents, validation reports
- Early worktracker proposals and design plans
- Jerry skill patterns research (41KB)
- Adds `docs/archive/**/*.md` PATH_PATTERN to DocumentTypeDetector
- Adds `docs/archive/` to mkdocs `exclude_docs` to prevent strict build failures

## Test plan

- [x] All pre-commit hooks pass (ruff, pyright, architecture, pytest, mkdocs)
- [x] Document type regression test passes — archive files classified via PATH
- [x] mkdocs strict build passes with archive/ excluded
- [x] No existing test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)