### PR TITLE
fix(ci): correct cyclonedx-py output flag --outfile to -o

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           uv run --with cyclonedx-bom \
             cyclonedx-py environment \
             --of JSON \
-            --outfile dist/sbom.cyclonedx.json
+            -o dist/sbom.cyclonedx.json
           echo "SBOM generated:"
           head -5 dist/sbom.cyclonedx.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove all `pip install` instructions from docs, error messages, and CI comments — replaced with `uv add`/`uv tool install`/`uv run`
 
 ### Fixed
+- **fix(ci):** correct `cyclonedx-py` output flag from `--outfile` to `-o` — fixes v0.31.4 release SBOM generation failure
 - Migrate 7 enum classes from `(str, Enum)` to `StrEnum` in `docs/schemas/types/session_context.py` — Python 3.11+ modernization, unblocks ruff 0.15.10 UP042 rule
 - **fix(ci):** replace bare `python3 -m py_compile` with `uv run python -m py_compile` in plugin-validation — closes last H-05 violation
 - **fix(ci):** scope `pull-requests:write` to `coverage-report` job only — eliminates PR write blast radius for 14 jobs (TASK-021)

--- a/docs/reference/ci-cd-pipeline-security.md
+++ b/docs/reference/ci-cd-pipeline-security.md
@@ -494,7 +494,7 @@ The `release` job generates a CycloneDX JSON SBOM for the project's locked depen
 **Generation command:**
 
 ```yaml
-uv run --with cyclonedx-bom cyclonedx-py environment --of JSON --outfile dist/sbom.cyclonedx.json
+uv run --with cyclonedx-bom cyclonedx-py environment --of JSON -o dist/sbom.cyclonedx.json
 ```
 
 **Attested artifact:**


### PR DESCRIPTION
## Summary

Hotfix for v0.31.4 release failure. `cyclonedx-py environment` does not accept `--outfile` — the correct flag is `-o`.

The v0.31.4 release pipeline failed at the "Generate SBOM (CycloneDX)" step:
```
cyclonedx-py: error: unrecognized arguments: --outfile
```

Root cause: eng-infra agent used `--outfile` when authoring the SBOM step in TASK-029 (Wave 4, PR #256). The actual `cyclonedx-py environment --help` shows `-o <file>` as the output flag.

## Test plan

- [x] `cyclonedx-py environment --help` confirms `-o` is the correct flag
- [x] Reference doc updated to match
- [x] Once merged, re-tag v0.31.4 or let next version bump test the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
