### PR TITLE
fix(ci): regenerate uv.lock + switch dependabot to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -167,9 +167,11 @@ updates:
     # Each gets its own PR for individual review of breaking changes.
 
   # ==================================================================
-  # pip -- weekly check for Python dependency updates
+  # uv -- weekly check for Python dependency updates
   # ==================================================================
-  - package-ecosystem: "pip"
+  # Uses uv ecosystem (not pip) so Dependabot updates both pyproject.toml
+  # AND uv.lock together, preventing lockfile drift.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,26 @@ jobs:
           echo "No banned YAML APIs found. OK."
 
   # ===========================================================================
+  # Lockfile Freshness Check
+  # ===========================================================================
+  # Catches stale uv.lock at PR time before it can merge to main.
+  # Belt-and-suspenders: uv sync --frozen also fails on drift, but this
+  # gives a clear, fast signal with an obvious job name.
+  lockfile-check:
+    name: Lockfile Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          version: "0.10.9"
+
+      - name: Verify uv.lock is fresh
+        run: uv lock --check
+
+  # ===========================================================================
   # Plugin Validation (EN-005)
   # ===========================================================================
   # Validates plugin manifests and hook scripts
@@ -626,7 +646,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, type-check, security, plugin-validation, template-validation, frontmatter-validation, license-headers, cli-integration, test-pip, test-uv, version-sync, hard-rule-ceiling, changelog-check]
+    needs: [lint, type-check, security, lockfile-check, plugin-validation, template-validation, frontmatter-validation, license-headers, cli-integration, test-pip, test-uv, version-sync, hard-rule-ceiling, changelog-check]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -634,6 +654,7 @@ jobs:
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.type-check.result }}" != "success" ]] || \
              [[ "${{ needs.security.result }}" != "success" ]] || \
+             [[ "${{ needs.lockfile-check.result }}" != "success" ]] || \
              [[ "${{ needs.plugin-validation.result }}" != "success" ]] || \
              [[ "${{ needs.template-validation.result }}" != "success" ]] || \
              [[ "${{ needs.frontmatter-validation.result }}" != "success" ]] || \
@@ -647,6 +668,7 @@ jobs:
             echo "  lint: ${{ needs.lint.result }}"
             echo "  type-check: ${{ needs.type-check.result }}"
             echo "  security: ${{ needs.security.result }}"
+            echo "  lockfile-check: ${{ needs.lockfile-check.result }}"
             echo "  plugin-validation: ${{ needs.plugin-validation.result }}"
             echo "  template-validation: ${{ needs.template-validation.result }}"
             echo "  frontmatter-validation: ${{ needs.frontmatter-validation.result }}"
@@ -672,6 +694,7 @@ jobs:
           echo "  - Linting: OK"
           echo "  - Type checking: OK"
           echo "  - Security scan: OK"
+          echo "  - Lockfile freshness: OK"
           echo "  - Plugin validation: OK"
           echo "  - Template validation: OK"
           echo "  - Frontmatter validation: OK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated Bash command patterns (`/bin/bash`, `bash -c`) replaced with direct command syntax in all settings permission entries (#182)
 - `pymdown-extensions` upgraded to 10.21.2 — fixes `filename=None` crash with Pygments 2.20.0 in mkdocs code block rendering
 - Flaky 50-file batch performance test thresholds relaxed from 500ms to 1000ms to handle pre-commit hook concurrent load
+- `uv.lock` regenerated after Dependabot pip updates caused lockfile drift — unblocks CI on main
 
 ### Changed
+- Dependabot `package-ecosystem` switched from `pip` to `uv` — updates both `pyproject.toml` and `uv.lock` together, preventing future lockfile drift
+- Added `uv lock --check` CI job for lockfile freshness verification at PR time
 - 28 stale eng-team output files removed from `skills/eng-team/output/` (600K)
 - ADR-PROJ007-001 renamed to ADR-agent-design-001 (domain-first naming convention)
 - ADR-PROJ007-002 renamed to ADR-routing-triggers-001 (domain-first naming convention)

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.11" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "webvtt-py", specifier = ">=0.5.1" },
     { name = "webvtt-py", marker = "extra == 'transcript'", specifier = ">=0.5.1" },


### PR DESCRIPTION
## Summary

- Regenerate `uv.lock` from current `pyproject.toml` to fix lockfile drift caused by Dependabot PR #243 (pip ecosystem updated `pyproject.toml` but not `uv.lock`). This unblocks CI on main, which fails at `uv sync --frozen` due to the mismatch.
- Switch dependabot `package-ecosystem` from `"pip"` to `"uv"` so future dependency update PRs regenerate both `pyproject.toml` and `uv.lock` together, preventing recurrence.
- Add a dedicated **Lockfile Freshness** CI job (`uv lock --check`) as a belt-and-suspenders guard that catches stale lockfiles at PR time with a clear job name.

## Test plan

- [ ] CI passes on this PR (confirms lockfile is now in sync)
- [ ] `Lockfile Freshness` job appears and passes in the CI run
- [ ] After merge, verify next push to main no longer fails at dependency install step
- [ ] Verify Dependabot's next scheduled run (Monday) creates PRs under the `uv` ecosystem instead of `pip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)