### PR TITLE
feat(ci): risk-tiered Dependabot config — FMEA-informed grouping (#188) [skip-changelog]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,7 +104,7 @@
 #     ~4 direct dev deps. The old limit of 5 could queue PRs when
 #     multiple majors are pending simultaneously.
 #
-# D7: Labels
+# D7: Labels (verified #188; update when PR volume changes)
 #   - All Dependabot PRs get "dependencies" (existing).
 #   - Actions PRs additionally get "ci" (existing).
 #   - No risk-tier labels added. At Jerry's current PR volume (~2-4 PRs
@@ -117,7 +117,7 @@
 # REFERENCES:
 #   - Research: projects/PROJ-030-bugs/research/merge-queue-vs-dependabot-grouping.md
 #   - Risk analysis (FMEA): projects/PROJ-030-bugs/research/dependabot-risk-analysis.md
-#   - Supply chain assessment: projects/PROJ-030-bugs/reviews/ (red-recon #188)
+#   - Supply chain assessment: projects/PROJ-030-bugs/reviews/188-s002-devils-advocate.md
 #   - Filter B: .github/workflows/version-bump.yml (#187)
 #   - SHA pinning: EN-001
 #   - Dependabot options: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference


### PR DESCRIPTION
## Summary

Reconfigures Dependabot with risk-tiered dependency management. Prevents gherkin-official class incidents. Reduces ~13 individual PRs to ~2-3 grouped PRs per week.

Closes #188

## Configuration

| Ecosystem | Patch+Minor | Major | Transitive | Security |
|-----------|-------------|-------|------------|----------|
| **pip** | Grouped | Individual | Excluded (`allow: direct`) | Individual (default) |
| **GitHub Actions** | Grouped | Individual | N/A | Individual (default) |

## Key Design Decisions (D1-D7)

- **D1**: Single pip group for patch+minor (not split by runtime/dev at current dep count)
- **D2**: Actions minor/patch grouped; major individual (SHA pinning doesn't prevent API changes)
- **D3**: `allow: dependency-type: direct` — prevents ALL transitive dep bumps (gherkin-official fix)
- **D4**: Security updates ungrouped (event-driven, each CVE gets own PR)
- **D5-D7**: Commit prefix, limits, labels — see inline comments

## FMEA Deviations (explicitly traced)

| FMEA Recommendation | Config Decision | Justification |
|---------------------|----------------|---------------|
| R-1: Group all Actions incl. major | Major ungrouped | Major bumps change runtime behavior |
| R-3: Separate pytest ecosystem | Single group | `allow: direct` eliminates transitive conflict |
| R-4: Runtime deps ungrouped | Grouped | Small dep count + CI catches breakage |
| R-5: Ignore list for transitives | `allow: direct` | Durable policy vs whack-a-mole |

## Reviews

| Review | Agent | Key Finding |
|--------|-------|-------------|
| ps-analyst | FMEA risk analysis | RPN 120 for transitive conflicts; 3-tier grouping recommended |
| eng-architect | Config design | 7 decisions with `allow: direct` as anchor policy |
| red-recon | Supply chain | `direct` blindspot documented; `pip-audit` compensates |
| adv-scorer | Quality: 0.83→revising | FMEA not cited; deviations untraced — all fixed |

## Test plan

- [ ] CI passes
- [ ] After merge: Dependabot closes existing individual PRs
- [ ] Next Monday: grouped PRs appear instead of individual ones
- [ ] No transitive dep PRs (gherkin-official class)


Generated with [Claude Code](https://claude.com/claude-code)
