### PR TITLE
fix(ci): complete BUG-003 — UV_LOCKED=1 for version-bump job [skip-changelog]

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -96,11 +96,11 @@ jobs:
 
       # ------------------------------------------------------------------
       # Install project dependencies for bump detection
-      # BUG-003: --frozen is redundant with job-level UV_LOCKED=1 (see
-      # env block above) but kept for explicitness.
+      # BUG-003: UV_LOCKED=1 (job-level env) handles lockfile protection.
+      # Do NOT add --frozen here — it conflicts with UV_LOCKED.
       # ------------------------------------------------------------------
       - name: Install project dependencies
-        run: uv sync --frozen
+        run: uv sync
 
       # ------------------------------------------------------------------
       # Determine bump type from commits
@@ -175,12 +175,13 @@ jobs:
 
       # ------------------------------------------------------------------
       # Validate version consistency
-      # BUG-003: --frozen redundant with job-level UV_LOCKED=1.
+      # BUG-003: UV_LOCKED=1 (job-level env) prevents lockfile modification.
+      # Do NOT add --frozen — it conflicts with UV_LOCKED.
       # ------------------------------------------------------------------
       - name: Validate version sync
         if: steps.bump.outputs.type != 'none'
         run: |
-          uv sync --frozen
+          uv sync
           uv run python scripts/sync_versions.py --check
 
       # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `UV_LOCKED=1` as a job-level environment variable to the version-bump workflow, fixing the recurring uv.lock dirty tree failure.

## Root Cause

The original BUG-003 fix (PR #152) added `--frozen` to `uv sync` calls but missed `uv run` calls. `uv run` performs its own lockfile resolution. When CI's pinned uv version (0.10.9) differs from the local version that generated `uv.lock`, `uv run` silently rewrites lockfile metadata, dirtying the tree.

## Fix

`UV_LOCKED=1` at job level covers ALL `uv sync` and `uv run` commands. It is stricter than `UV_FROZEN` — it also fails fast if `uv.lock` is stale relative to `pyproject.toml`.

`--frozen` flags removed from `uv sync` steps because `UV_LOCKED` and `--frozen` are mutually exclusive in uv.

## Evidence

- Failed run: https://github.com/geekatron/jerry/actions/runs/22972573134
- Conflict error: `the argument UV_LOCKED (environment variable) cannot be used with --frozen`
- eng-devsecops review: UV_LOCKED recommended over UV_FROZEN for CI fail-fast
- Sources: https://docs.astral.sh/uv/reference/environment/, https://github.com/astral-sh/uv/issues/9379

## Test plan

- [x] CI passes (27/27 jobs green on run 22975154963)
- [ ] Version-bump workflow succeeds on merge (uv.lock stays clean)


Generated with [Claude Code](https://claude.com/claude-code)
