### PR TITLE
fix(ci): UV_LOCKED=0 for uv lock override — boolish value required [skip-changelog]

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -179,7 +179,7 @@ jobs:
           # this step. In the prerelease path, the amend also folds the
           # --no-commit changes from line 171 into the bump commit.
           # Unset UV_LOCKED temporarily so uv lock can update the file.
-          UV_LOCKED="" uv lock
+          UV_LOCKED=0 uv lock
 
           # Guard: verify uv lock only changed the jerry version field,
           # not transitive dependencies. A broader change could indicate


### PR DESCRIPTION
## Summary

One-line fix: `UV_LOCKED=""` → `UV_LOCKED=0` in the `uv lock` override step.

## Root Cause

uv environment variables expect boolish values (`0`/`1`/`true`/`false`), not empty strings. `UV_LOCKED=""` causes:
```
error: Failed to parse environment variable UV_LOCKED with invalid value: expected a boolish value
```

## Evidence

- Failed run: https://github.com/geekatron/jerry/actions/runs/22977775761/job/66710443210
- Tested locally: `UV_LOCKED=0 uv lock` succeeds, `UV_LOCKED="" uv lock` fails

## Test plan

- [x] Local test: `UV_LOCKED=0 uv lock` resolves successfully
- [ ] CI passes on this PR


Generated with [Claude Code](https://claude.com/claude-code)